### PR TITLE
Implements FieldSelectorSerializer

### DIFF
--- a/cadasta/core/serializers.py
+++ b/cadasta/core/serializers.py
@@ -10,3 +10,15 @@ class DetailSerializer:
         if is_list and not detail:
             for field_name in self.Meta.detail_only_fields:
                 self.fields.pop(field_name)
+
+
+class FieldSelectorSerializer:
+    def __init__(self, *args, **kwargs):
+        fields = kwargs.pop('fields', None)
+        super(FieldSelectorSerializer, self).__init__(*args, **kwargs)
+
+        if fields:
+            allowed = set(fields)
+            existing = set(self.fields.keys())
+            for field_name in existing - allowed:
+                self.fields.pop(field_name)

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -1,13 +1,14 @@
 from django.utils.text import slugify
 from rest_framework.serializers import ModelSerializer
 
-from core.serializers import DetailSerializer
+from core.serializers import DetailSerializer, FieldSelectorSerializer
 from accounts.serializers import UserSerializer
 from accounts.models import User
 from .models import Organization
 
 
-class OrganizationSerializer(DetailSerializer, ModelSerializer):
+class OrganizationSerializer(DetailSerializer, FieldSelectorSerializer,
+                             ModelSerializer):
     users = UserSerializer(many=True, read_only=True)
 
     class Meta:
@@ -24,15 +25,9 @@ class OrganizationSerializer(DetailSerializer, ModelSerializer):
         return super(OrganizationSerializer, self).to_internal_value(data)
 
 
-class UserOrganizationSerializer(ModelSerializer):
-    class Meta:
-        model = Organization
-        fields = ('id', 'name')
-        read_only_fields = ('id', 'name')
-
-
 class UserAdminSerializer(UserSerializer):
-    organizations = UserOrganizationSerializer(many=True, read_only=True)
+    organizations = OrganizationSerializer(
+        many=True, read_only=True, fields=('id', 'name'))
 
     class Meta:
         model = User


### PR DESCRIPTION
`FieldSelectorSerializer` is a serializer mixin that enables selecting fields for serialization, by adding the `field` keyword argument during initialization. 

Example:

```python
from core.serializers import FieldSelectorSerializer
from rest_framework.serializers import ModelSerializer

class OrganizationSerializer(FieldSelectorSerializer, ModelSerializer):
    class Meta:
        model = Organization
        fields = ('id', 'name', 'description',)

org = Organization.objects.create(name='Org', description='some org')
serializer = OrganizationSerializer(org, fields=('id', 'name'))
serializer.data  # {'id': 123, 'name': 'Org'}
```

Also removes `organzation.serializers.UserOrganizationSerializer` because it's not needed any longer.