### PR TITLE
Fixes #196: Private projects only visible to organization members 

### DIFF
--- a/cadasta/core/fixtures.py
+++ b/cadasta/core/fixtures.py
@@ -128,7 +128,7 @@ class FixturesData:
             This is a test project.  This is a test project.  This is a test
             project.  This is a test project.  This is a test project.  This
             is a test project.  This is a test project.""",
-            organization=orgs[0],
+            organization=orgs[1],
             country='KE',
             extent=('SRID=4326;'
                     'POLYGON ((-5.1031494140625000 8.1299292850467957, '
@@ -144,7 +144,7 @@ class FixturesData:
             This is a test project.  This is a test project.  This is a test
             project.  This is a test project.  This is a test project.  This
             is a test project.  This is a test project.""",
-            organization=orgs[0],
+            organization=orgs[1],
             country='PH',
             extent=('SRID=4326;'
                     'POLYGON ((-63.6328125000000000 44.7233201889582475, '
@@ -161,7 +161,7 @@ class FixturesData:
             project. This is another test project.  This is a test project.
             This is another test project.  This is another test project.
             This is another test project.""",
-            organization=orgs[1],
+            organization=orgs[0],
             country='ID',
             extent=('SRID=4326;'
                     'POLYGON ((-57.0520019531250000 -1.0793428942462329, '
@@ -179,7 +179,7 @@ class FixturesData:
             project. This is another test project.  This is a test project.
             This is another test project.  This is another test project.
             This is another test project.""",
-            organization=orgs[1],
+            organization=orgs[0],
             country='MM'
         ))
         projs.append(ProjectFactory.create(
@@ -190,7 +190,7 @@ class FixturesData:
             project. This is another test project.  This is a test project.
             This is another test project.  This is another test project.
             This is another test project.""",
-            organization=orgs[1],
+            organization=orgs[0],
             country='MM',
             extent=GEOSGeometry(
                 '{"type": "Polygon",'
@@ -212,7 +212,7 @@ class FixturesData:
             project. This is another test project.  This is a test project.
             This is another test project.  This is another test project.
             This is another test project.""",
-            organization=orgs[1],
+            organization=orgs[0],
             country='MM',
             extent=GEOSGeometry(
                 '{"type": "Polygon",'
@@ -233,7 +233,7 @@ class FixturesData:
             project. This is another test project.  This is a test project.
             This is another test project.  This is another test project.
             This is another test project.""",
-            organization=orgs[0],
+            organization=orgs[1],
             extent=GEOSGeometry(
                 '{"type": "Polygon",'
                 '"coordinates": [['
@@ -251,6 +251,48 @@ class FixturesData:
                 '[-245.3981566429138, -3.331934566552203],'
                 '[-245.39695501327512, -3.328635665488632]]]}')
         ))
+
+        projs.append(ProjectFactory.create(
+            name='Private Cadasta Test Project',
+            slug='private-cadasta',
+            description=""""This is a private test project.  This is pivate test
+            project. This is pivate test project.  This is pivate test
+            project. This is pivate test project.  This is a test project.
+            This is another test project.  This is another test project.
+            This is another test project.""",
+            organization=orgs[0],
+            extent=GEOSGeometry(
+                '{"type": "Polygon",'
+                '"coordinates": [['
+                '[-21.81009292602539, 64.07722793795327],'
+                '[-21.81009292602539, 64.09425757251603],'
+                '[-21.76013946533203, 64.09425757251603],'
+                '[-21.76013946533203, 64.07722793795327],'
+                '[-21.81009292602539, 64.07722793795327]]'
+                ']}'),
+            access='private'
+        ))
+
+        projs.append(ProjectFactory.create(
+            name='Private H4H Test Project',
+            slug='private-h4h',
+            description=""""This is a private test project.  This is pivate test
+            project. This is pivate test project.  This is pivate test
+            project. This is pivate test project.  This is a test project.
+            This is another test project.  This is another test project.
+            This is another test project.""",
+            organization=orgs[1],
+            extent=GEOSGeometry(
+                '{"type": "Polygon",'
+                '"coordinates": [['
+                '[-166.18331909179688, 59.891003681240576],'
+                '[-166.18331909179688, 60.06346983332297],'
+                '[-165.596923828125, 60.06346983332297],'
+                '[-165.596923828125, 59.891003681240576],'
+                '[-166.18331909179688, 59.891003681240576]]]}'),
+            access='private'
+        ))
+
         print('\nSuccessfully added organizations {}'.
               format(Project.objects.all()))
 

--- a/cadasta/core/tests/test_fixtures.py
+++ b/cadasta/core/tests/test_fixtures.py
@@ -21,7 +21,7 @@ class FixturesTest(TestCase):
         assert User.objects.count() == 20
         assert Policy.objects.count() == 7
         assert Organization.objects.count() == 2
-        assert Project.objects.count() == 7
+        assert Project.objects.count() == 9
         assert SpatialUnit.objects.count() == 7
         assert SpatialUnitRelationship.objects.count() == 2
 

--- a/cadasta/core/tests/test_views_default.py
+++ b/cadasta/core/tests/test_views_default.py
@@ -1,8 +1,15 @@
+import json
+
 from django.test import TestCase
 from django.http import HttpRequest
 from django.contrib.auth.models import AnonymousUser
+from django.template import RequestContext
+from django.template.loader import render_to_string
 
 from accounts.tests.factories import UserFactory
+from organization.tests.factories import OrganizationFactory, ProjectFactory
+from organization.models import OrganizationRole, Project
+from organization.serializers import ProjectGeometrySerializer
 
 from ..views.default import IndexPage, Dashboard
 
@@ -31,7 +38,39 @@ class DashboardTest(TestCase):
         self.view = Dashboard.as_view()
         self.request = HttpRequest()
         setattr(self.request, 'method', 'GET')
+        self.org = OrganizationFactory.create()
+        extent = ('SRID=4326;'
+                  'POLYGON ((-5.1031494140625000 8.1299292850467957, '
+                  '-5.0482177734375000 7.6837733211111425, '
+                  '-4.6746826171875000 7.8252894725496338, '
+                  '-4.8641967773437491 8.2278005261522775, '
+                  '-5.1031494140625000 8.1299292850467957))')
+        ProjectFactory.create(organization=self.org, extent=extent)
+        ProjectFactory.create(organization=self.org, extent=extent)
+        ProjectFactory.create(
+            name='Private Project',
+            access='private', organization=self.org, extent=extent)
+
         setattr(self.request, 'user', AnonymousUser())
+
+    def _test_projects_rendered(self, response, member=False):
+        content = response.render().content.decode('utf-8')
+
+        context = RequestContext(self.request)
+        projects = []
+        if member:
+            projects.extend(Project.objects.filter(
+                organization__slug=self.org.slug, access='private'))
+        projects.extend(Project.objects.filter(access='public'))
+        context['geojson'] = json.dumps(
+            ProjectGeometrySerializer(projects, many=True).data
+        )
+        expected = render_to_string(
+            'core/dashboard.html',
+            context
+        )
+
+        assert expected == content
 
     def test_redirects_when_user_is_not_signed_in(self):
         response = self.view(self.request)
@@ -43,3 +82,18 @@ class DashboardTest(TestCase):
         setattr(self.request, 'user', user)
         response = self.view(self.request)
         assert response.status_code == 200
+
+    def test_private_projects_rendered_when_org_member_is_signed_in(self):
+        user = UserFactory.create()
+        OrganizationRole.objects.create(organization=self.org, user=user)
+        setattr(self.request, 'user', user)
+        response = self.view(self.request)
+        assert response.status_code == 200
+        self._test_projects_rendered(response, member=True)
+
+    def test_private_projects_not_rendered_when_not_an_org_member(self):
+        user = UserFactory.create()
+        setattr(self.request, 'user', user)
+        response = self.view(self.request)
+        assert response.status_code == 200
+        self._test_projects_rendered(response)

--- a/cadasta/organization/models.py
+++ b/cadasta/organization/models.py
@@ -97,6 +97,12 @@ class Organization(SlugModel, RandomIDModel):
     def __repr__(self):
         return str(self)
 
+    def public_projects(self):
+        return self.projects.filter(access='public')
+
+    def all_projects(self):
+        return self.projects.all()
+
 
 class OrganizationRole(RandomIDModel):
     organization = models.ForeignKey(Organization)

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -54,6 +54,25 @@ class OrganizationDashboard(PermissionRequiredMixin, generic.DetailView):
     template_name = 'organization/organization_dashboard.html'
     permission_required = 'org.view'
 
+    def get_context_data(self, member=False, **kwargs):
+        context = super(OrganizationDashboard, self).get_context_data(**kwargs)
+        if member:
+            projects = self.object.all_projects()
+        else:
+            projects = self.object.public_projects()
+        context['projects'] = projects
+        return context
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        context = self.get_context_data()
+        if hasattr(self.request.user, 'organizations'):
+            orgs = self.request.user.organizations.all()
+            for org in orgs:
+                if org.slug == self.kwargs['slug']:
+                    context = self.get_context_data(member=True)
+        return super(generic.DetailView, self).render_to_response(context)
+
 
 class OrganizationEdit(LoginPermissionRequiredMixin,
                        generic.UpdateView):

--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -85,7 +85,7 @@
       <div class="col-md-8 col-text">
         <h2 class="page-title">{% trans "Overview" %}</h2>
         <div class="project-list">
-          {% if object.projects.all  %}
+          {% if projects  %}
           <table class="table table-hover datatable" data-paging-type="simple">
             <thead>
               <tr>
@@ -95,7 +95,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for prj in object.projects.all %}
+              {% for prj in projects %}
               <tr onclick="window.document.location='{% url 'organization:project-dashboard' organization=object.slug project=prj.slug %}';">
                 <td>{{ prj.name }}</td>
                 <td>{{ prj.country }}</td>

--- a/cadasta/templates/organization/organization_list.html
+++ b/cadasta/templates/organization/organization_list.html
@@ -42,7 +42,11 @@
             {% endif %}
           </div>
         </td>
-        <td>{{ org.projects.count }}</td>
+        {% if user.is_authenticated and org in user.organizations.all %}
+          <td>{{ org.all_projects.count }}</td>
+        {% else %}
+          <td>{{ org.public_projects.count }}</td>
+        {% endif %}
       </tr>
       {% endfor %}
     </table>


### PR DESCRIPTION
- Dashboard only displays projects the user has view access to.
- Organization dashboard only displays private projects if user is a member of that organization.
- Organization list view only shows number of public projects, unless the user is a member of a specific organization, in which case it shows the real amount.
- Added fixtures for private projects.

