### PR TITLE
Implements FieldSelectorSerializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ htmlcov
 # JS
 */dist/bundle.js
 node_modules/
+/.envrc
+/.virtualenv/
+
+ghostdriver.log
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: python
 python:
-  - "3.4"
+  - "3.5"
 services:
   - postgresql
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ services:
   - postgresql
 addons:
   postgresql: "9.4"
+# env:
+#  - DJANGO_LIVE_TEST_SERVER_ADDRESS=127.0.0.1:5000
+# before_install:
+#  - travis_retry sudo apt-get update
+#  - travis_retry sudo apt-get install phantomjs
+#  - sudo mkdir /var/log/django
+#  - sudo chmod 777 /var/log/django
 install:
   - pip install -r requirements/common.txt
   - pip install -r requirements/dev.txt
@@ -23,4 +30,8 @@ script:
   - py.test cadasta --cov=cadasta --ds=config.settings.travis
   - cd app
   - npm run travis-test
-  - cd ..
+#   - npm start | tee /tmp/npm-start.log &
+#   - while ! grep 'bundle is now VALID' /tmp/npm-start.log; do sleep 1; done
+#   - sleep 2
+#   - cd ../functional_tests
+#   - ./run.py --ds=config.settings.travis

--- a/README.md
+++ b/README.md
@@ -23,15 +23,17 @@ SSH into to the VM, activate the virtualenv and run the server:
 ```
 vagrant ssh
 cd /vagrant/
-source env/bin/activate
+source /opt/cadasta/env/bin/activate
 python cadasta/manage.py runserver
 ```
 
 Open `http://localhost:5000/` in your browser, you should see a default Django page.
 
+See the wiki ([here](https://github.com/Cadasta/cadasta-platform/wiki/Installation) and [here](https://github.com/Cadasta/cadasta-platform/wiki/Run-for-development)) for detailed instructions on installation and running the platform for development.
+
 ## Run tests
 
-From the repository's root run:
+Within the development VM, from the `/vagrant` directory run:
 
 ```
 py.test cadasta

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,9 @@ Vagrant.configure(2) do |config|
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 8080, host: 5000
+  config.vm.network "forwarded_port", guest: 5000, host: 5000
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/app/src/css/_variables.scss
+++ b/app/src/css/_variables.scss
@@ -3,7 +3,7 @@
 //== Colors
 
 $gray-dark:              #595a5c;  // Cadasta gray
-$brand-primary:          #2069b3;  // Cadasta blue
+$brand-primary:          #2e51a3;  // Cadasta blue
 
 //== Scaffolding
 

--- a/app/src/css/main.scss
+++ b/app/src/css/main.scss
@@ -35,8 +35,14 @@
 /* =Basics
 -------------------------------------------------------------- */
 
+html, body {
+  height: 100%;
+  overflow: auto;
+}
+
 #cadasta {
   padding-top: 120px;
+  margin-bottom: 30px;
 }
 
 .wrapper {
@@ -181,4 +187,24 @@ header nav a:hover {
 
 .translation-wrapper {
   background-color: fuchsia;
+}
+
+/* =Footer
+-------------------------------------------------------------- */
+
+footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 30px;
+  background-color: #eee;
+  border-top: solid 1px #ddd;
+  font-size: 11px;
+  white-space: nowrap;
+  padding-top: 4px;
+}
+
+footer .list-inline > li {
+  padding-left: 24px;
+  text-align: right;
 }

--- a/app/src/js/account/components/Login.jsx
+++ b/app/src/js/account/components/Login.jsx
@@ -85,6 +85,7 @@ export class Login extends React.Component {
         />
 
         <button
+          name="sign-in"
           type="submit"
           formNoValidate
           className="btn btn-default btn-lg btn-block text-uppercase"

--- a/app/src/js/account/components/Profile.jsx
+++ b/app/src/js/account/components/Profile.jsx
@@ -47,7 +47,7 @@ export class Profile extends React.Component {
   render() {
     return (
       <Form
-        className="form-narrow"
+        className="profile-form form-narrow"
         onValidSubmit={this.handleFormSubmit}
         ref="form"
       >
@@ -105,6 +105,7 @@ export class Profile extends React.Component {
 
         <button
           formNoValidate
+          name="update"
           type="submit"
           className="btn btn-default btn-lg btn-block text-uppercase"
         >

--- a/app/src/js/account/components/RegistrationForm.jsx
+++ b/app/src/js/account/components/RegistrationForm.jsx
@@ -109,6 +109,7 @@ class RegistrationForm extends React.Component {
         />
 
         <button
+          name="register"
           type="submit"
           formNoValidate
           className="btn btn-default btn-lg btn-block text-uppercase"

--- a/app/src/js/core/components/App.jsx
+++ b/app/src/js/core/components/App.jsx
@@ -4,6 +4,7 @@ import connect from 'react-redux/lib/components/connect';
 import Message from '../../messages/components/Message';
 import { HomeContainer } from './Home';
 import Header from './Header';
+import Footer from './Footer';
 
 const propTypes = {
   messages: React.PropTypes.object.isRequired,
@@ -32,6 +33,8 @@ export class App extends React.Component {
           </div>
         { this.props.children || <HomeContainer /> }
         </div>
+        
+        <Footer />
       </div>
     );
   }

--- a/app/src/js/core/components/Footer.jsx
+++ b/app/src/js/core/components/Footer.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Link from './Link';
+import { t } from '../../i18n';
+
+export class Footer extends React.Component {
+  render() {
+    return (
+      <footer className="footer">
+        <div className="container">
+          <p className="pull-left">Copyright 2016 Cadasta. All Rights Reserved.</p>
+          <ul className="list-inline pull-right">
+            <li><Link to={ "http://cadasta.org/about-us" }>{ t('About Us') }</Link></li>
+            <li><Link to={ "#" }>{ t('Privacy') }</Link></li>
+            <li><Link to={ "#" }>{ t('Terms of Service') }</Link></li>
+            <li><Link to={ "http://cadasta.org/code-of-conduct" }>{ t('Code of Conduct') }</Link></li>
+            <li><Link to={ "http://github.com/Cadasta" }>{ t('Visit us on Github') }</Link></li>
+          </ul>
+        </div>
+      </footer>
+    );
+  }
+}
+
+export default Footer;

--- a/app/src/js/settings.js
+++ b/app/src/js/settings.js
@@ -1,5 +1,5 @@
 const SETTINGS = {
-  API_BASE: 'http://localhost:5000/v1'
+  API_BASE: 'http://0.0.0.0:5000/v1'
 };
 
 export default SETTINGS;

--- a/app/src/locale/gettext.po
+++ b/app/src/locale/gettext.po
@@ -3,22 +3,68 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Plural-Forms: nplurals = 2; plural = (n !== 1);\n"
 
+#: src/js/account/components/Login.jsx:48
+msgid "Sign in to your account"
+msgstr ""
+
 #: src/js/account/components/Profile.jsx:60
 msgid "Username"
 msgstr ""
 
-#: test/locale/test_locale.js:16
-msgid "Hello %(name)s"
+#: src/js/account/components/RegistrationForm.jsx:88
+msgid "This field is required"
 msgstr ""
 
-#: test/locale/test_locale.js:33
-msgid "%d unread message"
-msgid_plural "%d unread messages"
-msgstr[0] ""
-msgstr[1] ""
+#: src/js/account/components/RegistrationForm.jsx:67
+msgid "Password"
+msgstr ""
 
-#: test/locale/test_locale.js:38
-msgid "Need more information? [link:Click here]."
+#: src/js/account/components/Login.jsx:77
+msgid "Forgotten password?"
+msgstr ""
+
+#: src/js/account/components/Login.jsx:84
+msgid "Remember me"
+msgstr ""
+
+#: src/js/account/components/Login.jsx:93
+msgid "Sign in"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:54
+msgid "Update your profile"
+msgstr ""
+
+#: src/js/account/components/RegistrationForm.jsx:53
+msgid "Email"
+msgstr ""
+
+#: src/js/account/components/RegistrationForm.jsx:57
+msgid "Please provide a valid email address"
+msgstr ""
+
+#: src/js/account/components/RegistrationForm.jsx:98
+msgid "First name"
+msgstr ""
+
+#: src/js/account/components/RegistrationForm.jsx:107
+msgid "Last name"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:112
+msgid "Update profile"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:115
+msgid "Password options"
+msgstr ""
+
+#: src/js/account/components/Password.jsx:84
+msgid "Change password"
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:81
+msgid "Reset password"
 msgstr ""
 
 #: src/js/account/components/Password.jsx:34
@@ -33,72 +79,16 @@ msgstr ""
 msgid "New password"
 msgstr ""
 
-#: src/js/account/components/RegistrationForm.jsx:67
+#: src/js/account/components/RegistrationForm.jsx:72
 msgid "Your password must be at least 6 characters long."
 msgstr ""
 
-#: src/js/account/components/PasswordResetConfirm.jsx:62
+#: src/js/account/components/PasswordResetConfirm.jsx:65
 msgid "Repeat new password"
 msgstr ""
 
-#: src/js/account/components/RegistrationForm.jsx:80
+#: src/js/account/components/RegistrationForm.jsx:87
 msgid "Passwords must match."
-msgstr ""
-
-#: src/js/account/components/Profile.jsx:112
-msgid "Change password"
-msgstr ""
-
-#: src/js/account/components/Login.jsx:48
-msgid "Sign in to your account"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:63
-msgid "Password"
-msgstr ""
-
-#: src/js/account/components/Login.jsx:71
-msgid "Forgotten password?"
-msgstr ""
-
-#: src/js/account/components/Login.jsx:78
-msgid "Remember me"
-msgstr ""
-
-#: src/js/account/components/Login.jsx:86
-msgid "Sign in"
-msgstr ""
-
-#: src/js/account/components/Profile.jsx:54
-msgid "Update your profile"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:50
-msgid "Email"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:54
-msgid "Please provide a valid email address"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:90
-msgid "First name"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:99
-msgid "Last name"
-msgstr ""
-
-#: src/js/account/components/Profile.jsx:107
-msgid "Update profile"
-msgstr ""
-
-#: src/js/account/components/Profile.jsx:110
-msgid "Password options"
-msgstr ""
-
-#: src/js/account/components/PasswordResetConfirm.jsx:77
-msgid "Reset password"
 msgstr ""
 
 #: src/js/account/components/PasswordReset.jsx:34
@@ -107,38 +97,6 @@ msgstr ""
 
 #: src/js/account/components/PasswordReset.jsx:41
 msgid "Enter email"
-msgstr ""
-
-#: src/js/account/components/PasswordResetConfirm.jsx:44
-msgid "Create a new password"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:33
-msgid "Sign up for a free account"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:40
-msgid "Choose username"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:75
-msgid "Confirm password"
-msgstr ""
-
-#: src/js/core/components/Header.jsx:33
-msgid "Register"
-msgstr ""
-
-#: src/js/core/components/Header.jsx:23
-msgid "Profile"
-msgstr ""
-
-#: src/js/core/components/Header.jsx:24
-msgid "Logout"
-msgstr ""
-
-#: src/js/core/components/Header.jsx:32
-msgid "Login"
 msgstr ""
 
 #: src/js/messages/reducer.js:10
@@ -205,4 +163,36 @@ msgstr ""
 
 #: src/js/messages/reducer.js:29
 msgid "Account successfully activated."
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:44
+msgid "Create a new password"
+msgstr ""
+
+#: src/js/core/components/Header.jsx:23
+msgid "Profile"
+msgstr ""
+
+#: src/js/core/components/Header.jsx:24
+msgid "Logout"
+msgstr ""
+
+#: src/js/core/components/Header.jsx:32
+msgid "Login"
+msgstr ""
+
+#: src/js/account/components/RegistrationForm.jsx:117
+msgid "Register"
+msgstr ""
+
+#: src/js/account/components/RegistrationForm.jsx:33
+msgid "Sign up for a free account"
+msgstr ""
+
+#: src/js/account/components/RegistrationForm.jsx:40
+msgid "Choose username"
+msgstr ""
+
+#: src/js/account/components/RegistrationForm.jsx:82
+msgid "Confirm password"
 msgstr ""

--- a/app/src/locale/gettext.po
+++ b/app/src/locale/gettext.po
@@ -3,102 +3,6 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Plural-Forms: nplurals = 2; plural = (n !== 1);\n"
 
-#: src/js/account/components/Login.jsx:48
-msgid "Sign in to your account"
-msgstr ""
-
-#: src/js/account/components/Profile.jsx:60
-msgid "Username"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:88
-msgid "This field is required"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:67
-msgid "Password"
-msgstr ""
-
-#: src/js/account/components/Login.jsx:77
-msgid "Forgotten password?"
-msgstr ""
-
-#: src/js/account/components/Login.jsx:84
-msgid "Remember me"
-msgstr ""
-
-#: src/js/account/components/Login.jsx:93
-msgid "Sign in"
-msgstr ""
-
-#: src/js/account/components/Profile.jsx:54
-msgid "Update your profile"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:53
-msgid "Email"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:57
-msgid "Please provide a valid email address"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:98
-msgid "First name"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:107
-msgid "Last name"
-msgstr ""
-
-#: src/js/account/components/Profile.jsx:112
-msgid "Update profile"
-msgstr ""
-
-#: src/js/account/components/Profile.jsx:115
-msgid "Password options"
-msgstr ""
-
-#: src/js/account/components/Password.jsx:84
-msgid "Change password"
-msgstr ""
-
-#: src/js/account/components/PasswordResetConfirm.jsx:81
-msgid "Reset password"
-msgstr ""
-
-#: src/js/account/components/Password.jsx:34
-msgid "Change your password"
-msgstr ""
-
-#: src/js/account/components/Password.jsx:40
-msgid "Current password"
-msgstr ""
-
-#: src/js/account/components/PasswordResetConfirm.jsx:50
-msgid "New password"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:72
-msgid "Your password must be at least 6 characters long."
-msgstr ""
-
-#: src/js/account/components/PasswordResetConfirm.jsx:65
-msgid "Repeat new password"
-msgstr ""
-
-#: src/js/account/components/RegistrationForm.jsx:87
-msgid "Passwords must match."
-msgstr ""
-
-#: src/js/account/components/PasswordReset.jsx:34
-msgid "Reset your password"
-msgstr ""
-
-#: src/js/account/components/PasswordReset.jsx:41
-msgid "Enter email"
-msgstr ""
-
 #: src/js/messages/reducer.js:10
 msgid "Unable to login with provided username and password."
 msgstr ""
@@ -165,8 +69,24 @@ msgstr ""
 msgid "Account successfully activated."
 msgstr ""
 
-#: src/js/account/components/PasswordResetConfirm.jsx:44
-msgid "Create a new password"
+#: src/js/core/components/Footer.jsx:12
+msgid "About Us"
+msgstr ""
+
+#: src/js/core/components/Footer.jsx:13
+msgid "Privacy"
+msgstr ""
+
+#: src/js/core/components/Footer.jsx:14
+msgid "Terms of Service"
+msgstr ""
+
+#: src/js/core/components/Footer.jsx:15
+msgid "Code of Conduct"
+msgstr ""
+
+#: src/js/core/components/Footer.jsx:16
+msgid "Visit us on Github"
 msgstr ""
 
 #: src/js/core/components/Header.jsx:23
@@ -193,6 +113,106 @@ msgstr ""
 msgid "Choose username"
 msgstr ""
 
+#: src/js/account/components/PasswordResetConfirm.jsx:71
+msgid "This field is required"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:75
+msgid "Email"
+msgstr ""
+
+#: src/js/account/components/PasswordReset.jsx:46
+msgid "Please provide a valid email address"
+msgstr ""
+
+#: src/js/account/components/Login.jsx:67
+msgid "Password"
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:55
+msgid "Your password must be at least 6 characters long."
+msgstr ""
+
 #: src/js/account/components/RegistrationForm.jsx:82
 msgid "Confirm password"
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:70
+msgid "Passwords must match."
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:91
+msgid "First name"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:101
+msgid "Last name"
+msgstr ""
+
+#: src/js/account/components/Login.jsx:48
+msgid "Sign in to your account"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:60
+msgid "Username"
+msgstr ""
+
+#: src/js/account/components/Login.jsx:77
+msgid "Forgotten password?"
+msgstr ""
+
+#: src/js/account/components/Login.jsx:84
+msgid "Remember me"
+msgstr ""
+
+#: src/js/account/components/Login.jsx:93
+msgid "Sign in"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:54
+msgid "Update your profile"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:112
+msgid "Update profile"
+msgstr ""
+
+#: src/js/account/components/Profile.jsx:115
+msgid "Password options"
+msgstr ""
+
+#: src/js/account/components/Password.jsx:84
+msgid "Change password"
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:81
+msgid "Reset password"
+msgstr ""
+
+#: src/js/account/components/Password.jsx:34
+msgid "Change your password"
+msgstr ""
+
+#: src/js/account/components/Password.jsx:40
+msgid "Current password"
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:50
+msgid "New password"
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:65
+msgid "Repeat new password"
+msgstr ""
+
+#: src/js/account/components/PasswordReset.jsx:34
+msgid "Reset your password"
+msgstr ""
+
+#: src/js/account/components/PasswordReset.jsx:41
+msgid "Enter email"
+msgstr ""
+
+#: src/js/account/components/PasswordResetConfirm.jsx:44
+msgid "Create a new password"
 msgstr ""

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -34,11 +34,19 @@ module.exports = {
   },
   devServer: {
     contentBase: './dist',
+    host: '0.0.0.0',
     hot: true,
     historyApiFallback: true,
+    watchOptions: {
+      aggregateTimeout: 300,
+      poll: 1000
+    }
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin(BUILD_OPTIONS),
   ],
+  watchOptions: {
+    poll: true
+  }
 };

--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -1,14 +1,22 @@
 import datetime
 from django.db import models
 from django.contrib.auth.models import AbstractUser
+from tutelary.decorators import permissioned_model
 
 
 def now_plus_48_hours():
     return datetime.datetime.now() + datetime.timedelta(hours=48)
 
 
+@permissioned_model
 class User(AbstractUser):
     email_verified = models.BooleanField(default=False)
     verify_email_by = models.DateTimeField(default=now_plus_48_hours)
 
     REQUIRED_FIELDS = ['email', 'first_name', 'last_name']
+
+    class TutelaryMeta:
+        perm_type = 'user'
+        path_fields = ('username',)
+        actions = [('user.view', {'permissions_object': None}),
+                   'user.update']

--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -2,7 +2,7 @@ from django.utils import timezone
 
 from django.utils.translation import ugettext as _
 
-from rest_framework.serializers import EmailField
+from rest_framework.serializers import EmailField, ValidationError
 from rest_framework.validators import UniqueValidator
 from djoser import serializers as djoser_serializers
 
@@ -58,6 +58,23 @@ class UserSerializer(djoser_serializers.UserSerializer):
             'email': {'required': True, 'unique': True},
             'email_verified': {'read_only': True}
         }
+
+    def validate_username(self, username):
+        instance = self.instance
+        if instance is not None:
+            if (username is not None and
+               username != instance.username and
+               self.context['request'].user != instance):
+                raise ValidationError('Cannot update username')
+        return username
+
+    def validate_last_login(self, last_login):
+        instance = self.instance
+        if instance is not None:
+            if (last_login is not None and
+               last_login != instance.last_login):
+                raise ValidationError('Cannot update last_login')
+        return last_login
 
 
 class AccountLoginSerializer(djoser_serializers.LoginSerializer):

--- a/cadasta/accounts/tests/factories.py
+++ b/cadasta/accounts/tests/factories.py
@@ -2,6 +2,7 @@ import factory
 
 from ..models import User
 
+
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User

--- a/cadasta/config/permissions/data-collector.json
+++ b/cadasta/config/permissions/data-collector.json
@@ -1,0 +1,12 @@
+{
+  "clause": [
+    // In addition to the permissions provided by the default
+    // policy, data collectors are allowed to manage resources for a
+    // specified project within a specified organization.
+    {
+      "effect": "allow",
+      "action": ["project.resources.*"],
+      "object": ["project/$organization/$project"]
+    }
+  ]
+}

--- a/cadasta/config/permissions/default.json
+++ b/cadasta/config/permissions/default.json
@@ -1,13 +1,31 @@
 {
   "clause": [
     {
+      // Any user is allowed to list organizations and create new
+      // ones.
       "effect": "allow",
-      "object": ["*"],
-      "action": ["org.list"]
-    }, {
+      "action": ["org.list", "org.create"]
+    },
+    {
+      // Any user is allowed to view the details of an organization.
       "effect": "allow",
-      "object": ["organization/*"],
-      "action": ["org.view"]
+      "action": ["org.view"],
+      "object": ["organization/*"]
+    },
+
+    {
+      // Any user is allowed to list the public projects in an
+      // organization.
+      "effect": "allow",
+      "action": ["project.list"],
+      "object": ["organization/*"]
+    },
+    {
+      // Any user is allowed to view the details of public projects in
+      // an organization.
+      "effect": "allow",
+      "action": ["project.view"],
+      "object": ["project/*/*"]
     }
-  ]   
+  ]
 }

--- a/cadasta/config/permissions/org-admin.json
+++ b/cadasta/config/permissions/org-admin.json
@@ -1,13 +1,20 @@
 {
   "clause": [
+    // In addition to the permissions provided by the default
+    // policy, organization administrators are allowed to perform all
+    // organization management actions for a specified organization,
+    // and all project management actions for all projects within a
+    // specified organization.
     {
       "effect": "allow",
-      "object": ["*"],
-      "action": ["org.*"]
-    }, {
+      "action": ["org.*", "org.*.*", "project.*", "project.*.*"],
+      "object": ["organization/$organization"]
+    },
+
+    {
       "effect": "allow",
-      "object": ["organization/*"],
-      "action": ["org.*"]
+      "action": ["project.*", "project.*.*"],
+      "object": ["project/$organization/*"]
     }
-  ]   
+  ]
 }

--- a/cadasta/config/permissions/project-manager.json
+++ b/cadasta/config/permissions/project-manager.json
@@ -1,0 +1,19 @@
+{
+  "clause": [
+    // In addition to the permissions provided by the default
+    // policy, project managers are allowed to perform all project
+    // management actions, except for project archiving and
+    // unarchiving, for a specified project within a specified
+    // organization.
+    {
+      "effect": "allow",
+      "action": ["project.*", "project.*.*"],
+      "object": ["project/$organization/$project"]
+    },
+    {
+      "effect": "deny",
+      "action": ["project.archive", "project.unarchive"],
+      "object": ["project/$organization/$project"]
+    }
+  ]
+}

--- a/cadasta/config/permissions/project-user.json
+++ b/cadasta/config/permissions/project-user.json
@@ -1,0 +1,8 @@
+{
+  "clause": [
+    // Currently, "ordinary" users associated with a project have no
+    // additional permissions over those given to all users.  This may
+    // change in the future.  In particular, project users may be
+    // permitted access to projects that are normally private.
+  ]
+}

--- a/cadasta/config/permissions/superuser.json
+++ b/cadasta/config/permissions/superuser.json
@@ -1,9 +1,36 @@
 {
   "clause": [
+    // A superuser is permitted to perform all actions on all entities
+    // within the platform.
     {
       "effect": "allow",
-      "object": ["organization/*"],
       "action": ["org.*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["org.*", "org.*.*"],
+      "object": ["organization/*"]
+    },
+
+    {
+      "effect": "allow",
+      "action": ["project.*", "project.*.*"],
+      "object": ["organization/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["project.*", "project.*.*"],
+      "object": ["project/*/*"]
+    },
+
+    {
+      "effect": "allow",
+      "action": ["user.*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["user.*"],
+      "object": ["user/*"]
     }
   ]
 }

--- a/cadasta/config/settings/dev.py
+++ b/cadasta/config/settings/dev.py
@@ -22,6 +22,7 @@ INSTALLED_APPS = (
 
 DJOSER.update({
     'DOMAIN': 'localhost:8080',
+    'SEND_ACTIVATION_EMAIL': False,
 })
 
 # devserver settings

--- a/cadasta/config/settings/travis.py
+++ b/cadasta/config/settings/travis.py
@@ -14,3 +14,7 @@ DATABASES = {
         'HOST': '',
     }
 }
+
+DJOSER.update({
+    'SEND_ACTIVATION_EMAIL': False,
+})

--- a/cadasta/config/urls.py
+++ b/cadasta/config/urls.py
@@ -19,7 +19,10 @@ urls = [
     url(r'^account/', include('accounts.urls', namespace='accounts')),
     url(r'^account/', include('djoser.urls.authtoken')),
 
-    url(r'^organizations/', include('organization.urls', namespace='organization')),
+    url(r'^organizations/',
+        include('organization.urls.organizations', namespace='organization')),
+    url(r'^users/',
+        include('organization.urls.users', namespace='user')),
 ]
 
 urlpatterns = [

--- a/cadasta/core/serializers.py
+++ b/cadasta/core/serializers.py
@@ -10,3 +10,15 @@ class DetailSerializer:
         if is_list and not detail:
             for field_name in self.Meta.detail_only_fields:
                 self.fields.pop(field_name)
+
+
+class FieldSelectorSerializer:
+    def __init__(self, *args, **kwargs):
+        fields = kwargs.pop('fields', None)
+        super(FieldSelectorSerializer, self).__init__(*args, **kwargs)
+
+        if fields:
+            allowed = set(fields)
+            existing = set(self.fields.keys())
+            for field_name in existing - allowed:
+                self.fields.pop(field_name)

--- a/cadasta/core/views.py
+++ b/cadasta/core/views.py
@@ -2,14 +2,11 @@ import json
 import re
 from django.http import Http404
 
-from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework.exceptions import NotFound
 from rest_framework.views import exception_handler as drf_exception_handler
-
-from tutelary.engine import Object
 
 
 def set_exception(exception):
@@ -53,50 +50,3 @@ def exception_handler(exception, context):
     response.data = eval_json(response.data)
 
     return response
-
-
-class PermissionRequiredMixin:
-    def get_permission_required(self):
-        """
-        Override this method to override the permission_required attribute.
-        Must return an iterable.
-        """
-        if self.permission_required is None:
-            raise ImproperlyConfigured(
-                '{0} is missing the permission_required attribute. Define '
-                '{0}.permission_required, or override '
-                '{0}.get_permission_required().'.format(
-                    self.__class__.__name__)
-            )
-        if isinstance(self.permission_required, dict):
-            perms = self.permission_required[self.request.method]
-        else:
-            perms = self.permission_required
-
-        if isinstance(perms, six.string_types):
-            perms = (perms, )
-
-        if hasattr(self, 'add_permission_required'):
-            perms = perms + self.add_permission_required
-
-        return perms
-
-    def check_permissions(self, request):
-        obj = None
-        allowed = {}
-        if hasattr(self, 'model') and hasattr(self.model, 'TutelaryMeta'):
-            obj = Object(self.model.TutelaryMeta.perm_type)
-            allowed = self.model.TutelaryMeta.allowed_methods
-        try:
-            if hasattr(self, 'get_object') and self.get_object() is not None:
-                obj = self.get_object().get_permissions_object()
-        except:
-            pass
-        perms = self.get_permission_required()
-
-        has_perm = all(self.request.user.has_perm(p, obj) for p in perms
-                       if not (p in allowed and
-                               self.request.method in allowed[p]))
-
-        if not has_perm:
-            self.permission_denied(request, message="Permission denied.")

--- a/cadasta/organization/models.py
+++ b/cadasta/organization/models.py
@@ -21,9 +21,11 @@ class Organization(RandomIDModel):
     class TutelaryMeta:
         perm_type = 'organization'
         path_fields = ('slug',)
-        actions = (('org.list', "List existing organisations"),
+        actions = (('org.list', {'description': "List existing organisations",
+                                 'permissions_object': None}),
                    ('org.view', "View existing organisations"),
-                   ('org.create', "Create organisations"),
+                   ('org.create', {'description': "Create organisations",
+                                   'permissions_object': None}),
                    ('org.update', "Update an existing organization"),
                    ('org.archive', "Archive an existing organization"),
                    ('org.unarchive', "Unarchive an existing organization"),

--- a/cadasta/organization/models.py
+++ b/cadasta/organization/models.py
@@ -15,7 +15,8 @@ class Organization(RandomIDModel):
     archived = models.BooleanField(default=False)
     urls = ArrayField(models.URLField(), default=[])
     contacts = JSONField(validators=[validate_contact], default={})
-    users = models.ManyToManyField('accounts.User')
+    users = models.ManyToManyField('accounts.User',
+                                   related_name='organizations')
     # logo = TemporalForeignKey('Resource')
 
     class TutelaryMeta:

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -3,6 +3,7 @@ from rest_framework.serializers import ModelSerializer
 
 from core.serializers import DetailSerializer
 from accounts.serializers import UserSerializer
+from accounts.models import User
 from .models import Organization
 
 
@@ -21,3 +22,19 @@ class OrganizationSerializer(DetailSerializer, ModelSerializer):
             data['slug'] = slugify(data.get('name'))
 
         return super(OrganizationSerializer, self).to_internal_value(data)
+
+
+class UserOrganizationSerializer(ModelSerializer):
+    class Meta:
+        model = Organization
+        fields = ('id', 'name')
+        read_only_fields = ('id', 'name')
+
+
+class UserAdminSerializer(UserSerializer):
+    organizations = UserOrganizationSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = User
+        fields = ('username', 'first_name', 'last_name', 'email',
+                  'organizations', 'last_login', 'is_active')

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -1,13 +1,14 @@
 from django.utils.text import slugify
 from rest_framework.serializers import ModelSerializer
 
-from core.serializers import DetailSerializer
+from core.serializers import DetailSerializer, FieldSelectorSerializer
 from accounts.serializers import UserSerializer
 from accounts.models import User
 from .models import Organization
 
 
-class OrganizationSerializer(DetailSerializer, ModelSerializer):
+class OrganizationSerializer(DetailSerializer, FieldSelectorSerializer,
+                             ModelSerializer):
     users = UserSerializer(many=True, read_only=True)
 
     class Meta:
@@ -24,15 +25,9 @@ class OrganizationSerializer(DetailSerializer, ModelSerializer):
         return super(OrganizationSerializer, self).to_internal_value(data)
 
 
-class UserOrganizationSerializer(ModelSerializer):
-    class Meta:
-        model = Organization
-        fields = ('id', 'name')
-        read_only_fields = ('id', 'name')
-
-
 class UserAdminSerializer(UserSerializer):
-    organizations = UserOrganizationSerializer(many=True, read_only=True)
+    organizations = OrganizationSerializer(
+        many=True, read_only=True, fields=('id', 'name'))
 
     class Meta:
         model = User

--- a/cadasta/organization/tests/factories.py
+++ b/cadasta/organization/tests/factories.py
@@ -22,3 +22,10 @@ class OrganizationFactory(factory.django.DjangoModelFactory):
         if users:
             for u in users:
                 self.users.add(u)
+
+
+def clause(effect, action, object=None):
+    if object is None:
+        return {'effect': effect, 'action': action}
+    else:
+        return {'effect': effect, 'action': action, 'object': object}

--- a/cadasta/organization/tests/test_serializers.py
+++ b/cadasta/organization/tests/test_serializers.py
@@ -1,7 +1,8 @@
+from datetime import datetime
 from django.utils.text import slugify
 from django.test import TestCase
 
-from ..serializers import OrganizationSerializer
+from ..serializers import OrganizationSerializer, UserAdminSerializer
 
 from accounts.tests.factories import UserFactory
 from .factories import OrganizationFactory
@@ -44,3 +45,21 @@ class OrganizationSerializerTest(TestCase):
 
         serializer = OrganizationSerializer(org, detail=True)
         assert 'users' in serializer.data
+
+
+class UserAdminSerializerTest(TestCase):
+    def test_user_fields_are_set(self):
+        user = UserFactory.create(last_login=datetime.now())
+        serializer = UserAdminSerializer(user)
+
+        assert 'username' in serializer.data
+        assert 'last_login' in serializer.data
+        assert 'is_active' in serializer.data
+
+    def test_organizations_are_serialized(self):
+        user = UserFactory.create()
+        OrganizationFactory.create(add_users=[user])
+        OrganizationFactory.create(add_users=[user])
+
+        serializer = UserAdminSerializer(user)
+        assert 'organizations' in serializer.data

--- a/cadasta/organization/tests/test_views.py
+++ b/cadasta/organization/tests/test_views.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta, timezone
 
 from django.test import TestCase
 from django.http import QueryDict
@@ -8,30 +9,23 @@ from rest_framework.exceptions import PermissionDenied
 from tutelary.models import Policy, assign_user_policies
 
 from accounts.tests.factories import UserFactory
-from .factories import OrganizationFactory
+from .factories import OrganizationFactory, clause
 from .. import views
 from ..models import Organization
 
 
 class OrganizationListAPITest(TestCase):
     def setUp(self):
-        clause = {
+        clauses = {
             'clause': [
-                {
-                  'effect': 'allow',
-                  'object': ['*'],
-                  'action': ['org.list']
-                }, {
-                  'effect': 'allow',
-                  'object': ['organization/*'],
-                  'action': ['org.view']
-                }
+                clause('allow', ['org.list']),
+                clause('allow', ['org.view'], ['organization/*'])
             ]
         }
 
         policy = Policy.objects.create(
             name='default',
-            body=json.dumps(clause))
+            body=json.dumps(clauses))
         self.user = UserFactory.create()
         assign_user_policies(self.user, policy)
 
@@ -50,43 +44,35 @@ class OrganizationListAPITest(TestCase):
         assert len(content) == 2
         assert 'users' not in content[0]
 
-    # def test_list_only_one_organization_is_authorized(self):
-    #     """
-    #     It should return all organizations.
-    #     """
-    #     OrganizationFactory.create()
-    #     OrganizationFactory.create(**{'slug': 'unauthorized'})
+    def test_list_only_one_organization_is_authorized(self):
+        """
+        It should return all organizations.
+        """
+        OrganizationFactory.create()
+        OrganizationFactory.create(**{'slug': 'unauthorized'})
 
-    #     clause = {
-    #         'clause': [{
-    #             "effect": "allow",
-    #             "object": ["*"],
-    #             "action": ["org.list"]
-    #         }, {
-    #             "effect": "allow",
-    #             "object": ["organization/*"],
-    #             "action": ["org.view"]
-    #         }, {
-    #             'effect': 'deny',
-    #             'object': ['organization/unauthorized'],
-    #             'action': ['org.view']
-    #         }]
-    #     }
+        clauses = {
+            'clause': [
+                clause('allow', ['org.list']),
+                clause('allow', ['org.view'], ['organization/*']),
+                clause('deny', ['org.view'], ['organization/unauthorized'])
+            ]
+        }
 
-    #     policy = Policy.objects.create(
-    #         name='deny',
-    #         body=json.dumps(clause))
-    #     assign_user_policies(self.user, policy)
+        policy = Policy.objects.create(
+            name='deny',
+            body=json.dumps(clauses))
+        assign_user_policies(self.user, policy)
 
-    #     request = APIRequestFactory().get('/v1/organizations/')
-    #     force_authenticate(request, user=self.user)
+        request = APIRequestFactory().get('/v1/organizations/')
+        force_authenticate(request, user=self.user)
 
-    #     response = views.OrganizationList.as_view()(request).render()
-    #     content = json.loads(response.content.decode('utf-8'))
+        response = views.OrganizationList.as_view()(request).render()
+        content = json.loads(response.content.decode('utf-8'))
 
-    #     assert response.status_code == 200
-    #     assert len(content) == 1
-    #     assert content[0]['slug'] != 'unauthorized'
+        assert response.status_code == 200
+        assert len(content) == 1
+        assert content[0]['slug'] != 'unauthorized'
 
     def test_full_list_with_unautorized_user(self):
         """
@@ -99,8 +85,8 @@ class OrganizationListAPITest(TestCase):
         response = views.OrganizationList.as_view()(request).render()
         content = json.loads(response.content.decode('utf-8'))
 
-        assert response.status_code == 403
-        assert content['detail'] == PermissionDenied.default_detail
+        assert response.status_code == 200
+        assert len(content) == 0
 
     def test_filter_active(self):
         """
@@ -187,23 +173,16 @@ class OrganizationListAPITest(TestCase):
 
 class OrganizationCreateAPITest(TestCase):
     def setUp(self):
-        clause = {
-            "clause": [
-                {
-                      "effect": "allow",
-                      "object": ["*"],
-                      "action": ["org.*"]
-                }, {
-                      "effect": "allow",
-                      "object": ["organization/*"],
-                      "action": ["org.*"]
-                }
+        clauses = {
+            'clause': [
+                clause('allow', ['org.*']),
+                clause('allow', ['org.*'], ['organization/*'])
             ]
         }
 
         policy = Policy.objects.create(
             name='default',
-            body=json.dumps(clause))
+            body=json.dumps(clauses))
 
         self.user = UserFactory.create()
         assign_user_policies(self.user, policy)
@@ -236,23 +215,16 @@ class OrganizationCreateAPITest(TestCase):
         assert Organization.objects.count() == 0
 
     def test_create_organization_with_unauthorized_user(self):
-        clause = {
+        clauses = {
             'clause': [
-                {
-                  'effect': 'allow',
-                  'object': ['*'],
-                  'action': ['org.list']
-                }, {
-                  'effect': 'allow',
-                  'object': ['organization/*'],
-                  'action': ['org.view']
-                }
+                clause('allow', ['org.list']),
+                clause('allow', ['org.view'], ['organization/*'])
             ]
         }
 
         policy = Policy.objects.create(
             name='default',
-            body=json.dumps(clause))
+            body=json.dumps(clauses))
         unauthorized_user = UserFactory.create()
         assign_user_policies(unauthorized_user, policy)
 
@@ -275,23 +247,16 @@ class OrganizationDetailTest(TestCase):
     def setUp(self):
         self.view = views.OrganizationDetail.as_view()
 
-        clause = {
-            "clause": [
-                {
-                      "effect": "allow",
-                      "object": ["*"],
-                      "action": ["org.*"]
-                }, {
-                      "effect": "allow",
-                      "object": ["organization/*"],
-                      "action": ["org.*"]
-                }
+        clauses = {
+            'clause': [
+                clause('allow', ['org.*']),
+                clause('allow', ['org.*'], ['organization/*'])
             ]
         }
 
         policy = Policy.objects.create(
             name='default',
-            body=json.dumps(clause))
+            body=json.dumps(clauses))
 
         self.user = UserFactory.create()
         assign_user_policies(self.user, policy)
@@ -400,23 +365,16 @@ class OrganizationDetailTest(TestCase):
     def test_archive_with_unauthorized_user(self):
         org = OrganizationFactory.create(**{'slug': 'org'})
 
-        clause = {
-            "clause": [
-                {
-                      "effect": "allow",
-                      "object": ["organization/*"],
-                      "action": ["org.update"]
-                }, {
-                      "effect": "deny",
-                      "object": ["organization/*"],
-                      "action": ["org.archive"]
-                }
+        clauses = {
+            'clause': [
+                clause('allow', ['org.update'], ['organization/*']),
+                clause('deny', ['org.archive'], ['organization/*'])
             ]
         }
 
         policy = Policy.objects.create(
             name='default',
-            body=json.dumps(clause))
+            body=json.dumps(clauses))
         assign_user_policies(self.user, policy)
 
         data = {'archived': True}
@@ -451,23 +409,16 @@ class OrganizationDetailTest(TestCase):
     def test_unarchive_unauthorized_user(self):
         org = OrganizationFactory.create(**{'slug': 'org', 'archived': True})
 
-        clause = {
-            "clause": [
-                {
-                      "effect": "allow",
-                      "object": ["organization/*"],
-                      "action": ["org.update"]
-                }, {
-                      "effect": "deny",
-                      "object": ["organization/*"],
-                      "action": ["org.unarchive"]
-                }
+        clauses = {
+            'clause': [
+                clause('allow', ['org.update'], ['organization/*']),
+                clause('deny', ['org.unarchive'], ['organization/*'])
             ]
         }
 
         policy = Policy.objects.create(
             name='default',
-            body=json.dumps(clause))
+            body=json.dumps(clauses))
         assign_user_policies(self.user, policy)
 
         data = {'archived': False}
@@ -488,23 +439,16 @@ class OrganizationUsersTest(TestCase):
     def setUp(self):
         self.view = views.OrganizationUsers.as_view()
 
-        clause = {
-            "clause": [
-                {
-                      "effect": "allow",
-                      "object": ["*"],
-                      "action": ["org.*"]
-                }, {
-                      "effect": "allow",
-                      "object": ["organization/*"],
-                      "action": ["org.*", "org.*.*"]
-                }
+        clauses = {
+            'clause': [
+                clause('allow', ['org.*']),
+                clause('allow', ['org.*', 'org.*.*'], ['organization/*'])
             ]
         }
 
         policy = Policy.objects.create(
             name='default',
-            body=json.dumps(clause))
+            body=json.dumps(clauses))
 
         self.user = UserFactory.create()
         assign_user_policies(self.user, policy)
@@ -608,23 +552,16 @@ class OrganizationUsersDetailTest(TestCase):
     def setUp(self):
         self.view = views.OrganizationUsersDetail.as_view()
 
-        clause = {
-            "clause": [
-                {
-                      "effect": "allow",
-                      "object": ["*"],
-                      "action": ["org.*"]
-                }, {
-                      "effect": "allow",
-                      "object": ["organization/*"],
-                      "action": ["org.*", "org.*.*"]
-                }
+        clauses = {
+            'clause': [
+                clause('allow', ['org.*']),
+                clause('allow', ['org.*', 'org.*.*'], ['organization/*'])
             ]
         }
 
         policy = Policy.objects.create(
             name='default',
-            body=json.dumps(clause))
+            body=json.dumps(clauses))
 
         self.user = UserFactory.create()
         assign_user_policies(self.user, policy)
@@ -706,3 +643,262 @@ class OrganizationUsersDetailTest(TestCase):
 
         assert response.status_code == 404
         assert content['detail'] == "Organization not found."
+
+
+class UserListAPITest(TestCase):
+    def setUp(self):
+        clauses = {
+            'clause': [
+                clause('allow', ['user.view'])
+            ]
+        }
+
+        policy = Policy.objects.create(
+            name='default',
+            body=json.dumps(clauses))
+        self.user = UserFactory.create()
+        assign_user_policies(self.user, policy)
+
+    def test_full_list(self):
+        """
+        It should return all users.
+        """
+        UserFactory.create_batch(2)
+        request = APIRequestFactory().get('/v1/users/')
+        force_authenticate(request, user=self.user)
+
+        response = views.UserAdminList.as_view()(request).render()
+        content = json.loads(response.content.decode('utf-8'))
+
+        assert response.status_code == 200
+        assert len(content) == 3
+
+    def test_full_list_organizations(self):
+        """
+        It should return all users with their organizations.
+        """
+        user1, user2 = UserFactory.create_batch(2)
+        o0 = OrganizationFactory.create(add_users=[user1, user2])
+        o1 = OrganizationFactory.create(add_users=[user1])
+        o2 = OrganizationFactory.create(add_users=[user2])
+        request = APIRequestFactory().get('/v1/users/')
+        force_authenticate(request, user=self.user)
+
+        response = views.UserAdminList.as_view()(request).render()
+        content = json.loads(response.content.decode('utf-8'))
+
+        assert response.status_code == 200
+        assert len(content) == 3
+        assert 'organizations' in content[0]
+        assert content[0]['organizations'] == []
+        assert 'organizations' in content[1]
+        assert {'id': o0.id, 'name': o0.name} in content[1]['organizations']
+        assert {'id': o1.id, 'name': o1.name} in content[1]['organizations']
+        assert 'organizations' in content[2]
+        assert {'id': o0.id, 'name': o0.name} in content[2]['organizations']
+        assert {'id': o2.id, 'name': o2.name} in content[2]['organizations']
+
+    def test_full_list_with_unautorized_user(self):
+        """
+        It should 403 "You do not have permission to perform this action."
+        """
+        UserFactory.create_batch(2)
+        request = APIRequestFactory().get('/v1/users/')
+        force_authenticate(request, user=AnonymousUser())
+
+        response = views.UserAdminList.as_view()(request).render()
+        content = json.loads(response.content.decode('utf-8'))
+
+        assert response.status_code == 403
+        assert content['detail'] == PermissionDenied.default_detail
+
+    def test_filter_active(self):
+        """
+        It should return only one active user (plus the "setup" user).
+        """
+        UserFactory.create(**{'is_active': True})
+        UserFactory.create(**{'is_active': False})
+
+        request = APIRequestFactory().get('/v1/users/?is_active=True')
+        setattr(request, 'GET', QueryDict('is_active=True'))
+        force_authenticate(request, user=self.user)
+
+        response = views.UserAdminList.as_view()(request).render()
+        content = json.loads(response.content.decode('utf-8'))
+
+        assert response.status_code == 200
+        assert len(content) == 2
+
+    def test_search_filter(self):
+        """
+        It should return only two matching users.
+        """
+        UserFactory.create(**{'last_name': 'Match'})
+        UserFactory.create(**{'username': 'ivegotamatch'})
+        UserFactory.create(**{'username': 'excluded'})
+
+        request = APIRequestFactory().get('/v1/users/?search=match')
+        setattr(request, 'GET', QueryDict('search=match'))
+        force_authenticate(request, user=self.user)
+
+        response = views.UserAdminList.as_view()(request).render()
+        content = json.loads(response.content.decode('utf-8'))
+
+        assert response.status_code == 200
+        assert len(content) == 2
+
+        for user in content:
+            assert user['username'] != 'excluded'
+
+    def test_ordering(self):
+        UserFactory.create(**{'username': 'A'})
+        UserFactory.create(**{'username': 'C'})
+        UserFactory.create(**{'username': 'B'})
+
+        request = APIRequestFactory().get('/v1/users/?ordering=username')
+        setattr(request, 'GET', QueryDict('ordering=username'))
+        force_authenticate(request, user=self.user)
+
+        response = views.UserAdminList.as_view()(request).render()
+        content = json.loads(response.content.decode('utf-8'))
+
+        assert response.status_code == 200
+        assert len(content) == 4
+
+        prev_username = ''
+        for user in content:
+            if prev_username:
+                assert user['username'] > prev_username
+
+            prev_username = user['username']
+
+    def test_reverse_ordering(self):
+        UserFactory.create(**{'username': 'A'})
+        UserFactory.create(**{'username': 'C'})
+        UserFactory.create(**{'username': 'B'})
+
+        request = APIRequestFactory().get('/v1/users/?ordering=-username')
+        setattr(request, 'GET', QueryDict('ordering=-username'))
+        force_authenticate(request, user=self.user)
+
+        response = views.UserAdminList.as_view()(request).render()
+        content = json.loads(response.content.decode('utf-8'))
+
+        assert response.status_code == 200
+        assert len(content) == 4
+
+        prev_username = ''
+        for org in content:
+            if prev_username:
+                assert org['username'] < prev_username
+
+            prev_username = org['username']
+
+
+class UserDetailAPITest(TestCase):
+    def setUp(self):
+        self.view = views.UserAdminDetail.as_view()
+
+        clauses = {
+            'clause': [
+                clause('allow', ['user.*']),
+                clause('allow', ['user.*'], ['user/*'])
+            ]
+        }
+
+        policy = Policy.objects.create(
+            name='default',
+            body=json.dumps(clauses))
+
+        self.user = UserFactory.create()
+        assign_user_policies(self.user, policy)
+
+    def test_get_user(self):
+        user = UserFactory.create(**{'username': 'test-user'})
+        request = APIRequestFactory().get(
+            '/v1/users/{username}/'.format(username=user.username),
+        )
+        force_authenticate(request, user=self.user)
+        response = self.view(request, username=user.username).render()
+        content = json.loads(response.content.decode('utf-8'))
+
+        assert response.status_code == 200
+        assert content['username'] == user.username
+        assert 'organizations' in content
+
+    def test_get_user_with_unauthorized_user(self):
+        user = UserFactory.create(**{'username': 'test-user'})
+        request = APIRequestFactory().get(
+            '/v1/users/{username}/'.format(username=user.username),
+        )
+        force_authenticate(request, user=AnonymousUser())
+        response = self.view(request, username=user.username).render()
+        content = json.loads(response.content.decode('utf-8'))
+
+        assert response.status_code == 403
+        assert content['detail'] == PermissionDenied.default_detail
+
+    def test_get_user_that_does_not_exist(self):
+        request = APIRequestFactory().get('/v1/users/some-user/')
+        force_authenticate(request, user=self.user)
+
+        response = self.view(request, username='some-user').render()
+        content = json.loads(response.content.decode('utf-8'))
+
+        assert response.status_code == 404
+        assert content['detail'] == "User not found."
+
+    def test_valid_update(self):
+        user = UserFactory.create(**{'username': 'test-user'})
+        assert user.is_active
+
+        data = {'is_active': False}
+        request = APIRequestFactory().patch(
+            '/v1/users/{username}/'.format(username=user.username),
+            data
+        )
+        force_authenticate(request, user=self.user)
+
+        response = self.view(request, username=user.username).render()
+        user.refresh_from_db()
+
+        assert response.status_code == 200
+        assert user.is_active == data.get('is_active')
+
+    def test_update_with_unauthorized_user(self):
+        user = UserFactory.create(**{'last_name': 'Smith',
+                                     'username': 'test-user'})
+
+        data = {'last_name': 'Jones'}
+        request = APIRequestFactory().patch(
+            '/v1/users/{username}/'.format(username=user.username),
+            data
+        )
+        force_authenticate(request, user=AnonymousUser())
+
+        response = self.view(request, username=user.username).render()
+        user.refresh_from_db()
+
+        assert response.status_code == 403
+        assert user.last_name == 'Smith'
+
+    def test_invalid_update(self):
+        t1 = datetime(12, 10, 30, tzinfo=timezone.utc)
+        t2 = t1 + timedelta(seconds=10)
+        user = UserFactory.create(**{'last_login': t1,
+                                     'username': 'test-user'})
+
+        data = {'last_login': t2}
+        request = APIRequestFactory().patch(
+            '/v1/users/{username}/'.format(username=user.username),
+            data
+        )
+        force_authenticate(request, user=self.user)
+
+        response = self.view(request, username=user.username).render()
+        content = json.loads(response.content.decode('utf-8'))
+        user.refresh_from_db()
+
+        assert response.status_code == 400
+        assert user.last_login == t1
+        assert content['last_login'][0] == 'Cannot update last_login'

--- a/cadasta/organization/tests/test_views.py
+++ b/cadasta/organization/tests/test_views.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 from django.http import QueryDict
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework.exceptions import PermissionDenied
 from tutelary.models import Policy, assign_user_policies
 
 from accounts.tests.factories import UserFactory
@@ -89,7 +90,7 @@ class OrganizationListAPITest(TestCase):
 
     def test_full_list_with_unautorized_user(self):
         """
-        It should 403 Permission denied.
+        It should 403 "You do not have permission to perform this action."
         """
         OrganizationFactory.create_batch(2)
         request = APIRequestFactory().get('/v1/organizations/')
@@ -99,7 +100,7 @@ class OrganizationListAPITest(TestCase):
         content = json.loads(response.content.decode('utf-8'))
 
         assert response.status_code == 403
-        assert content['detail'] == "Permission denied."
+        assert content['detail'] == PermissionDenied.default_detail
 
     def test_filter_active(self):
         """
@@ -256,6 +257,7 @@ class OrganizationCreateAPITest(TestCase):
         assign_user_policies(unauthorized_user, policy)
 
         data = {
+            'name': 'new_org',
             'description': 'Org description'
         }
         request = APIRequestFactory().post('/v1/organizations/', data)
@@ -265,7 +267,7 @@ class OrganizationCreateAPITest(TestCase):
         content = json.loads(response.content.decode('utf-8'))
 
         assert response.status_code == 403
-        assert content['detail'] == 'Permission denied.'
+        assert content['detail'] == PermissionDenied.default_detail
         assert Organization.objects.count() == 0
 
 
@@ -317,7 +319,7 @@ class OrganizationDetailTest(TestCase):
         content = json.loads(response.content.decode('utf-8'))
 
         assert response.status_code == 403
-        assert content['detail'] == "Permission denied."
+        assert content['detail'] == PermissionDenied.default_detail
 
     def test_get_organization_that_does_not_exist(self):
         request = APIRequestFactory().get('/v1/organizations/some-org/')
@@ -495,7 +497,7 @@ class OrganizationUsersTest(TestCase):
                 }, {
                       "effect": "allow",
                       "object": ["organization/*"],
-                      "action": ["org.*"]
+                      "action": ["org.*", "org.*.*"]
                 }
             ]
         }
@@ -533,7 +535,7 @@ class OrganizationUsersTest(TestCase):
         content = json.loads(response.content.decode('utf-8'))
 
         assert response.status_code == 403
-        assert content['detail'] == 'Permission denied.'
+        assert content['detail'] == PermissionDenied.default_detail
 
     def test_add_user(self):
         org_users = UserFactory.create_batch(2)
@@ -566,7 +568,7 @@ class OrganizationUsersTest(TestCase):
         content = json.loads(response.content.decode('utf-8'))
 
         assert response.status_code == 403
-        assert content['detail'] == 'Permission denied.'
+        assert content['detail'] == PermissionDenied.default_detail
         assert org.users.count() == 2
 
     def test_add_user_that_does_not_exist(self):
@@ -615,7 +617,7 @@ class OrganizationUsersDetailTest(TestCase):
                 }, {
                       "effect": "allow",
                       "object": ["organization/*"],
-                      "action": ["org.*"]
+                      "action": ["org.*", "org.*.*"]
                 }
             ]
         }
@@ -665,7 +667,7 @@ class OrganizationUsersDetailTest(TestCase):
 
         assert response.status_code == 403
         assert org.users.count() == 2
-        assert content['detail'] == 'Permission denied.'
+        assert content['detail'] == PermissionDenied.default_detail
 
     def test_remove_user_that_does_not_exist(self):
         user = UserFactory.create()

--- a/cadasta/organization/urls/organizations.py
+++ b/cadasta/organization/urls/organizations.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 
-from . import views
+from .. import views
 
 urlpatterns = [
     url(

--- a/cadasta/organization/urls/users.py
+++ b/cadasta/organization/urls/users.py
@@ -1,0 +1,14 @@
+from django.conf.urls import url
+
+from .. import views
+
+urlpatterns = [
+    url(
+        r'^$',
+        views.UserAdminList.as_view(),
+        name='list'),
+    url(
+        r'^(?P<slug>[-\w]+)/$',
+        views.UserAdminDetail.as_view(),
+        name='detail'),
+]

--- a/cadasta/organization/views.py
+++ b/cadasta/organization/views.py
@@ -6,7 +6,7 @@ from tutelary.mixins import PermissionRequiredMixin
 from accounts.serializers import UserSerializer
 from accounts.models import User
 from .models import Organization
-from .serializers import OrganizationSerializer
+from .serializers import OrganizationSerializer, UserAdminSerializer
 from .mixins import OrganizationUsersQuerySet
 
 
@@ -23,6 +23,7 @@ class OrganizationList(PermissionRequiredMixin, generics.ListCreateAPIView):
         'GET': 'org.list',
         'POST': 'org.create',
     }
+    permission_filter_queryset = ('org.view',)
 
 
 class OrganizationDetail(PermissionRequiredMixin,
@@ -89,3 +90,25 @@ class OrganizationUsersDetail(PermissionRequiredMixin,
         self.org.users.remove(user)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class UserAdminList(PermissionRequiredMixin, generics.ListAPIView):
+    queryset = User.objects.all()
+    serializer_class = UserAdminSerializer
+    filter_backends = (filters.DjangoFilterBackend,
+                       filters.SearchFilter,
+                       filters.OrderingFilter,)
+    filter_fields = ('is_active',)
+    search_fields = ('username', 'first_name', 'last_name', 'email')
+    ordering_fields = ('username', 'first_name', 'last_name')
+    permission_required = 'user.view'
+
+
+class UserAdminDetail(PermissionRequiredMixin, generics.RetrieveUpdateAPIView):
+    serializer_class = UserAdminSerializer
+    queryset = User.objects.all()
+    lookup_field = 'username'
+    permission_required = {
+        'GET': 'user.view',
+        'PATCH': 'user.update'
+    }

--- a/functional_tests/accounts/test_login.py
+++ b/functional_tests/accounts/test_login.py
@@ -1,0 +1,47 @@
+from base import FunctionalTest
+from pages.Login import LoginPage
+from accounts.tests.factories import UserFactory
+
+
+class LoginTest(FunctionalTest):
+    def setUp(self):
+        UserFactory.create(username='user1', password='user1pwd')
+
+    def test_unregistered_user(self):
+        """An unregistered user cannot log in."""
+
+        sign_in = LoginPage(self).setup('baduser', 'password')
+        self.click_through(sign_in, self.BY_ALERT)
+
+        self.assert_has_message('alert', "Unable to login")
+
+    def test_wrong_password(self):
+        """An user cannot log in with an invalid password."""
+        sign_in = LoginPage(self).setup('user1', 'not_right')
+        self.click_through(sign_in, self.BY_ALERT)
+
+        self.assert_has_message('alert', "Unable to login")
+
+    def test_valid_login(self):
+        """A registered user can log in with their username and password and
+        log out again.  The logged in and logged out states are
+        persistent across page refreshes.
+
+        """
+        sign_in = LoginPage(self).setup('user1', 'user1pwd')
+        self.click_through(sign_in, self.BY_ALERT)
+        self.browser.find_element_by_xpath("//h1[.='Dashboard']")
+
+        self.browser.refresh()
+        self.wait_for_no_alerts()
+        self.browser.find_element_by_xpath("//h1[.='Dashboard']")
+
+        self.click_through(
+            self.browser.find_element_by_xpath("//a[.='Logout']"),
+            self.BY_ALERT
+        )
+        self.assert_has_message('alert', "logged out")
+
+        self.browser.refresh()
+        self.wait_for_no_alerts()
+        self.browser.find_element_by_xpath("//h1[.='Sign in to your account']")

--- a/functional_tests/accounts/test_profile.py
+++ b/functional_tests/accounts/test_profile.py
@@ -1,0 +1,38 @@
+from base import FunctionalTest
+from pages.Profile import ProfilePage
+from pages.Login import LoginPage
+from accounts.tests.factories import UserFactory
+
+
+class ProfileTest(FunctionalTest):
+    def setUp(self):
+        UserFactory.create(username='user1', password='user1pwd')
+
+    def test_profile_view_and_edit(self):
+        """A registered user can view and edit their profile."""
+        LoginPage(self).login('user1', 'user1pwd')
+
+        page = ProfilePage(self)
+        page.go_to()
+        fields = page.get_fields()
+
+        fields['first_name'].clear()
+        fields['first_name'].send_keys('Kenny')
+        fields['last_name'].clear()
+        fields['last_name'].send_keys('Everett')
+        self.click_through(fields['update'], self.BY_ALERT)
+        self.assert_has_message('alert',
+                                "Successfully updated profile information")
+
+        self.click_through(
+            self.browser.find_element_by_xpath("//a[.='Logout']"),
+            self.BY_ALERT
+        )
+        self.assert_has_message('alert', "logged out")
+        LoginPage(self).login('user1', 'user1pwd')
+
+        page = ProfilePage(self)
+        page.go_to()
+        fields = page.get_fields()
+        assert fields['first_name'].get_attribute('value') == 'Kenny'
+        assert fields['last_name'].get_attribute('value') == 'Everett'

--- a/functional_tests/accounts/test_registration.py
+++ b/functional_tests/accounts/test_registration.py
@@ -1,0 +1,75 @@
+from base import FunctionalTest
+from pages.Registration import RegistrationPage
+from pages.Login import LoginPage
+from accounts.tests.factories import UserFactory
+
+
+class RegistrationTest(FunctionalTest):
+    def setUp(self):
+        UserFactory.create(username='user1', password='user1pwd')
+
+    def test_register_user(self):
+        """An unregistered user can register with valid user details."""
+
+        page = RegistrationPage(self)
+        page.go_to()
+        fields = page.get_fields()
+
+        # Try to submit an empty form and check for validation errors.
+        page.try_submit(err=['username', 'email',
+                             'password', 'password_repeat'])
+
+        # Fill in required fields one by one, try to submit and check
+        # for errors.
+        fields['username'].send_keys('user3')
+        page.try_submit(err=['email', 'password', 'password_repeat'],
+                        ok=['username'])
+        fields['email'].send_keys('user3@example.net')
+        page.try_submit(err=['password', 'password_repeat'],
+                        ok=['username', 'email'])
+        fields['password'].send_keys('very_secret')
+        page.try_submit(err=['password_repeat'],
+                        ok=['username', 'email', 'password'])
+        fields['password_repeat'].send_keys('not_very_secret')
+        page.try_submit(err=['password_repeat'],
+                        ok=['username', 'email', 'password'])
+
+        # Fill in extra fields, fill in final required form and
+        # submit.
+        fields['first_name'].send_keys('User')
+        fields['last_name'].send_keys('Three')
+        fields['password_repeat'].clear()
+        fields['password_repeat'].send_keys('very_secret')
+        self.click_through(fields['register'], self.BY_ALERT)
+        self.assert_has_message('alert', "logged in")
+        self.browser.find_element_by_xpath("//h1[.='Dashboard']")
+
+        # Log out.
+        self.click_through(
+            self.browser.find_element_by_xpath("//a[.='Logout']"),
+            self.BY_ALERT
+        )
+        self.assert_has_message('alert', "logged out")
+
+        # Log in as new user.
+        sign_in = LoginPage(self).setup('user3', 'very_secret')
+        self.click_through(sign_in, self.BY_ALERT)
+        self.browser.find_element_by_xpath("//h1[.='Dashboard']")
+
+    def test_register_duplicate_user(self):
+        page = RegistrationPage(self)
+        page.go_to()
+        fields = page.get_fields()
+
+        fields['username'].send_keys('user1')
+        fields['email'].send_keys('b@lah.net')
+        fields['password'].send_keys('password123')
+        fields['password_repeat'].send_keys('password123')
+        fields['first_name'].send_keys('Jane')
+        fields['last_name'].send_keys('Doe')
+        self.click_through(fields['register'], self.BY_ALERT)
+        self.assert_has_message('alert',
+                                "Unable to register with provided credentials")
+        self.browser.find_element_by_xpath(
+            "//h1[.='Sign up for a free account']"
+        )

--- a/functional_tests/base.py
+++ b/functional_tests/base.py
@@ -1,0 +1,150 @@
+from django.test import LiveServerTestCase
+
+import sys
+import time
+import re
+import os
+import os.path
+import shutil
+
+from selenium import webdriver
+from selenium.common.exceptions import (
+    NoSuchElementException, WebDriverException
+)
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+class FunctionalTest(LiveServerTestCase):
+    DEFAULT_UI_ENDPOINT = 'localhost:8080'
+    DEFAULT_WAIT = 5
+
+    BY_ALERT = (By.CLASS_NAME, 'alert')
+
+    @classmethod
+    def setUpClass(cls):
+        # IMPORTANT: Make sure the window size is big enough to see
+        # everything (e.g. links in the nav bar).  Otherwise tests
+        # will fail mysteriously because PhantomJS will clip the
+        # viewport.
+        cls.browser = webdriver.PhantomJS()
+        cls.browser.set_window_size(1024, 768)
+
+        # Set up API and UI URLs.  This is intended for future testing
+        # against a staging server.  Don't know if it works properly
+        # yet (and there are other concerns to be dealt with for
+        # staging testing, like database fixtures).
+        cls.api_url = None
+        cls.ui_url = 'http://' + cls.DEFAULT_UI_ENDPOINT
+        for arg in sys.argv:
+            if 'ui' in arg:
+                cls.ui_url = 'http://' + arg.split('=')[1]
+            if 'api' in arg:
+                cls.api_url = 'http://' + arg.split('=')[1]
+        if cls.api_url is None:
+            super().setUpClass()
+            cls.api_url = cls.live_server_url
+
+        print('Live server URL:', cls.live_server_url)
+        print('        API URL:', cls.api_url)
+        cls.screenshot_dir = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            'screenshots'
+        )
+        if os.path.exists(cls.screenshot_dir):
+            shutil.rmtree(cls.screenshot_dir)
+        os.makedirs(cls.screenshot_dir, exist_ok=True)
+        cls.screenshot_index = 1
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.browser.quit()
+        super(FunctionalTest, cls).tearDownClass()
+
+    def form(self, f):
+        """Find a form of a given class."""
+        return self.browser.find_element_by_xpath(
+            "//form[contains(@class,'{}')]".format(f)
+        )
+
+    def form_field(self, f, field):
+        """Find a field in a form of a given class."""
+        return self.form(f).find_element_by_xpath("//" + field)
+
+    def wait_for(self, function_with_assertion, timeout=DEFAULT_WAIT):
+        """Wait for an assertion to become true."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                return function_with_assertion()
+            except (AssertionError, WebDriverException):
+                time.sleep(0.1)
+        return function_with_assertion()
+
+    def click_through(self, button, wait, screenshot=None):
+        """Click a button or link and wait for something to appear."""
+        button.click()
+        if screenshot is not None:
+            self.screenshot(screenshot)
+        WebDriverWait(self.browser, 10).until(
+            EC.presence_of_element_located(wait)
+        )
+
+    def wait_for_no_alerts(self):
+        """Wait for all alerts to be cleared by a page reload."""
+        WebDriverWait(self.browser, 10).until_not(
+            EC.presence_of_element_located((By.CLASS_NAME, 'alert'))
+        )
+
+    def assert_has_message(self, msg_type, msg):
+        """Check for the presence of a message of a particular type containing
+        given text.
+
+        """
+        msgs = self.browser.find_element_by_xpath("//div[@id='messages']")
+        try:
+            msgs.find_element_by_xpath(
+                ("div[contains(@class,'{}')]//p[contains(.,'{}')]").
+                format(msg_type, msg)
+            )
+        except NoSuchElementException as e:
+            # Debugging help.
+            print("Messages: " + msgs.text)
+            raise e
+
+    def assert_field_has_error(self, field):
+        """Check whether a form field has an error marker: this will be a
+        ``has_error`` class on the field's immediate parent.
+
+        """
+        cls = field.find_element_by_xpath('..').get_attribute('class')
+        assert re.search(r'\bhas-error\b', cls)
+
+    def assert_field_has_no_error(self, field):
+        """Check that a form field has no error marker: this will be a
+        ``has_error`` class on the field's immediate parent.
+
+        """
+        cls = field.find_element_by_xpath('..').get_attribute('class')
+        assert not re.search(r'\bhas-error\b', cls)
+
+    def screenshot(self, title=None):
+        if title is not None:
+            f, _ = unique_file(self.screenshot_dir, title, 1)
+        else:
+            f, self.screenshot_index = unique_file(self.screenshot_dir,
+                                                   'screenshot',
+                                                   self.screenshot_index)
+        self.browser.save_screenshot(f)
+
+
+def unique_file(dir, base, startidx):
+    f = os.path.join(dir, base + '.png')
+    idx = startidx
+    if os.path.exists(f):
+        f = os.path.join(dir, base + '-{:04d}.png'.format(idx))
+        while os.path.exists(f):
+            idx = idx + 1
+            f = os.path.join(dir, base + '-{:04d}.png'.format(idx))
+    return f, idx

--- a/functional_tests/pages/Login.py
+++ b/functional_tests/pages/Login.py
@@ -1,0 +1,38 @@
+from .base import Page
+
+
+class LoginPage(Page):
+    def __init__(self, test):
+        super(LoginPage, self).__init__(test)
+        self.url = self.test.ui_url + '/account/login/'
+
+    def go_to(self):
+        self.browser.get(self.url)
+        self.test.wait_for(self.get_form)
+        return self
+
+    def get_form(self):
+        return self.test.form('login-form')
+
+    def get_form_field(self, xpath):
+        return self.test.form_field('login-form', xpath)
+
+    def get_username_input(self):
+        return self.get_form_field("input[@name='username']")
+
+    def get_password_input(self):
+        return self.get_form_field("input[@name='password']")
+
+    def get_sign_in_button(self):
+        return self.get_form_field("button[@name='sign-in']")
+
+    def setup(self, username, password):
+        """Go to login page and set up user and password fields."""
+        self.go_to()
+        self.get_username_input().send_keys(username)
+        self.get_password_input().send_keys(password)
+        return self.get_sign_in_button()
+
+    def login(self, username, password):
+        self.test.click_through(self.setup(username, password),
+                                self.test.BY_ALERT)

--- a/functional_tests/pages/Profile.py
+++ b/functional_tests/pages/Profile.py
@@ -1,0 +1,42 @@
+from .base import Page
+
+
+class ProfilePage(Page):
+    def __init__(self, test):
+        super(ProfilePage, self).__init__(test)
+        self.url = self.test.ui_url + '/account/profile/'
+
+    def go_to(self):
+        self.browser.get(self.url)
+        self.test.wait_for(self.get_form)
+        return self
+
+    def get_form(self):
+        return self.test.form('profile-form')
+
+    def get_form_field(self, xpath):
+        return self.test.form_field('profile-form', xpath)
+
+    def get_username_input(self):
+        return self.get_form_field("input[@name='username']")
+
+    def get_email_input(self):
+        return self.get_form_field("input[@name='email']")
+
+    def get_first_name_input(self):
+        return self.get_form_field("input[@name='first_name']")
+
+    def get_last_name_input(self):
+        return self.get_form_field("input[@name='last_name']")
+
+    def get_update_button(self):
+        return self.get_form_field("button[@name='update']")
+
+    def get_fields(self):
+        return {
+            'username':   self.get_username_input(),
+            'email':      self.get_email_input(),
+            'first_name': self.get_first_name_input(),
+            'last_name':  self.get_last_name_input(),
+            'update':     self.get_update_button()
+        }

--- a/functional_tests/pages/Registration.py
+++ b/functional_tests/pages/Registration.py
@@ -1,0 +1,80 @@
+from .base import Page
+
+
+class RegistrationPage(Page):
+    def __init__(self, test):
+        super(RegistrationPage, self).__init__(test)
+        self.url = self.test.ui_url + '/account/register/'
+
+    def go_to(self):
+        self.browser.get(self.url)
+        self.test.wait_for(self.get_form)
+        return self
+
+    def get_form(self):
+        return self.test.form('account-register')
+
+    def get_form_field(self, xpath):
+        return self.test.form_field('account-register', xpath)
+
+    def get_username_input(self):
+        return self.get_form_field("input[@name='username']")
+
+    def get_email_input(self):
+        return self.get_form_field("input[@name='email']")
+
+    def get_password_input(self):
+        return self.get_form_field("input[@name='password']")
+
+    def get_password_repeat_input(self):
+        return self.get_form_field("input[@name='password_repeat']")
+
+    def get_first_name_input(self):
+        return self.get_form_field("input[@name='first_name']")
+
+    def get_last_name_input(self):
+        return self.get_form_field("input[@name='last_name']")
+
+    def get_register_button(self):
+        return self.get_form_field("button[@name='register']")
+
+    def get_fields(self):
+        return {
+            'username':        self.get_username_input(),
+            'email':           self.get_email_input(),
+            'password':        self.get_password_input(),
+            'password_repeat': self.get_password_repeat_input(),
+            'first_name':      self.get_first_name_input(),
+            'last_name':       self.get_last_name_input(),
+            'register':        self.get_register_button()
+        }
+
+    def setup(self, values):
+        """Go to registration page and set up selected fields."""
+        self.go_to()
+        fields = self.get_fields()
+        for k, v in values:
+            fields[k].send_keys(v)
+        return fields['register']
+
+    def register(self, values):
+        self.test.click_through(self.setup(values),
+                                self.test.BY_ALERT)
+
+    def try_submit(self, err=None, ok=None):
+        fields = self.get_fields()
+        fields['register'].click()
+        if err is not None:
+            for f in err:
+                try:
+                    self.test.assert_field_has_error(fields[f])
+                except:
+                    raise AssertionError('Field "' + f +
+                                         '" should have error, but does not')
+        if ok is not None:
+            for f in ok:
+                try:
+                    self.test.assert_field_has_no_error(fields[f])
+                except:
+                    raise AssertionError('Field "' + f +
+                                         '" should not have error, but does')

--- a/functional_tests/pages/base.py
+++ b/functional_tests/pages/base.py
@@ -1,0 +1,4 @@
+class Page:
+    def __init__(self, test):
+        self.test = test
+        self.browser = test.browser

--- a/functional_tests/run.py
+++ b/functional_tests/run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import os.path
+import sys
+import pytest
+
+if __name__ == '__main__':
+    d = os.path.dirname(os.path.realpath(__file__))
+    sys.path.append(d)
+    sys.path.append(os.path.join(os.path.dirname(d), 'cadasta'))
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'config.settings.dev'
+    pytest.main()

--- a/provision/roles/cadasta/application/tasks/main.yml
+++ b/provision/roles/cadasta/application/tasks/main.yml
@@ -7,11 +7,17 @@
       - python-virtualenv
       - git
 
+- name: Create base directory for virtual environment
+  become: yes
+  become_user: root
+  file: path="{{ virtualenv_path | dirname }}" state=directory
+        owner="{{ app_user }}" mode=0755
+
 - name: Manually create the initial virtualenv
   become: yes
   become_user: "{{ app_user }}"
   command: virtualenv {{ virtualenv_path }} --python=python3
-           creates="{{ virtualenv_path }}"
+           creates="{{ virtualenv_path }}bin"
 
 - name: Install requirements
   become: yes
@@ -37,3 +43,16 @@
   become_user: "{{ app_user }}"
   template: src=settings.j2
             dest="{{ application_path }}/app/src/js/settings.js"
+
+- name: Install NodeJS dependencies
+  become: yes
+  become_user: "{{ app_user }}"
+  ignore_errors: yes
+  command: npm install
+           chdir="{{ application_path }}app"
+
+- name: Fix node-sass problem
+  become: yes
+  become_user: "{{ app_user }}"
+  command: npm rebuild node-sass
+           chdir="{{ application_path }}app"

--- a/provision/roles/cadasta/application/tasks/main.yml
+++ b/provision/roles/cadasta/application/tasks/main.yml
@@ -1,9 +1,15 @@
+- name: Add deadsnakes Python repository
+  become: yes
+  become_user: root
+  apt_repository: repo='ppa:fkrull/deadsnakes'
+
 - name: Install packages
   become: yes
   become_user: root
   apt: pkg={{ item }} state=installed update_cache=yes
   with_items:
-      - python3-dev
+      - python3.5
+      - python3.5-dev
       - python-virtualenv
       - git
 
@@ -16,7 +22,7 @@
 - name: Manually create the initial virtualenv
   become: yes
   become_user: "{{ app_user }}"
-  command: virtualenv {{ virtualenv_path }} --python=python3
+  command: virtualenv {{ virtualenv_path }} --python=python3.5
            creates="{{ virtualenv_path }}bin"
 
 - name: Install requirements

--- a/provision/roles/cadasta/production/tasks/main.yml
+++ b/provision/roles/cadasta/production/tasks/main.yml
@@ -1,16 +1,3 @@
-- name: Install NodeJS dependencies
-  become: yes
-  become_user: "{{ app_user }}"
-  ignore_errors: yes
-  command: npm install
-           chdir="{{ application_path }}app"
-
-- name: Fix node-sass problem
-  become: yes
-  become_user: "{{ app_user }}"
-  command: npm rebuild node-sass
-           chdir="{{ application_path }}app"
-
 - name: Install npm-run
   become: yes
   become_user: root

--- a/provision/roles/testing/tasks/main.yml
+++ b/provision/roles/testing/tasks/main.yml
@@ -1,0 +1,18 @@
+- name: Install PhantomJS
+  become: yes
+  become_user: root
+  apt: pkg={{ item }} state=installed update_cache=yes
+  with_items:
+      - phantomjs
+
+- name: Install Python Selenium driver
+  become: yes
+  become_user: "{{ app_user }}"
+  pip: virtualenv="{{ virtualenv_path }}"
+       name=selenium
+
+- name: Fix Django live test server address
+  become: yes
+  become_user: "{{ app_user }}"
+  lineinfile: dest=/home/vagrant/.bashrc
+              line="export DJANGO_LIVE_TEST_SERVER_ADDRESS=0.0.0.0:8000"

--- a/provision/roles/webserver/development/templates/nginx-development
+++ b/provision/roles/webserver/development/templates/nginx-development
@@ -1,5 +1,5 @@
 server {
-    listen      8080;
+    listen      5000;
     charset     utf-8;
 
     client_max_body_size 75M;
@@ -13,5 +13,13 @@ server {
         add_header 'Access-Control-Allow-Methods' 'GET, PUT, PATCH, POST, DELETE, OPTIONS';
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Headers' 'Authorization,Access-Control-Allow-Origin,Content-Type';
+    }
+}
+
+server {
+    listen 3000;
+
+    location / {
+        root /vagrant/app/dist;
     }
 }

--- a/provision/vagrant.yml
+++ b/provision/vagrant.yml
@@ -1,9 +1,9 @@
 - hosts: all
   vars:
     application_path: /vagrant/
-    virtualenv_path: /vagrant/env/
+    virtualenv_path: /opt/cadasta/env/
     django_settings: config.settings.dev
-    api_url: localhost:5000
+    api_url: 0.0.0.0:5000
     api_version: v1
     app_user: vagrant
     uwsgi_socket: /tmp/uwsgi.sock
@@ -18,3 +18,4 @@
     - cadasta/development
     - webserver/common
     - webserver/development
+    - testing

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,11 +1,11 @@
 Django==1.9.2
 psycopg2==2.6.1
-djoser==0.4.0
+djoser==0.4.3
 django-cors-headers==1.1.0
 django-filter==0.12.0
 django-crispy-forms==1.6.0
 jsonschema==2.5.1
 rfc3987==1.3.5
--e git+https://github.com/Cadasta/django-tutelary.git#egg=tutelary
+django-tutelary==0.1.3
 django-audit-log==0.7.0
 simplejson==3.8.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,6 +6,6 @@ django-filter==0.12.0
 django-crispy-forms==1.6.0
 jsonschema==2.5.1
 rfc3987==1.3.5
-django-tutelary==0.1.3
+django-tutelary==0.1.6
 django-audit-log==0.7.0
 simplejson==3.8.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 pytest-django
 pytest-cov
 factory_boy
+selenium


### PR DESCRIPTION
`FieldSelectorSerializer` is a serializer mixin that enables selecting fields for serialization, by adding the `field` keyword argument during initialization. 

Example:

```python
from core.serializers import FieldSelectorSerializer
from rest_framework.serializers import ModelSerializer

class OrganizationSerializer(FieldSelectorSerializer, ModelSerializer):
    class Meta:
        model = Organization
        fields = ('id', 'name', 'description',)

org = Organization.objects.create(name='Org', description='some org')
serializer = OrganizationSerializer(org, fields=('id', 'name'))
serializer.data  # {'id': 123, 'name': 'Org'}
```

Also removes `organzation.serializers.UserOrganizationSerializer` because it's not needed any longer.