### PR TITLE
Add permissions to organization default views

### DIFF
--- a/cadasta/core/mixins.py
+++ b/cadasta/core/mixins.py
@@ -2,13 +2,18 @@ from django.contrib import messages
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 
-import tutelary.mixins
+from tutelary import mixins
 
 
-class PermissionRequiredMixin(tutelary.mixins.PermissionRequiredMixin):
+class PermissionRequiredMixin(mixins.PermissionRequiredMixin):
     def handle_no_permission(self):
         msg = super().handle_no_permission()
         messages.add_message(self.request, messages.WARNING,
                              msg[0] if len(msg) > 0
                              else _("PERMISSION DENIED"))
         return redirect(self.request.META.get('HTTP_REFERER', '/'))
+
+
+class LoginPermissionRequiredMixin(PermissionRequiredMixin,
+                                   mixins.LoginPermissionRequiredMixin):
+    pass

--- a/cadasta/organization/messages.py
+++ b/cadasta/organization/messages.py
@@ -1,0 +1,14 @@
+from django.utils.translation import ugettext as _
+
+ORG_VIEW = _("You don't have permission to access this organization")
+ORG_EDIT = _("You don't have permission to update this organization")
+ORG_ARCHIVE = _("You don't have permission to archive this organization")
+ORG_UNARCHIVE = _("You don't have permission to unarchive this organization")
+ORG_USERS_LIST = _("You don't have permission to view members of this "
+                   "organization")
+ORG_USERS_ADD = _("You don't have permission to add members to this "
+                  "organization")
+ORG_USERS_EDIT = _("You don't have permission to edit roles of this "
+                   "organization")
+ORG_USERS_REMOVE = _("You don't have permission to remove members from this "
+                     "organization")

--- a/cadasta/organization/models.py
+++ b/cadasta/organization/models.py
@@ -12,6 +12,7 @@ from tutelary.models import Policy
 from core.models import RandomIDModel
 from .validators import validate_contact
 from .choices import ROLE_CHOICES
+from .import messages
 
 
 PERMISSIONS_DIR = settings.BASE_DIR + '/permissions/'
@@ -54,23 +55,33 @@ class Organization(RandomIDModel):
             ('org.list',
              {'description': _("List existing organizations"),
               'permissions_object': None}),
-            ('org.view',
-             {'description': _("View existing organizations")}),
             ('org.create',
              {'description': _("Create organizations"),
               'permissions_object': None}),
+            ('org.view',
+             {'description':   _("View existing organizations"),
+              'error_message': messages.ORG_VIEW}),
             ('org.update',
-             {'description': _("Update an existing organization")}),
+             {'description':   _("Update an existing organization"),
+              'error_message': messages.ORG_EDIT}),
             ('org.archive',
-             {'description': _("Archive an existing organization")}),
+             {'description':   _("Archive an existing organization"),
+              'error_message': messages.ORG_ARCHIVE}),
             ('org.unarchive',
-             {'description': _("Unarchive an existing organization")}),
+             {'description':   _("Unarchive an existing organization"),
+              'error_message': messages.ORG_UNARCHIVE}),
             ('org.users.list',
-             {'description': _("List members of an organization")}),
+             {'description':   _("List members of an organization"),
+              'error_message': messages.ORG_USERS_LIST}),
             ('org.users.add',
-             {'description': _("Add a member to an organization")}),
+             {'description':   _("Add a member to an organization"),
+              'error_message': messages.ORG_USERS_ADD}),
+            ('org.users.edit',
+             {'description':   _("Edit a member of an organization"),
+              'error_message': messages.ORG_USERS_EDIT}),
             ('org.users.remove',
-             {'description': _("Remove a member from an organization")})
+             {'description':   _("Remove a member from an organization"),
+              'error_message': messages.ORG_USERS_REMOVE})
         )
 
     def __str__(self):
@@ -196,10 +207,8 @@ def assign_project_permissions(sender, instance, **kwargs):
         assigned_policies.append(project_user)
 
     if is_collector and not new_role == 'DC':
-        print('remove')
         assigned_policies.remove(data_collector)
     elif not is_collector and new_role == 'DC':
-        print('add')
         assigned_policies.append(data_collector)
 
     if is_manager and not new_role == 'PM':

--- a/cadasta/organization/tests/test_urls_default.py
+++ b/cadasta/organization/tests/test_urls_default.py
@@ -41,6 +41,14 @@ class OrganizationUrlsTest(TestCase):
         assert resolved.func.__name__ == default.OrganizationArchive.__name__
         assert resolved.kwargs['slug'] == 'org-slug'
 
+    def test_organization_unarchive(self):
+        url = reverse('organization:unarchive', kwargs={'slug': 'org-slug'})
+        assert (url == '/organizations/org-slug/unarchive/')
+
+        resolved = resolve('/organizations/org-slug/unarchive/')
+        assert resolved.func.__name__ == default.OrganizationUnarchive.__name__
+        assert resolved.kwargs['slug'] == 'org-slug'
+
 
 class UserUrlsTest(TestCase):
     def test_user_list(self):

--- a/cadasta/organization/urls/default/organizations.py
+++ b/cadasta/organization/urls/default/organizations.py
@@ -23,6 +23,10 @@ urlpatterns = [
         r'^(?P<slug>[-\w]+)/archive/$',
         default.OrganizationArchive.as_view(),
         name='archive'),
+    url(
+        r'^(?P<slug>[-\w]+)/unarchive/$',
+        default.OrganizationUnarchive.as_view(),
+        name='unarchive'),
     #
     # PROJECTS
     #

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -8,7 +8,7 @@ from accounts.models import User
 
 from ..models import Organization
 from .. import serializers
-from ..mixins import OrganizationRoles, ProjectRoles
+from .mixins import OrganizationRoles, ProjectRoles
 
 
 class OrganizationList(APIPermissionRequiredMixin, generics.ListCreateAPIView):

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -2,12 +2,18 @@ from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import get_object_or_404
 
-from .models import Organization, Project
+from ..models import Organization, Project
 
 
 class OrganizationMixin:
     def get_organization(self):
-        return get_object_or_404(Organization, slug=self.kwargs['slug'])
+        if not hasattr(self, 'org'):
+            self.org = get_object_or_404(Organization,
+                                         slug=self.kwargs['slug'])
+        return self.org
+
+    def get_perms_objects(self):
+        return [self.get_organization()]
 
 
 class OrganizationRoles(OrganizationMixin):
@@ -24,9 +30,6 @@ class OrganizationRoles(OrganizationMixin):
         context['domain'] = get_current_site(self.request).domain
         context['sitename'] = settings.SITE_NAME
         return context
-
-    def get_perms_objects(self):
-        return [self.get_organization()]
 
 
 class ProjectMixin:

--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -22,9 +22,15 @@
     <a href="{% url 'organization:edit' object.slug %}">
       {% trans "Edit" %}
     </a> |
+    {% if object.archived %}
+    <a href="#unarchive_confirm" data-toggle="modal">
+      {% trans "Unarchive" %}
+    </a>
+    {% else %}
     <a href="#archive_confirm" data-toggle="modal">
       {% trans "Archive" %}
     </a>
+    {% endif %}
   </div>
 </div>
 
@@ -105,6 +111,33 @@
         </button>
         <a href="{% url 'organization:archive' object.slug %}"  class="btn btn-primary">
           {% trans "Archive" %}
+        </a>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+
+<div class="modal fade" id="unarchive_confirm" tabindex="-1" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">{% trans "Unarchive organization" %}</h4>
+      </div>
+      <div class="modal-body">
+        <p>
+          {% trans "Are you sure you want to unarchive this organization?" %}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-link" data-dismiss="modal">
+          {% trans "Cancel" %}
+        </button>
+        <a href="{% url 'organization:unarchive' object.slug %}"  class="btn btn-primary">
+          {% trans "Unarchive" %}
         </a>
       </div>
     </div><!-- /.modal-content -->

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -14,7 +14,7 @@ djangorestframework-gis==0.10.1
 jsonschema==2.5.1
 rfc3987==1.3.5
 drfdocs==0.0.9
-django-tutelary==0.1.10
+django-tutelary==0.1.11
 django-audit-log==0.7.0
 simplejson==3.8.1
 django-widget-tweaks==1.4.1


### PR DESCRIPTION
- Use custom LoginPermissionRequiredMixin based on django-tutelary's LoginPermissionRequiredMixin
- Add unarchive view
- Moved mixins.py into directory views
- Moved all permission related messages into messages.py, models and views read from there, so messages will be consistent
- Tests for authorized, unauthorized, unauthenticated users, both for GET and POST