### PR TITLE
First cut at permissions policies

### DIFF
--- a/cadasta/config/permissions/data-collector.json
+++ b/cadasta/config/permissions/data-collector.json
@@ -1,0 +1,9 @@
+{
+  "clause": [
+    {
+      "effect": "allow",
+      "action": ["project.resources.*"]
+      "object": ["project/$organization/$project"],
+    }
+  ]
+}

--- a/cadasta/config/permissions/data-collector.json
+++ b/cadasta/config/permissions/data-collector.json
@@ -2,7 +2,7 @@
   "clause": [
     {
       "effect": "allow",
-      "action": ["project.resources.*"]
+      "action": ["project.resources.*"],
       "object": ["project/$organization/$project"],
     }
   ]

--- a/cadasta/config/permissions/data-collector.json
+++ b/cadasta/config/permissions/data-collector.json
@@ -1,9 +1,12 @@
 {
   "clause": [
+    // In addition to the permissions provided by the default
+    // policy, data collectors are allowed to manage resources for a
+    // specified project within a specified organization.
     {
       "effect": "allow",
       "action": ["project.resources.*"],
-      "object": ["project/$organization/$project"],
+      "object": ["project/$organization/$project"]
     }
   ]
 }

--- a/cadasta/config/permissions/default.json
+++ b/cadasta/config/permissions/default.json
@@ -6,7 +6,7 @@
     },
     {
       "effect": "allow",
-      "action": ["org.view"]
+      "action": ["org.view"],
       "object": ["organization/*"],
     },
 

--- a/cadasta/config/permissions/default.json
+++ b/cadasta/config/permissions/default.json
@@ -1,21 +1,28 @@
 {
   "clause": [
     {
+      // Any user is allowed to list organizations and create new
+      // ones.
       "effect": "allow",
       "action": ["org.list", "org.create"]
     },
     {
+      // Any user is allowed to view the details of an organization.
       "effect": "allow",
       "action": ["org.view"],
-      "object": ["organization/*"],
+      "object": ["organization/*"]
     },
 
     {
+      // Any user is allowed to list the public projects in an
+      // organization.
       "effect": "allow",
       "action": ["project.list"],
       "object": ["organization/*"]
     },
     {
+      // Any user is allowed to view the details of public projects in
+      // an organization.
       "effect": "allow",
       "action": ["project.view"],
       "object": ["project/*/*"]

--- a/cadasta/config/permissions/default.json
+++ b/cadasta/config/permissions/default.json
@@ -2,12 +2,23 @@
   "clause": [
     {
       "effect": "allow",
-      "object": ["*"],
-      "action": ["org.list"]
-    }, {
+      "action": ["org.list", "org.create"]
+    },
+    {
       "effect": "allow",
-      "object": ["organization/*"],
       "action": ["org.view"]
+      "object": ["organization/*"],
+    },
+
+    {
+      "effect": "allow",
+      "action": ["project.list"],
+      "object": ["organization/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["project.view"],
+      "object": ["project/*/*"]
     }
-  ]   
+  ]
 }

--- a/cadasta/config/permissions/org-admin.json
+++ b/cadasta/config/permissions/org-admin.json
@@ -2,12 +2,14 @@
   "clause": [
     {
       "effect": "allow",
-      "object": ["*"],
-      "action": ["org.*"]
-    }, {
+      "action": ["org.*", "org.*.*", "project.*", "project.*.*"]
+      "object": ["organization/$organization"],
+    },
+
+    {
       "effect": "allow",
-      "object": ["organization/*"],
-      "action": ["org.*"]
+      "action": ["project.*", "project.*.*"]
+      "object": ["project/$organization/*"],
     }
-  ]   
+  ]
 }

--- a/cadasta/config/permissions/org-admin.json
+++ b/cadasta/config/permissions/org-admin.json
@@ -2,13 +2,13 @@
   "clause": [
     {
       "effect": "allow",
-      "action": ["org.*", "org.*.*", "project.*", "project.*.*"]
+      "action": ["org.*", "org.*.*", "project.*", "project.*.*"],
       "object": ["organization/$organization"],
     },
 
     {
       "effect": "allow",
-      "action": ["project.*", "project.*.*"]
+      "action": ["project.*", "project.*.*"],
       "object": ["project/$organization/*"],
     }
   ]

--- a/cadasta/config/permissions/org-admin.json
+++ b/cadasta/config/permissions/org-admin.json
@@ -1,15 +1,20 @@
 {
   "clause": [
+    // In addition to the permissions provided by the default
+    // policy, organization administrators are allowed to perform all
+    // organization management actions for a specified organization,
+    // and all project management actions for all projects within a
+    // specified organization.
     {
       "effect": "allow",
       "action": ["org.*", "org.*.*", "project.*", "project.*.*"],
-      "object": ["organization/$organization"],
+      "object": ["organization/$organization"]
     },
 
     {
       "effect": "allow",
       "action": ["project.*", "project.*.*"],
-      "object": ["project/$organization/*"],
+      "object": ["project/$organization/*"]
     }
   ]
 }

--- a/cadasta/config/permissions/project-manager.json
+++ b/cadasta/config/permissions/project-manager.json
@@ -1,14 +1,19 @@
 {
   "clause": [
+    // In addition to the permissions provided by the default
+    // policy, project managers are allowed to perform all project
+    // management actions, except for project archiving and
+    // unarchiving, for a specified project within a specified
+    // organization.
     {
       "effect": "allow",
       "action": ["project.*", "project.*.*"],
-      "object": ["project/$organization/$project"],
+      "object": ["project/$organization/$project"]
     },
     {
       "effect": "deny",
       "action": ["project.archive", "project.unarchive"],
-      "object": ["project/$organization/$project"],
+      "object": ["project/$organization/$project"]
     }
   ]
 }

--- a/cadasta/config/permissions/project-manager.json
+++ b/cadasta/config/permissions/project-manager.json
@@ -1,0 +1,14 @@
+{
+  "clause": [
+    {
+      "effect": "allow",
+      "action": ["project.*", "project.*.*"]
+      "object": ["project/$organization/$project"],
+    },
+    {
+      "effect": "deny",
+      "action": ["project.archive", "project.unarchive"]
+      "object": ["project/$organization/$project"],
+    }
+  ]
+}

--- a/cadasta/config/permissions/project-manager.json
+++ b/cadasta/config/permissions/project-manager.json
@@ -2,12 +2,12 @@
   "clause": [
     {
       "effect": "allow",
-      "action": ["project.*", "project.*.*"]
+      "action": ["project.*", "project.*.*"],
       "object": ["project/$organization/$project"],
     },
     {
       "effect": "deny",
-      "action": ["project.archive", "project.unarchive"]
+      "action": ["project.archive", "project.unarchive"],
       "object": ["project/$organization/$project"],
     }
   ]

--- a/cadasta/config/permissions/project-user.json
+++ b/cadasta/config/permissions/project-user.json
@@ -1,13 +1,8 @@
 {
   "clause": [
-    {
-      "effect": "allow",
-      "action": ["org.list", "org.create"]
-    },
-    {
-      "effect": "allow",
-      "object": ["organization/*"],
-      "action": ["org.view"]
-    }
+    // Currently, "ordinary" users associated with a project have no
+    // additional permissions over those given to all users.  This may
+    // change in the future.  In particular, project users may be
+    // permitted access to projects that are normally private.
   ]
 }

--- a/cadasta/config/permissions/project-user.json
+++ b/cadasta/config/permissions/project-user.json
@@ -1,0 +1,13 @@
+{
+  "clause": [
+    {
+      "effect": "allow",
+      "action": ["org.list", "org.create"]
+    },
+    {
+      "effect": "allow",
+      "object": ["organization/*"],
+      "action": ["org.view"]
+    }
+  ]
+}

--- a/cadasta/config/permissions/superuser.json
+++ b/cadasta/config/permissions/superuser.json
@@ -1,5 +1,7 @@
 {
   "clause": [
+    // A superuser is permitted to perform all actions on all entities
+    // within the platform.
     {
       "effect": "allow",
       "action": ["org.*"]
@@ -7,18 +9,18 @@
     {
       "effect": "allow",
       "action": ["org.*", "org.*.*"],
-      "object": ["organization/*"],
+      "object": ["organization/*"]
     },
 
     {
       "effect": "allow",
       "action": ["project.*", "project.*.*"],
-      "object": ["organization/*"],
+      "object": ["organization/*"]
     },
     {
       "effect": "allow",
       "action": ["project.*", "project.*.*"],
-      "object": ["project/*/*"],
+      "object": ["project/*/*"]
     },
 
     {
@@ -28,7 +30,7 @@
     {
       "effect": "allow",
       "action": ["user.*"],
-      "object": ["user/*"],
+      "object": ["user/*"]
     }
   ]
 }

--- a/cadasta/config/permissions/superuser.json
+++ b/cadasta/config/permissions/superuser.json
@@ -2,8 +2,33 @@
   "clause": [
     {
       "effect": "allow",
-      "object": ["organization/*"],
       "action": ["org.*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["org.*", "org.*.*"]
+      "object": ["organization/*"],
+    },
+
+    {
+      "effect": "allow",
+      "action": ["project.*", "project.*.*"]
+      "object": ["organization/*"],
+    },
+    {
+      "effect": "allow",
+      "action": ["project.*", "project.*.*"]
+      "object": ["project/*/*"],
+    },
+
+    {
+      "effect": "allow",
+      "action": ["user.*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["user.*"]
+      "object": ["user/*"],
     }
   ]
 }

--- a/cadasta/config/permissions/superuser.json
+++ b/cadasta/config/permissions/superuser.json
@@ -6,18 +6,18 @@
     },
     {
       "effect": "allow",
-      "action": ["org.*", "org.*.*"]
+      "action": ["org.*", "org.*.*"],
       "object": ["organization/*"],
     },
 
     {
       "effect": "allow",
-      "action": ["project.*", "project.*.*"]
+      "action": ["project.*", "project.*.*"],
       "object": ["organization/*"],
     },
     {
       "effect": "allow",
-      "action": ["project.*", "project.*.*"]
+      "action": ["project.*", "project.*.*"],
       "object": ["project/*/*"],
     },
 
@@ -27,7 +27,7 @@
     },
     {
       "effect": "allow",
-      "action": ["user.*"]
+      "action": ["user.*"],
       "object": ["user/*"],
     }
   ]


### PR DESCRIPTION
Covers organisations, projects and users.  This goes with the information on the wiki page at https://github.com/Cadasta/cadasta-platform/wiki/Permissioning-policies and is intended to cover at least the first part of https://github.com/Cadasta/cadasta-platform/issues/8 -- there will be more permissions-related stuff as we implement new features.