### PR TITLE
Contacts form for organizations and projects

### DIFF
--- a/cadasta/core/static/js/contacts.js
+++ b/cadasta/core/static/js/contacts.js
@@ -1,0 +1,64 @@
+$(document).ready(function () {
+    function getNumberOfForms(form, prefix) {
+        var totalForms = form.find('[name="' + prefix + '-TOTAL_FORMS"]');
+        return parseInt(totalForms.val())
+    }
+
+    function updateNumberOfForms(form, prefix, no) {
+        var totalForms = form.find('[name="' + prefix + '-TOTAL_FORMS"]');
+        totalForms.val(parseInt(totalForms.val()) + no)
+
+        form.find('[name="' + prefix + '-INITIAL_FORMS"]').val(0);
+    }
+
+    function removeContact(event) {
+        event.preventDefault();
+        var target = $(event.target);
+        if (target.tagName !== 'A') {
+            target = target.parent();
+        }
+        var prefix = target.attr('data-prefix');
+
+        var row = target.parents('tr');
+        row.hide()
+        row.find('[name="' + prefix + '-remove"]').val('on')
+    }
+
+    function replaceAttr(el, attr, prefix, newPrefix) {
+        if (el.hasAttribute(attr)) {
+            var val = el.getAttribute(attr);
+            val = val.replace(new RegExp(prefix + '-[0-9]*', 'g'), newPrefix);
+            el.setAttribute(attr, val);
+        }
+    }
+
+    function addContact(event) {
+        var target = $(event.target);
+        var form = target.parents('form');
+        var tbody = target.parents('table').children('tbody');
+
+        var prefix = target.attr('data-prefix');
+        var newRow = tbody.find("tr:first").clone(true);
+        var newPrefix = prefix + '-' + getNumberOfForms(form, prefix);
+        
+        var td = newRow.children('td')
+        for (var i = 0, ilen = td.length; i < ilen; i++) {
+            var elements = $(td[i]).children();
+
+            for (var j = 0, jlen = elements.length; j < jlen; j++) {
+                var el = elements[j];
+
+                ['name', 'id', 'data-prefix'].forEach(function(attr) {
+                    replaceAttr(el, attr, prefix, newPrefix);
+                });
+                el.value = '';
+            }
+        }
+        tbody.append(newRow.show());
+
+        updateNumberOfForms(form, prefix, 1)
+    }
+
+    $('.remove-contact').click(removeContact);
+    $('#add-contact').click(addContact);
+});

--- a/cadasta/organization/tests/test_fields.py
+++ b/cadasta/organization/tests/test_fields.py
@@ -1,8 +1,11 @@
+from pytest import raises
 from django.test import TestCase
+from django.forms import formset_factory, ValidationError
 
 from accounts.tests.factories import UserFactory
 
-from ..fields import ProjectRoleField, PublicPrivateField
+from ..fields import ProjectRoleField, PublicPrivateField, ContactsField
+from ..forms import ContactsForm
 
 
 class ProjectRoleFieldTest(TestCase):
@@ -19,3 +22,58 @@ class PublicPrivateFieldTest(TestCase):
         field = PublicPrivateField()
         assert field.clean(None) == 'public'
         assert field.clean('on') == 'private'
+
+
+class ContactsFieldTest(TestCase):
+    def test_init(self):
+        field = ContactsField(form=ContactsForm)
+        assert isinstance(field.formset, type(formset_factory(ContactsForm)))
+
+    def test_clean(self):
+        ContactFormset = formset_factory(form=ContactsForm)
+        value = ContactFormset({
+            'form-TOTAL_FORMS': '2',
+            'form-INITIAL_FORMS': '1',
+            'form-MAX_NUM_FORMS': '0',
+            'form-MAX_NUM_FORMS': '1000',
+            'form-0-name': 'Ringo',
+            'form-0-email': 'ringo@beatles.uk',
+            'form-0-tel': '555-555',
+            'form-1-name': 'john',
+            'form-1-email': 'john@beatles.uk',
+            'form-1-tel': '555-555',
+            'form-1-remove': True,
+            'form-2-name': '',
+            'form-2-email': '',
+            'form-2-tel': '',
+        })
+        field = ContactsField(form=ContactsForm)
+        expected = [{
+            'name': 'Ringo',
+            'email': 'ringo@beatles.uk',
+            'tel': '555-555'
+        }]
+        assert field.clean(value) == expected
+
+    def test_invalid_clean(self):
+        ContactFormset = formset_factory(form=ContactsForm)
+        value = ContactFormset({
+            'form-TOTAL_FORMS': '2',
+            'form-INITIAL_FORMS': '1',
+            'form-MAX_NUM_FORMS': '0',
+            'form-MAX_NUM_FORMS': '1000',
+            'form-0-name': 'Ringo',
+            'form-0-email': 'ringo@beatles',
+            'form-0-tel': '',
+            'form-1-name': '',
+            'form-1-email': '',
+            'form-1-tel': ''
+        })
+        field = ContactsField(form=ContactsForm)
+        with raises(ValidationError):
+            field.clean(value)
+
+    def test_widget_attr(self):
+        field = ContactsField(form=ContactsForm)
+        widget_attrs = field.widget_attrs('widget')
+        assert widget_attrs == {'formset': field.formset}

--- a/cadasta/organization/tests/test_validators.py
+++ b/cadasta/organization/tests/test_validators.py
@@ -39,12 +39,10 @@ class ValidateContactTest(TestCase):
         assert len(exc.value.error_list) == 1
 
         actual = json.loads(exc.value.error_list[0].messages[0])
-        expected = json.loads(
-            '{"name": "' + _("This field is required.") + '", '
-            '"email": "' + _("\'{value}\' is not a \'{type}\'").format(
-                value='noemail', type='email'
-            ) + '"}'
-        )
+        expected = {
+            'name': 'This field is required.',
+            'email': '\'noemail\' is not a \'email\''
+        }
         assert actual == expected
 
     def test_validate_multiple_contacts(self):
@@ -58,10 +56,9 @@ class ValidateContactTest(TestCase):
         with pytest.raises(ValidationError) as exc:
             validate_contact(value)
 
+        print(exc.value.error_list)
         assert len(exc.value.error_list) == 2
         assert exc.value.error_list[0].messages[0] == (
             '{"name": "' + _("This field is required.") + '"}')
         assert exc.value.error_list[1].messages[0] == (
-            '{"email": "' + _("\'{value}\' is not a \'{type}\'").format(
-                value='noemail', type='email'
-            ) + '"}')
+            '{"email": "\'noemail\' is not a \'email\'"}')

--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -82,7 +82,13 @@ class OrganizationAddTest(TestCase):
         setattr(self.request, 'POST', {
             'name': 'Org',
             'description': 'Some description',
-            'url': 'http://example.com'
+            'url': 'http://example.com',
+            'contacts-TOTAL_FORMS': '1',
+            'contacts-INITIAL_FORMS': '0',
+            'contacts-MAX_NUM_FORMS': '0',
+            'contact-0-name': '',
+            'contact-0-email': '',
+            'contact-0-tel': '',
         })
         response = self.view(self.request)
         if status is not None:
@@ -229,7 +235,13 @@ class OrganizationEditTest(TestCase):
         setattr(self.request, 'POST', {
             'name': 'Org',
             'description': 'Some description',
-            'urls': 'http://example.com'
+            'urls': 'http://example.com',
+            'contacts-TOTAL_FORMS': '1',
+            'contacts-INITIAL_FORMS': '0',
+            'contacts-MAX_NUM_FORMS': '0',
+            'contact-0-name': '',
+            'contact-0-email': '',
+            'contact-0-tel': '',
         })
 
         response = self.view(self.request, slug=self.org.slug)

--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -407,6 +407,11 @@ class ProjectAddTest(TestCase):
         'details-description': 'This is a test project',
         'details-access': 'on',
         'details-url': 'http://www.test.org',
+        'details-contacts-TOTAL_FORMS': 1,
+        'details-contacts-INITIAL_FORMS': 0,
+        'details-contacts-0-name': '',
+        'details-contacts-0-email': '',
+        'details-contacts-0-tel': ''
     }
     PERMISSIONS_POST_DATA = {
         'project_add_wizard-current_step': 'permissions',
@@ -603,7 +608,12 @@ class ProjectEditDetailsTest(TestCase):
         'description': 'New Description',
         'access': 'public',
         'urls': '',
-        'questionnaire': ''
+        'questionnaire': '',
+        'contacts-TOTAL_FORMS': 1,
+        'contacts-INITIAL_FORMS': 0,
+        'contacts-0-name': '',
+        'contacts-0-email': '',
+        'contacts-0-tel': ''
     }
 
     def setUp(self):

--- a/cadasta/organization/validators.py
+++ b/cadasta/organization/validators.py
@@ -11,13 +11,13 @@ SCHEMA_CONTACT = {
     "type": "object",
     "properties": {
         "name": {"type": "string"},
-        "email": {"type": "string", "format": "email"},
+        "email": {"type": ["string", "null"], "format": "email"},
         "url": {"type": "string", "format": "uri"},
         "street-address": {"type": "string"},
         "locality": {"type": "string"},
         "postal-code": {"type": "string"},
         "country-name": {"type": "string"},
-        "tel": {"type": "string"},
+        "tel": {"type": ["string", "null"]},
         "job-title": {"type": "string"}
     },
     "anyOf": [

--- a/cadasta/organization/widgets.py
+++ b/cadasta/organization/widgets.py
@@ -74,3 +74,63 @@ class PublicPrivateToggle(Widget):
             private=_("Private"),
             checked=('checked' if value != 'public' else '')
         )
+
+
+class ContactsWidget(Widget):
+    html = (
+        '<table class="table">'
+        '  <thead>'
+        '    <tr>'
+        '      <th>{name}</th>'
+        '      <th>{email}</th>'
+        '      <th>{phone}</th>'
+        '      <th></th>'
+        '    </tr>'
+        '  </thead>'
+        '  <tbody>'
+        '    {table}'
+        '  </tbody>'
+        '  <tfoot>'
+        '    <tr>'
+        '      <td colspan="4">'
+        '        <button data-prefix="{prefix}" type="button" '
+        '                class="btn btn-primary pull-right" '
+        '                id="add-contact">{add_contact}</button>'
+        '      </td>'
+        '    </tr>'
+        '  </tfoot>'
+        '</table>'
+    )
+
+    class Media:
+        js = (
+            '/static/js/contacts.js',
+        )
+
+    def value_from_datadict(self, data, files, name):
+        return self.attrs['formset'](data, files, prefix=name)
+
+    def render(self, name, value, attrs=None):
+        if not isinstance(value, self.attrs['formset']):
+            value = self.attrs['formset'](prefix=name, initial=value)
+
+        # This is a bit naughty: Here we're passing on the widget's HTML class
+        # attributes to each field in each form of the formset. This is
+        # necessary to render the fields using bootstrap styles.
+        if attrs and 'class' in attrs:
+            for form in value.forms:
+                for field in form:
+                    widget_attrs = {}
+                    if field.field.widget.attrs:
+                        widget_attrs = field.field.widget.attrs.copy()
+                    widget_attrs['class'] = attrs['class']
+                    field.field.widget.attrs = widget_attrs
+
+        return self.html.format(
+            name=_("Name"),
+            phone=_("Phone"),
+            email=_("Email"),
+            add_contact=_("Add contact"),
+            table=value,
+            prefix=name
+        )

--- a/cadasta/templates/organization/organization_form.html
+++ b/cadasta/templates/organization/organization_form.html
@@ -30,3 +30,5 @@
   <label for="{{ form.urls.id_for_label }}">{% trans "URL" %}</label>
   {% render_field form.urls class+="form-control input-lg" %}
 </div>
+
+{% render_field form.contacts class+="form-control input-lg" %}

--- a/cadasta/templates/organization/project_add_details.html
+++ b/cadasta/templates/organization/project_add_details.html
@@ -98,6 +98,8 @@
       </label>
       {% render_field wizard.form.questionaire class+="form-control input-lg" %}
     </div>
+
+    {% render_field wizard.form.contacts class+="form-control input-lg" %}
   </div>
 </div>
 

--- a/cadasta/templates/organization/project_edit_details.html
+++ b/cadasta/templates/organization/project_edit_details.html
@@ -48,6 +48,8 @@
           {{ form.questionnaire }}
         </div>
 
+        {% render_field form.contacts class+="form-control input-lg" %}
+
         <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
         <a href="{% url 'organization:project-dashboard' project.organization.slug project.slug %}" class="btn btn-default">{% trans "Cancel" %}</a>
       </div>

--- a/functional_tests/base.py
+++ b/functional_tests/base.py
@@ -10,7 +10,8 @@ import base64
 from urllib.parse import urlparse
 from selenium import webdriver
 from selenium.common.exceptions import (
-    NoSuchElementException, WebDriverException, TimeoutException
+    NoSuchElementException, WebDriverException, TimeoutException,
+    ElementNotVisibleException
 )
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -118,7 +119,12 @@ class FunctionalTest(StaticLiveServerTestCase):
 
     def click_through(self, button, wait, screenshot=None):
         """Click a button or link and wait for something to appear."""
-        button.click()
+        try:
+            button.click()
+        except ElementNotVisibleException:
+            self.browser.execute_script(
+                "return arguments[0].scrollIntoView();", button)
+            button.click()
         if screenshot is not None:
             self.screenshot(screenshot)
         try:
@@ -132,7 +138,13 @@ class FunctionalTest(StaticLiveServerTestCase):
 
     def click_through_close(self, button, wait, screenshot=None):
         """Click a button or link and wait for something to disappear."""
-        button.click()
+        try:
+            button.click()
+        except ElementNotVisibleException:
+            self.browser.execute_script(
+                "return arguments[0].scrollIntoView();", button)
+            button.click()
+
         if screenshot is not None:
             self.screenshot(screenshot)
         try:

--- a/functional_tests/pages/OrganizationList.py
+++ b/functional_tests/pages/OrganizationList.py
@@ -1,5 +1,6 @@
 from .base import Page
 from selenium.webdriver.common.by import By
+from selenium.common.exceptions import ElementNotVisibleException
 
 
 class OrganizationListPage(Page):
@@ -111,7 +112,14 @@ class OrganizationListPage(Page):
 
     def try_submit(self, err=None, ok=None):
         fields = self.get_fields()
-        fields['add'].click()
+
+        try:
+            fields['add'].click()
+        except ElementNotVisibleException:
+            self.browser.execute_script(
+                "return arguments[0].scrollIntoView();", fields['add'])
+            fields['add'].click()
+
         fields = self.get_fields()
         if err is not None:
             for f in err:


### PR DESCRIPTION
- Adds `organzation.fields.ContactsFields`, which uses Django formsets to display and validate contacts
- `organzation.forms.ContactsForm` is used by the formset for individual contacts
- `organization.widgets.ContactsWidget` provides corresponding UI components