### PR TITLE
Bugs: new users default policy; org creation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements/*.txt

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -61,10 +61,8 @@ class RegisterFormTest(TestCase):
 
 class ProfileFormTest(TestCase):
     def test_update_user(self):
-        user = UserFactory.create(**{
-            'username': 'imagine71',
-            'email': 'john@beatles.uk'
-        })
+        user = UserFactory.create(username='imagine71',
+                                  email='john@beatles.uk')
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
@@ -80,10 +78,8 @@ class ProfileFormTest(TestCase):
 
     def test_update_user_with_existing_username(self):
         UserFactory.create(username='existing')
-        user = UserFactory.create(**{
-            'username': 'imagine71',
-            'email': 'john@beatles.uk'
-        })
+        user = UserFactory.create(username='imagine71',
+                                  email='john@beatles.uk')
         data = {
             'username': 'existing',
             'email': 'john@beatles.uk',
@@ -95,10 +91,8 @@ class ProfileFormTest(TestCase):
 
     def test_update_user_with_existing_email(self):
         UserFactory.create(email='existing@example.com')
-        user = UserFactory.create(**{
-            'username': 'imagine71',
-            'email': 'john@beatles.uk'
-        })
+        user = UserFactory.create(username='imagine71',
+                                  email='john@beatles.uk')
         data = {
             'username': 'imagine71',
             'email': 'existing@example.com',

--- a/cadasta/accounts/tests/test_serializers.py
+++ b/cadasta/accounts/tests/test_serializers.py
@@ -60,9 +60,7 @@ class RegistrationSerializerTest(TestCase):
         """Serialiser should be invalid when another user with the same email
            address is already registered."""
 
-        UserFactory.create(**{
-            'email': 'john@beatles.uk',
-        })
+        UserFactory.create(email='john@beatles.uk')
 
         data = {
             'username': 'imagine71',
@@ -137,11 +135,9 @@ class AccountLoginSerializerTest(TestCase):
         """Serializer should raise EmailNotVerifiedError exeception when the
            user has not verified their email address within 48 hours"""
 
-        UserFactory.create(**{
-            'username': 'sgt_pepper',
-            'password': 'iloveyoko79',
-            'verify_email_by': datetime.now()
-        })
+        UserFactory.create(username='sgt_pepper',
+                           password='iloveyoko79',
+                           verify_email_by=datetime.now())
 
         with pytest.raises(EmailNotVerifiedError):
             AccountLoginSerializer().validate(attrs={

--- a/cadasta/accounts/tests/test_views_api.py
+++ b/cadasta/accounts/tests/test_views_api.py
@@ -103,11 +103,9 @@ class AccountSignupTest(TestCase):
 
 class AccountLoginTest(TestCase):
     def setUp(self):
-        self.user = UserFactory.create(**{
-            'username': 'imagine71',
-            'email': 'john@beatles.uk',
-            'password': 'iloveyoko79'
-        })
+        self.user = UserFactory.create(username='imagine71',
+                                       email='john@beatles.uk',
+                                       password='iloveyoko79')
 
     def _post(self, data, status=None, token=None):
         url = '/v1/account/login/'

--- a/cadasta/core/fixtures.py
+++ b/cadasta/core/fixtures.py
@@ -65,7 +65,10 @@ class FixturesData:
         pols = {}
         for pol in ['default', 'superuser', 'org-admin', 'org-member',
                     'project-manager', 'data-collector', 'project-user']:
-            pols[pol] = PolicyFactory.create(name=pol, file=pol + '.json')
+            try:
+                pols[pol] = Policy.objects.get(name=pol)
+            except Policy.DoesNotExist:
+                pols[pol] = PolicyFactory.create(name=pol, file=pol + '.json')
 
         roles = {}
         roles['superuser'] = RoleFactory.create(

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -59,7 +59,8 @@ class OrganizationForm(forms.ModelForm):
         if create:
             OrganizationRole.objects.create(
                 organization=instance,
-                user=self.user
+                user=self.user,
+                admin=True
             )
 
         return instance

--- a/cadasta/organization/models.py
+++ b/cadasta/organization/models.py
@@ -88,6 +88,9 @@ class Organization(RandomIDModel):
     def __str__(self):
         return "<Organization: {name}>".format(name=self.name)
 
+    def __repr__(self):
+        return str(self)
+
 
 class OrganizationRole(RandomIDModel):
     organization = models.ForeignKey(Organization)
@@ -200,6 +203,9 @@ class Project(RandomIDModel):
 
     def __str__(self):
         return "<Project: {name}>".format(name=self.name)
+
+    def __repr__(self):
+        return str(self)
 
     def save(self, *args, **kwargs):
         if ((self.country is None or self.country == '') and

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -38,7 +38,8 @@ class OrganizationSerializer(DetailSerializer, FieldSelectorSerializer,
 
         OrganizationRole.objects.create(
             organization=org,
-            user=self.context['request'].user
+            user=self.context['request'].user,
+            admin=True
         )
 
         return org

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -68,7 +68,7 @@ class OrganzationAddTest(TestCase):
         assert org.contacts == [{'name': 'Ringo Starr', 'tel': '555-5555'}]
 
     def test_update_organization(self):
-        org = OrganizationFactory.create(**{'slug': 'some-org'})
+        org = OrganizationFactory.create(slug='some-org')
 
         data = {
             'name': 'Org',

--- a/cadasta/organization/tests/test_models.py
+++ b/cadasta/organization/tests/test_models.py
@@ -65,7 +65,7 @@ class OrganizationRoleTest(TestCase):
 
     def test_delete_project_roles(self):
         ProjectFactory.create_batch(2, add_users=[self.user],
-                                    **{'organization': self.org})
+                                    organization=self.org)
         ProjectFactory.create_batch(2, add_users=[self.user])
         assert ProjectRole.objects.filter(user=self.user).count() == 4
 

--- a/cadasta/organization/tests/test_serializers.py
+++ b/cadasta/organization/tests/test_serializers.py
@@ -276,7 +276,7 @@ class ProjectUserSerializerTest(TestCase):
     def test_set_roles_for_existing_user(self):
         user = UserFactory.create()
         org = OrganizationFactory.create(add_users=[user])
-        project = ProjectFactory.create(**{'organization': org})
+        project = ProjectFactory.create(organization=org)
         data = {'username': user.username, 'role': 'DC'}
         serializer = serializers.ProjectUserSerializer(
             data=data,

--- a/cadasta/organization/tests/test_views_api_projects.py
+++ b/cadasta/organization/tests/test_views_api_projects.py
@@ -36,7 +36,7 @@ class ProjectUsersAPITest(TestCase):
             ]
         }
         policy = Policy.objects.create(
-            name='default',
+            name='test-policy',
             body=json.dumps(clause))
         self.user = UserFactory.create()
         self.user.assign_policies(policy)
@@ -142,7 +142,7 @@ class ProjectUsersDetailAPITest(TestCase):
             ]
         }
         policy = Policy.objects.create(
-            name='default',
+            name='test-policy',
             body=json.dumps(clause))
         self.user = UserFactory.create()
         self.user.assign_policies(policy)
@@ -271,7 +271,7 @@ class OrganizationProjectListAPITest(TestCase):
             ]
         }
         policy = Policy.objects.create(
-            name='default',
+            name='test-policy',
             body=json.dumps(clause))
         self.user = UserFactory.create()
         assign_user_policies(self.user, policy)
@@ -370,7 +370,7 @@ class ProjectListAPITest(TestCase):
             ]
         }
         policy = Policy.objects.create(
-            name='default',
+            name='test-policy',
             body=json.dumps(clause))
         self.user = UserFactory.create()
         assign_user_policies(self.user, policy)
@@ -500,7 +500,7 @@ class ProjectListAPITest(TestCase):
             ]
         }
         policy = Policy.objects.create(
-            name='default',
+            name='test-policy',
             body=json.dumps(clause)
         )
         for user in users:
@@ -545,7 +545,7 @@ class ProjectCreateAPITest(TestCase):
             ]
         }
         policy = Policy.objects.create(
-            name='default',
+            name='test-policy',
             body=json.dumps(clauses))
         self.user = UserFactory.create()
         assign_user_policies(self.user, policy)
@@ -596,7 +596,7 @@ class ProjectDetailAPITest(TestCase):
             ]
         }
         policy = Policy.objects.create(
-            name='default',
+            name='test-policy',
             body=json.dumps(clauses))
         self.user = UserFactory.create()
         assign_user_policies(self.user, policy)
@@ -774,7 +774,7 @@ class ProjectDetailAPITest(TestCase):
             ]
         }
         policy = Policy.objects.create(
-            name='default',
+            name='test-policy',
             body=json.dumps(clauses)
         )
         org_user = UserFactory.create()

--- a/cadasta/organization/tests/test_views_api_users.py
+++ b/cadasta/organization/tests/test_views_api_users.py
@@ -160,13 +160,13 @@ class UserDetailAPITest(TestCase):
         return content
 
     def test_get_user(self):
-        user = UserFactory.create(**{'username': 'test-user'})
+        user = UserFactory.create(username='test-user')
         content = self._get(user.username, status=200)
         assert content['username'] == user.username
         assert 'organizations' in content
 
     def test_get_user_with_unauthorized_user(self):
-        user = UserFactory.create(**{'username': 'test-user'})
+        user = UserFactory.create(username='test-user')
         content = self._get(user.username, user=AnonymousUser(), status=403)
         assert content['detail'] == PermissionDenied.default_detail
 
@@ -175,7 +175,7 @@ class UserDetailAPITest(TestCase):
         assert content['detail'] == "User not found."
 
     def test_valid_update(self):
-        user = UserFactory.create(**{'username': 'test-user'})
+        user = UserFactory.create(username='test-user')
         assert user.is_active
         data = {'is_active': False}
         self._patch(user.username, data, status=200)
@@ -183,8 +183,7 @@ class UserDetailAPITest(TestCase):
         assert user.is_active == data.get('is_active')
 
     def test_update_with_unauthorized_user(self):
-        user = UserFactory.create(**{'last_name': 'Smith',
-                                     'username': 'test-user'})
+        user = UserFactory.create(last_name='Smith', username='test-user')
         self._patch(user.username, {'last_name': 'Jones'},
                     user=AnonymousUser(), status=403)
         user.refresh_from_db()
@@ -193,8 +192,7 @@ class UserDetailAPITest(TestCase):
     def test_invalid_update(self):
         t1 = datetime(12, 10, 30, tzinfo=timezone.utc)
         t2 = t1 + timedelta(seconds=10)
-        user = UserFactory.create(**{'last_login': t1,
-                                     'username': 'test-user'})
+        user = UserFactory.create(last_login=t1, username='test-user')
         content = self._patch(user.username, {'last_login': t2}, status=400)
         user.refresh_from_db()
         assert user.last_login == t1

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -252,7 +252,9 @@ class ProjectList(PermissionRequiredMixin, ProjectQuerySetMixin,
     model = Project
     template_name = 'organization/project_list.html'
     permission_required = 'project.list'
-    permission_filter_queryset = ('project.view',)
+    permission_filter_queryset = (lambda self, view, p: ('project.view',)
+                                  if p.access == 'public'
+                                  else ('project.view_private',))
 
     def get_context_data(self, **kwargs):
         context = super(ProjectList, self).get_context_data(**kwargs)

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -63,9 +63,9 @@ class ProjectRoles(ProjectMixin):
 class ProjectQuerySetMixin:
     def get_queryset(self):
         if hasattr(self.request.user, 'organizations'):
-            return Project.objects.filter(
-                Q(access='public') |
-                Q(organization__in=self.request.user.organizations.all())
-            )
-        else:
-            return Project.objects.filter(access='public')
+            orgs = self.request.user.organizations.all()
+            if len(orgs) > 0:
+                return Project.objects.filter(
+                    Q(access='public') | Q(organization__in=orgs)
+                )
+        return Project.objects.filter(access='public')

--- a/functional_tests/organizations/test_member.py
+++ b/functional_tests/organizations/test_member.py
@@ -6,6 +6,7 @@ from accounts.tests.factories import UserFactory
 from organization.tests.factories import OrganizationFactory, ProjectFactory
 from core.tests.factories import PolicyFactory, RoleFactory
 from organization.models import Organization
+from tutelary.models import Policy
 
 
 class MemberTest(FunctionalTest):
@@ -25,7 +26,10 @@ class MemberTest(FunctionalTest):
 
         PolicyFactory.set_directory('../cadasta/config/permissions')
         pols = {}
-        for pol in ['default', 'superuser', 'org-admin', 'project-manager',
+        # Default policy is installed automatically when first user is
+        # created.
+        pols['default'] = Policy.objects.get(name='default')
+        for pol in ['superuser', 'org-admin', 'project-manager',
                     'data-collector', 'project-user']:
             pols[pol] = PolicyFactory.create(name=pol, file=pol + '.json')
         roles = {}

--- a/functional_tests/organizations/test_organization.py
+++ b/functional_tests/organizations/test_organization.py
@@ -7,6 +7,7 @@ from organization.tests.factories import OrganizationFactory, ProjectFactory
 from core.tests.factories import PolicyFactory, RoleFactory
 from organization.models import Organization
 from selenium.webdriver.common.by import By
+from tutelary.models import Policy
 
 
 class OrganizationTest(FunctionalTest):
@@ -25,7 +26,10 @@ class OrganizationTest(FunctionalTest):
 
         PolicyFactory.set_directory('../cadasta/config/permissions')
         pols = {}
-        for pol in ['default', 'superuser', 'org-admin', 'project-manager',
+        # Default policy is installed automatically when first user is
+        # created.
+        pols['default'] = Policy.objects.get(name='default')
+        for pol in ['superuser', 'org-admin', 'project-manager',
                     'data-collector', 'project-user']:
             pols[pol] = PolicyFactory.create(name=pol, file=pol + '.json')
         roles = {}

--- a/functional_tests/organizations/test_organizations.py
+++ b/functional_tests/organizations/test_organizations.py
@@ -5,6 +5,7 @@ from accounts.tests.factories import UserFactory
 from organization.tests.factories import OrganizationFactory, ProjectFactory
 from core.tests.factories import PolicyFactory, RoleFactory
 from selenium.webdriver.common.by import By
+from tutelary.models import Policy
 
 
 class OrganizationsTest(FunctionalTest):
@@ -21,7 +22,10 @@ class OrganizationsTest(FunctionalTest):
 
         PolicyFactory.set_directory('../cadasta/config/permissions')
         pols = {}
-        for pol in ['default', 'superuser', 'org-admin', 'project-manager',
+        # Default policy is installed automatically when first user is
+        # created.
+        pols['default'] = Policy.objects.get(name='default')
+        for pol in ['superuser', 'org-admin', 'project-manager',
                     'data-collector', 'project-user']:
             pols[pol] = PolicyFactory.create(name=pol, file=pol + '.json')
         roles = {}
@@ -58,15 +62,15 @@ class OrganizationsTest(FunctionalTest):
         ))
 
     def test_organizations_view_without_permission(self):
-        """ Users without permission cannot view organizations """
+        """ Users without permission can view organizations """
 
         LoginPage(self).login('testuser', 'password')
 
         page = OrganizationsPage(self)
         page.go_to()
 
-        empty_table = page.get_empty_table()
-        assert empty_table.text == 'No data available in table'
+        organization_title = page.get_organization_titles()
+        assert organization_title.text == 'Organization #0'
 
     def test_organizations_view_with_permission(self):
         """A registered superuser user can view organizations"""

--- a/functional_tests/users/test_activation.py
+++ b/functional_tests/users/test_activation.py
@@ -6,6 +6,7 @@ from accounts.models import User
 from accounts.tests.factories import UserFactory
 from core.tests.factories import PolicyFactory, RoleFactory
 from selenium.webdriver.common.by import By
+from tutelary.models import Policy
 
 
 class ActivationTest(FunctionalTest):
@@ -34,9 +35,9 @@ class ActivationTest(FunctionalTest):
 
         pols = {}
         PolicyFactory.set_directory('../cadasta/config/permissions')
-        pols['default'] = PolicyFactory.create(
-            name='default',   file='default.json'
-        )
+        # Default policy is installed automatically when first user is
+        # created.
+        pols['default'] = Policy.objects.get(name='default')
         pols['superuser'] = PolicyFactory.create(
             name='superuser', file='superuser.json'
         )

--- a/functional_tests/users/test_page_access.py
+++ b/functional_tests/users/test_page_access.py
@@ -4,6 +4,7 @@ from pages.Users import UsersPage
 from pages.Login import LoginPage
 from accounts.tests.factories import UserFactory
 from core.tests.factories import PolicyFactory, RoleFactory
+from tutelary.models import Policy
 
 
 class PageAccessTest(FunctionalTest):
@@ -26,9 +27,9 @@ class PageAccessTest(FunctionalTest):
 
         pols = {}
         PolicyFactory.set_directory('../cadasta/config/permissions')
-        pols['default'] = PolicyFactory.create(
-            name='default',   file='default.json'
-        )
+        # Default policy is installed automatically when first user is
+        # created.
+        pols['default'] = Policy.objects.get(name='default')
         pols['superuser'] = PolicyFactory.create(
             name='superuser', file='superuser.json'
         )

--- a/functional_tests/users/test_page_list.py
+++ b/functional_tests/users/test_page_list.py
@@ -10,6 +10,7 @@ from accounts.tests.factories import UserFactory
 from core.tests.factories import PolicyFactory, RoleFactory
 from organization.tests.factories import OrganizationFactory
 from organization.models import OrganizationRole
+from tutelary.models import Policy
 
 
 class PageListTest(FunctionalTest):
@@ -44,9 +45,9 @@ class PageListTest(FunctionalTest):
 
         pols = {}
         PolicyFactory.set_directory('../cadasta/config/permissions')
-        pols['default'] = PolicyFactory.create(
-            name='default',   file='default.json'
-        )
+        # Default policy is installed automatically when first user is
+        # created.
+        pols['default'] = Policy.objects.get(name='default')
         pols['superuser'] = PolicyFactory.create(
             name='superuser', file='superuser.json'
         )

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -14,7 +14,7 @@ djangorestframework-gis==0.10.1
 jsonschema==2.5.1
 rfc3987==1.3.5
 drfdocs==0.0.9
-django-tutelary==0.1.11
+django-tutelary==0.1.12
 django-audit-log==0.7.0
 simplejson==3.8.1
 django-widget-tweaks==1.4.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,8 +1,9 @@
-pytest-django
-pytest-cov
-factory_boy
-selenium
-transifex-client
-django-compressor
-tox
-flake8
+-r common.txt
+pytest-django==2.9.1
+pytest-cov==2.2.1
+factory_boy==2.7.0
+selenium==2.53.2
+transifex-client==0.11
+django-compressor==2.0
+tox==2.3.1
+flake8==2.5.4

--- a/runtests.py
+++ b/runtests.py
@@ -84,20 +84,17 @@ def is_class(string):
 
 
 if __name__ == "__main__":
-    try:
-        sys.argv.remove('--nolint')
-    except ValueError:
-        run_flake8 = True
-    else:
-        run_flake8 = False
+    run_flake8 = False
+    run_tests = True
+    run_functional = False
 
     try:
-        sys.argv.remove('--lintonly')
+        sys.argv.remove('--lint')
     except ValueError:
-        run_tests = True
+        pass
     else:
+        run_flake8 = True
         run_tests = False
-        run_functional = False
 
     try:
         sys.argv.remove('--fast')
@@ -105,16 +102,15 @@ if __name__ == "__main__":
         style = 'default'
     else:
         style = 'fast'
-        run_flake8 = False
 
     try:
         sys.argv.remove('--functional')
     except ValueError:
-        run_functional = False
+        pass
     else:
         run_flake8 = False
-        run_functional = True
         run_tests = False
+        run_functional = True
 
     if len(sys.argv) > 1:
         pytest_args = sys.argv[1:]

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import re
 import os
-import sys
 from setuptools import setup
 
+BASE_DIR = os.path.dirname(__file__)
 
 name = 'cadasta-platform'
 package = 'cadasta'
@@ -13,8 +12,10 @@ url = 'https://github.com/Cadasta/cadasta-platform'
 author = 'Cadasta development team'
 author_email = 'dev@cadasta.org'
 license = 'GNU Affero'
+req_file = os.path.join(BASE_DIR, 'requirements/common.txt')
+requirements = open(req_file).read().splitlines()
 
-readme_file = os.path.join(os.path.dirname(__file__), 'README.rst')
+readme_file = os.path.join(BASE_DIR, 'README.rst')
 with open(readme_file, 'r') as f:
     long_description = f.readline().strip()
 
@@ -62,28 +63,7 @@ setup(
     author_email=author_email,
     packages=get_packages(package),
     package_data=get_package_data(package),
-    install_requires=[
-        'Django==1.9.4',
-        'djangorestframework==3.3.3',
-        'psycopg2==2.6.1',
-        'djoser==0.4.3',
-        'django-allauth==0.25.2',
-        'django-cors-headers==1.1.0',
-        'django-filter==0.12.0',
-        'django-crispy-forms==1.6.0',
-        'django-formtools==1.0',
-        'django-countries==3.4.1',
-        'django-leaflet==0.18.0',
-        'django-sass-processor==0.3.4',
-        'djangorestframework-gis==0.10.1',
-        'jsonschema==2.5.1',
-        'rfc3987==1.3.5',
-        'drfdocs==0.0.9',
-        'django-tutelary==0.1.11',
-        'django-audit-log==0.7.0',
-        'simplejson==3.8.1',
-        'django-widget-tweaks==1.4.1'
-    ],
+    install_requires=requirements,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -6,34 +6,8 @@ envlist =
 
 [testenv]
 passenv = DJANGO_SETTINGS_MODULE
-setenv =
-       PYTHONDONTWRITEBYTECODE=1
-deps =
-       django1.9: Django==1.9.4
-       djangorestframework==3.3.3
-       psycopg2==2.6.1
-       djoser==0.4.3
-       django-allauth==0.25.2
-       django-cors-headers==1.1.0
-       django-filter==0.12.0
-       django-crispy-forms==1.6.0
-       django-formtools==1.0
-       django-countries==3.4.1
-       django-leaflet==0.18.0
-       django-sass-processor==0.3.4
-       djangorestframework-gis==0.10.1
-       jsonschema==2.5.1
-       rfc3987==1.3.5
-       drfdocs==0.0.9
-       django-tutelary==0.1.11
-       django-audit-log==0.7.0
-       simplejson==3.8.1
-       django-widget-tweaks==1.4.1
-       pytest==2.9.1
-       pytest-django==2.9.1
-       pytest-cov==2.2.1
-       factory_boy==2.6.1
-       selenium==2.53.1
+setenv = PYTHONDONTWRITEBYTECODE=1
+deps = -r{toxinidir}/requirements/dev.txt
 
 [testenv:py35-django1.9-unit]
 commands = ./runtests.py
@@ -42,7 +16,7 @@ commands = ./runtests.py
 commands = ./runtests.py --functional
 
 [testenv:py35-flake8]
-commands = ./runtests.py --lintonly
+commands = ./runtests.py --lint
 deps =
        pytest==2.9.1
        flake8==2.5.4


### PR DESCRIPTION
- Add default policy to new users
 - Bump django-tutelary dependency for better queryset filtering
 - Avoid using "default" as a policy name in tests
 - Make creator of organization an org admin
 - DRY tox and setup dependency configuration
 - Fix up policy creation in functional tests