### PR TITLE
Remove redundant setup in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,13 @@ before_install:
   - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
 
 install:
-  - pip install -r requirements/common.txt
-  - pip install -r requirements/dev.txt
-  - nvm install 4.0.0
-  - nvm alias default 4.0.0
+  - pip install tox==2.3.1
 
 before_script:
   - export DJANGO_SETTINGS_MODULE=config.settings.travis
   - psql template1 postgres -c 'create extension hstore;'
   - psql -c 'create database cadasta;' -U postgres
   - psql -U postgres -d cadasta -c "create extension postgis;"
-  - python cadasta/manage.py migrate
   - mkdir cadasta/geography/data
   - export WBDATA=TM_WORLD_BORDERS-0.3.zip
   - export DATADIR=cadasta/geography/data


### PR DESCRIPTION
Since we're using `tox` for testing on Travis now, we don't need to install Python packages outside of the `tox` virtual environments.  We just need to install `tox` and set it running.  This shaves a few minutes off the test times.  The major remaining contributor to setup time is the SASS compiler: this downloads a source distribution of `libsass` and builds it for every run, which takes a lot of time.  I had a desultory try at doing something about this, by prebuilding a wheel and storing it locally in the `cadasta-platform` repo, but I wasn't able to get it working because of Python interpreter version funnies.  (To be fair, I spent about 10 minutes on it before getting bored with it, so it might still be an option.  I'll take a look next week.)