### PR TITLE
Better Webpack configuration

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -64,7 +64,8 @@
             "tn": ["msgid", "msgid_plural", "count"],
             "tct": ["msgid"]
           },
-          "baseDirectory": "."
+          "baseDirectory": ".",
+          "fileName": "./src/locale/gettext.po"
         }
       ]
     ]

--- a/app/package.json
+++ b/app/package.json
@@ -7,15 +7,17 @@
     "test": "./node_modules/.bin/karma start",
     "travis-test": "./node_modules/.bin/karma start --single-run",
     "lint": "./node_modules/.bin/eslint --ext .js,.jsx 'src/js/**/*.@(js|jsx)'; exit 0",
-    "start": "./node_modules/.bin/webpack-dev-server"
+    "start": "./node_modules/.bin/webpack-dev-server --inline --hot"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "autoprefixer-loader": "^3.1.0",
+    "babel-cli": "^6.5.1",
     "babel-core": "^6.3.17",
     "babel-eslint": "^4.1.6",
+    "babel-gettext-extractor": "git://github.com/Cadasta/babel-gettext-extractor.git",
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
@@ -53,6 +55,18 @@
     "presets": [
       "es2015",
       "react"
+    ],
+    "plugins": [
+      [
+        "babel-gettext-extractor", {
+          "functionNames": {
+            "t": ["msgid"],
+            "tn": ["msgid", "msgid_plural", "count"],
+            "tct": ["msgid"]
+          },
+          "baseDirectory": "."
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/app/src/locale/gettext.po
+++ b/app/src/locale/gettext.po
@@ -1,0 +1,150 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\n"
+"Plural-Forms: nplurals = 2; plural = (n !== 1);\n"
+
+#: src/js/core/components/Home.jsx:16
+msgid "Welcome"
+msgstr ""
+
+#: src/js/messages/reducer.js:10
+msgid "Unable to login with provided username and password."
+msgstr ""
+
+#: src/js/messages/reducer.js:11
+msgid "Unable to logout."
+msgstr ""
+
+#: src/js/messages/reducer.js:12
+msgid "Unable to change password."
+msgstr ""
+
+#: src/js/messages/reducer.js:13
+msgid "Unable to register with provided credentials."
+msgstr ""
+
+#: src/js/messages/reducer.js:14
+msgid "Unable to update profile."
+msgstr ""
+
+#: src/js/messages/reducer.js:15
+msgid "Unable to get user profile information from server."
+msgstr ""
+
+#: src/js/messages/reducer.js:17
+msgid "Unable to reset password."
+msgstr ""
+
+#: src/js/messages/reducer.js:18
+msgid "Unable to activate account."
+msgstr ""
+
+#: src/js/messages/reducer.js:22
+msgid "Successfully logged in."
+msgstr ""
+
+#: src/js/messages/reducer.js:23
+msgid "Successfully logged out."
+msgstr ""
+
+#: src/js/messages/reducer.js:24
+msgid "Successfully changed password."
+msgstr ""
+
+#: src/js/messages/reducer.js:25
+msgid "Successfully registered."
+msgstr ""
+
+#: src/js/messages/reducer.js:26
+msgid "Successfully updated profile information."
+msgstr ""
+
+#: src/js/messages/reducer.js:27
+msgid ""
+"Password successfully reset. Check your inbox for a link to confirm the "
+"reset."
+msgstr ""
+
+#: src/js/messages/reducer.js:28
+msgid "Password successfully reset."
+msgstr ""
+
+#: src/js/messages/reducer.js:29
+msgid "Account successfully activated."
+msgstr ""
+
+#: src/js/core/components/Header.jsx:22
+msgid "Profile"
+msgstr ""
+
+#: src/js/core/components/Header.jsx:23
+msgid "Logout"
+msgstr ""
+
+#: src/js/account/components/Login.jsx:57
+msgid "Login"
+msgstr ""
+
+#: src/js/account/components/RegistrationForm.jsx:48
+msgid "Register"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:57
+msgid "Username"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:65
+msgid "Email"
+msgstr ""
+
+#: src/js/account/components/Login.jsx:51
+msgid "Password"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:74
+msgid "First name"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:82
+msgid "Last name"
+msgstr ""
+
+#: src/js/account/components/Login.jsx:55
+msgid "Remember me"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:90
+msgid "Update profile"
+msgstr ""
+
+#: src/js/account/components/Password.jsx:39
+msgid "Change password"
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:41
+msgid "Reset password"
+msgstr ""
+
+#: src/js/account/components/Password.jsx:30
+msgid "New password"
+msgstr ""
+
+#: src/js/account/components/Password.jsx:33
+msgid "Repeat new password"
+msgstr ""
+
+#: src/js/account/components/Password.jsx:36
+msgid "Current password"
+msgstr ""
+
+#: src/js/account/components/PasswordReset.jsx:28
+msgid "Enter email"
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:35
+msgid "Enter new password"
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:38
+msgid "Retype new password"
+msgstr ""

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -15,8 +15,6 @@ process.argv.forEach(function processCliArgs(arg) {
 
 module.exports = {
   entry: [
-    'webpack-dev-server/client?http://localhost:8080',
-    'webpack/hot/only-dev-server',
     './src/index.jsx',
   ],
   module: {

--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -17,7 +17,7 @@ DATABASES = {
 }
 
 DJOSER.update({
-    'DOMAIN': 'cadasta.org',
+    'DOMAIN': os.environ['DOMAIN'],
 })
 
 # Adding localhost here for uWSGI debugging!
@@ -25,9 +25,12 @@ ALLOWED_HOSTS = [os.environ['API_HOST'], 'localhost']
 
 ADMINS = [('Cadasta platform admins', 'platform-admin@cadasta.org')]
 EMAIL_HOST = 'email-smtp.us-west-2.amazonaws.com'
+EMAIL_PORT = 465
+EMAIL_USE_SSL = True
 EMAIL_HOST_USER = os.environ['EMAIL_HOST_USER']
 EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
 SERVER_EMAIL = 'platform-errors@cadasta.org'
+DEFAULT_FROM_EMAIL = 'platform@cadasta.org'
 
 # Debug logging...
 LOGGING = {

--- a/provision/roles/cadasta/application/templates/settings.j2
+++ b/provision/roles/cadasta/application/templates/settings.j2
@@ -1,5 +1,5 @@
 const SETTINGS = {
-  API_BASE: '{{ api_url }}'
+  API_BASE: 'http://{{ api_url }}'
 };
 
 export default SETTINGS;

--- a/provision/roles/cadasta/install/tasks/main.yml
+++ b/provision/roles/cadasta/install/tasks/main.yml
@@ -31,6 +31,7 @@
     block: |
       DB_HOST="{{ db_host }}"
       API_HOST="{{ api_url }}"
+      DOMAIN="{{ main_url }}"
       SECRET_KEY="{{ secret_key }}"
       EMAIL_HOST_USER="{{ email_host_user }}"
       EMAIL_HOST_PASSWORD="{{ email_host_password }}"
@@ -47,6 +48,7 @@
     block: |
       Defaults	env_keep += DB_HOST
       Defaults	env_keep += API_HOST
+      Defaults	env_keep += DOMAIN
       Defaults	env_keep += SECRET_KEY
       Defaults	env_keep += EMAIL_HOST_USER
       Defaults	env_keep += EMAIL_HOST_PASSWORD

--- a/provision/roles/cadasta/production/tasks/main.yml
+++ b/provision/roles/cadasta/production/tasks/main.yml
@@ -5,6 +5,12 @@
   command: npm install
            chdir="{{ application_path }}app"
 
+- name: Fix node-sass problem
+  become: yes
+  become_user: "{{ app_user }}"
+  command: npm rebuild node-sass
+           chdir="{{ application_path }}app"
+
 - name: Install npm-run
   become: yes
   become_user: root

--- a/provision/roles/webserver/production/templates/uwsgi.ini
+++ b/provision/roles/webserver/production/templates/uwsgi.ini
@@ -20,6 +20,7 @@ daemonize = /var/log/uwsgi/cadasta.log
 
 env = DB_HOST={{ db_host }}
 env = API_HOST={{ api_url }}
+env = DOMAIN={{ main_url }}
 env = SECRET_KEY={{ secret_key }}
 env = EMAIL_HOST_USER={{ email_host_user }}
 env = EMAIL_HOST_PASSWORD={{ email_host_password }}


### PR DESCRIPTION
Remove the extra entry points for running the development server and replace them with command line switches in the command for "npm start".  This means we're left with a single index.jsx entry point in the Webpack configuration, which is almost certainly what we want.