### PR TITLE
Squid setup for functional testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,17 @@ addons:
 before_install:
   - export DEBIAN_FRONTEND=noninteractive
   - sudo -E apt-get -yq update &>> ~/apt-get-update.log
-  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install postgresql-9.4-postgis-2.2
+  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install postgresql-9.4-postgis-2.2 squid3
   - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
 
 install:
   - pip install tox==2.3.1
 
 before_script:
+  - sudo cp provision/roles/testing/files/squid.conf /etc/squid3/squid.conf
+  - sudo service squid3 restart
+  - export http_proxy=http://localhost:3128/
+  - export https_proxy=https://localhost:3128/
   - export DJANGO_SETTINGS_MODULE=config.settings.travis
   - psql template1 postgres -c 'create extension hstore;'
   - psql -c 'create database cadasta;' -U postgres

--- a/provision/roles/testing/files/squid.conf
+++ b/provision/roles/testing/files/squid.conf
@@ -1,0 +1,33 @@
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow localhost manager
+http_access deny manager
+http_access allow localhost
+http_access deny all
+
+http_port 3128
+
+coredump_dir /var/spool/squid3
+
+refresh_pattern ^http://?.tile.openstreetmap.org	1440	20%	10080	ignore-reload
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
+refresh_pattern .		0	20%	4320
+
+acl local dstdomain localhost
+always_direct allow local

--- a/provision/roles/testing/handlers/main.yml
+++ b/provision/roles/testing/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart Squid
+  become: yes
+  become_user: root
+  service: name=squid3 state=restarted enabled=yes

--- a/provision/roles/testing/tasks/main.yml
+++ b/provision/roles/testing/tasks/main.yml
@@ -1,13 +1,33 @@
-- name: Install Firefox and Xvfb
+- name: Install Firefox, Xvfb and Squid
   become: yes
   become_user: root
   apt: pkg={{ item }} state=installed update_cache=yes
   with_items:
       - firefox
       - xvfb
+      - squid3
 
 - name: Install Python Selenium driver
   become: yes
   become_user: "{{ app_user }}"
   pip: virtualenv="{{ virtualenv_path }}"
        name=selenium
+
+- name: Set up Squid configuration
+  become: yes
+  become_user: root
+  copy: src=squid.conf dest=/etc/squid3/squid.conf owner=root mode=644
+  notify:
+    - Restart Squid
+
+- name: Set up HTTP proxy
+  become: yes
+  become_user: "{{ app_user }}"
+  lineinfile: dest=/home/vagrant/.bashrc
+              line="export http_proxy=http://localhost:3128/"
+
+- name: Set up HTTPS proxy
+  become: yes
+  become_user: "{{ app_user }}"
+  lineinfile: dest=/home/vagrant/.bashrc
+              line="export https_proxy=https://localhost:3128/"


### PR DESCRIPTION
For both VM and Travis, install Squid web cache with configuration to prevent re-requesting of OSM map tiles -- this was causing functional tests to fail intermittently, probably because of request throttling by the OSM tile servers.

(I'm not absolutely 100% sure that this will fix *all* the problems we've had with functional tests, but it seems to have made a substantial difference both locally and on Travis, so I think it deals with most of the problem.)