### PR TITLE
Added wrapper to organization templates

### DIFF
--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -173,7 +173,7 @@ class OrganizationDashboardTest(TestCase):
         content = response.render().content.decode('utf-8')
 
         context = RequestContext(self.request)
-        context['object'] = org or self.org
+        context['organization'] = org or self.org
         if member:
             context['projects'] = Project.objects.filter(
                 organization__slug=self.org.slug)
@@ -242,7 +242,7 @@ class OrganizationEditTest(TestCase):
 
         context = RequestContext(self.request)
         context['form'] = forms.OrganizationForm(instance=self.org)
-        context['object'] = self.org
+        context['organization'] = self.org
 
         expected = render_to_string(
             'organization/organization_edit.html',
@@ -477,7 +477,7 @@ class OrganizationMembersTest(TestCase):
         content = response.content.decode('utf-8')
 
         context = RequestContext(self.request)
-        context['object'] = self.org
+        context['organization'] = self.org
 
         expected = render_to_string(
             'organization/organization_members.html',
@@ -485,6 +485,7 @@ class OrganizationMembersTest(TestCase):
         )
 
         assert response.status_code == 200
+        print(expected)
         assert expected == content
 
         response = self.view(self.request, slug=self.org.slug)
@@ -538,7 +539,7 @@ class OrganizationMembersAddTest(TestCase):
         content = response.content.decode('utf-8')
 
         context = RequestContext(self.request)
-        context['object'] = self.org
+        context['organization'] = self.org
         context['form'] = forms.AddOrganizationMemberForm()
 
         expected = render_to_string(

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -131,7 +131,7 @@ class OrganizationMembersAdd(mixins.OrganizationMixin,
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context['object'] = self.get_organization()
+        context['organization'] = self.get_organization()
         return context
 
     def get_form_kwargs(self, *args, **kwargs):

--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -1,83 +1,8 @@
-{% extends "core/base.html" %}
+{% extends "organization/organization_wrapper.html" %}
 
 {% load i18n %}
-{% load widget_tweaks %}
-{% load staticfiles %}
 
-{% block title %} | {{ object.name }}{% endblock %}
-
-{% block content %}
-
-<div class="row">
-  <div class="col-md-12">
-    <div class="inner-header">
-      <a class="index-link" href="{% url 'organization:list' %}">
-        <span class="glyphicon glyphicon-step-backward" aria-hidden="true"></span>
-      </a>
-      <div class="org-logo">
-        {% if org.logo %}
-        <img src="{{ object.logo }}" alt="{{ object.name }}" class="org-logo" />
-        {% else %}
-        <h2>{{ object.name }}</h2>
-        {% endif %}
-      </div>
-      <div class="top-btn pull-right">
-        <!-- More options menu -->
-        <div class="dropdown pull-right btn-more">
-          <a data-target="#" data-toggle="dropdown" class="dropdown-toggle" role="button">
-            <span class="icon kabob-icon"></span>
-          </a>
-          <ul class="dropdown-menu" aria-labelledby="dLabel">
-            <li><a class="edit" href="{% url 'organization:edit' object.slug %}">{% trans "Edit organization" %}</a></li>
-            <li role="separator" class="divider"></li>
-            <li>
-              {% if object.archived %}
-              <a class="archive" href="#unarchive_confirm" data-toggle="modal">{% trans "Unarchive organization" %}</a>
-              {% else %}
-              <a class="archive" href="#archive_confirm" data-toggle="modal">{% trans "Archive organization" %}</a>
-              {% endif %}
-            </li>
-          </ul>
-        </div>
-        <!-- Split add button -->
-        <div class="dropdown pull-right btn-add">
-          <button type="button" class="btn btn-primary btn-rt dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class="glyphicon glyphicon-plus" aria-hidden=true></span>
-            {% trans "Add" %}
-            <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu">
-            <li><a href="{% url 'organization:project-add' object.slug %}">{% trans "Add new project" %}</a></li>
-            <li><a href="#">{% trans "Add new member" %}</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="row">
-  <!-- Sidebar -->
-  <div class="col-md-1 sidebar">
-    <ul class="nav nav-sidebar">
-      <li class="active">
-        {% trans "Overview" %}
-      </li>
-      <li>
-        {% trans "Projects" %}
-      </li>
-      <li>
-        {% trans "Members" %}
-      </li>
-      <li>
-        {% trans "Reports" %}
-      </li>
-      <li>
-        {% trans "Activity" %}
-      </li>
-    </ul>
-  </div>
-  <!-- /.sidebar -->
+{% block organization_main %}
   <!-- Main content -->
   <div class="col-md-11 col-md-offset-1 main">
     <div class="row">
@@ -96,7 +21,7 @@
             </thead>
             <tbody>
               {% for prj in projects %}
-              <tr onclick="window.document.location='{% url 'organization:project-dashboard' organization=object.slug project=prj.slug %}';">
+              <tr onclick="window.document.location='{% url 'organization:project-dashboard' organization=organization.slug project=prj.slug %}';">
                 <td>{{ prj.name }}</td>
                 <td>{{ prj.country }}</td>
                 <td>{{ prj.last_updated }}</td>
@@ -112,7 +37,7 @@
             {% trans "What would you like to do next?" %}
           </p>
           <p>
-            <a href="{% url 'organization:project-add' object.slug %}" class="btn btn-primary" role="button">
+            <a href="{% url 'organization:project-add' organization.slug %}" class="btn btn-primary" role="button">
               {% trans "Add new project" %}
             </a>
             <a href="#" class="btn btn-primary" role="button">
@@ -127,17 +52,17 @@
       <!-- Right column detail  -->
       <div class="col-md-4 col-detail org-detail">
         <section class="desc">
-          <p>{{ object.description }}<p>
+          <p>{{ organization.description }}<p>
         </section>
         <section class="members">
           <h4>{% trans "Members" %}</h4>
-          {% for user in object.users.all %}
+          {% for user in organization.users.all %}
           <p>
             <b>{{ user.get_full_name }}</b><br />{% trans "Username" %}: {{ user.username }}
           </p>
           {% endfor %}
           <div class="btn-view">
-            <a href="{% url 'organization:members' object.slug %}" class="btn btn-primary" role="button">
+            <a href="{% url 'organization:members' organization.slug %}" class="btn btn-primary" role="button">
               {% trans "View all" %}
             </a>
           </div>
@@ -165,7 +90,7 @@
         <button type="button" class="btn btn-link cancel" data-dismiss="modal">
           {% trans "Cancel" %}
         </button>
-        <a href="{% url 'organization:archive' object.slug %}"  class="btn btn-primary archive-final" role="button">
+        <a href="{% url 'organization:archive' organization.slug %}"  class="btn btn-primary archive-final" role="button">
           {% trans "Archive" %}
         </a>
       </div>
@@ -191,7 +116,7 @@
         <button type="button" class="btn btn-link cancel" data-dismiss="modal">
           {% trans "Cancel" %}
         </button>
-        <a href="{% url 'organization:unarchive' object.slug %}"  class="btn btn-primary unarchive-final" role="button">
+        <a href="{% url 'organization:unarchive' organization.slug %}"  class="btn btn-primary unarchive-final" role="button">
           {% trans "Unarchive" %}
         </a>
       </div>

--- a/cadasta/templates/organization/organization_members.html
+++ b/cadasta/templates/organization/organization_members.html
@@ -1,88 +1,16 @@
-{% extends "core/base.html" %}
+{% extends "organization/organization_wrapper.html" %}
 
 {% load i18n %}
-{% load widget_tweaks %}
-{% load staticfiles %}
+{% block page_title %}Members | {% endblock %}
 
-{% block title %} | Members | {{ object.name }}{% endblock %}
-
-{% block content %}
-
-<div class="row">
-  <div class="col-md-12">
-    <div class="inner-header">
-      <a class="index-link" href="{% url 'organization:list' %}">
-        <span class="glyphicon glyphicon-step-backward" aria-hidden="true"></span>
-      </a>
-      <div class="org-logo">
-        <span class="category">{% trans "Organization" %}</span>
-        <img src="{{ object.logo }}" alt="{{ object.name }}" class="org-logo" />
-      </div>
-      <div class="top-btn pull-right">
-        <!-- More options menu -->
-        <div class="dropdown pull-right btn-more">
-          <a data-target="#" data-toggle="dropdown" class="dropdown-toggle" role="button">
-            <span class="icon kabob-icon"></span>
-          </a>
-          <ul class="dropdown-menu" aria-labelledby="dLabel">
-            <li><a class="edit" href="{% url 'organization:edit' object.slug %}">{% trans "Edit organization" %}</a></li>
-            <li role="separator" class="divider"></li>
-            <li>
-              {% if object.archived %}
-              <a class="archive" href="#unarchive_confirm" data-toggle="modal">{% trans "Unarchive organization" %}</a>
-              {% else %}
-              <a class="archive" href="#archive_confirm" data-toggle="modal">{% trans "Archive organization" %}</a>
-              {% endif %}
-            </li>
-          </ul>
-        </div>
-        <!-- Split add button -->
-        <div class="btn-group pull-right btn-add">
-          <button type="button" class="btn btn-primary">
-            <span class="glyphicon glyphicon-plus" aria-hidden=true></span> {% trans "Add project" %}
-          </button>
-          <button type="button" class="btn btn-primary btn-rt dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class="caret"></span>
-            <span class="sr-only">Toggle Add</span>
-          </button>
-          <ul class="dropdown-menu">
-            <li><a href="#">Add new member</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="row">
-  <!-- Sidebar -->
-  <div class="col-md-1 sidebar">
-    <ul class="nav nav-sidebar">
-      <li>
-        {% trans "Overview" %}
-      </li>
-      <li>
-        {% trans "Projects" %}
-      </li>
-      <li class="active">
-        {% trans "Members" %}
-      </li>
-      <li>
-        {% trans "Reports" %}
-      </li>
-      <li>
-        {% trans "Activity" %}
-      </li>
-    </ul>
-  </div>
-  <!-- /.sidebar -->
+{% block organization_main %}
   <!-- Main content -->
   <div class="col-md-11 col-md-offset-1 main col-text">
     <div class="row">
       <div class="col-md-12 page-title">
         <h2>{% trans "Members" %}</h2>
         <div class="top-btn pull-right">
-          <a class="btn btn-primary" href="{% url 'organization:members_add' object.slug %}">
+          <a class="btn btn-primary" href="{% url 'organization:members_add' organization.slug %}">
             <span class="glyphicon glyphicon-plus" aria-hidden=true></span> {% trans "Add" %}
           </a>
         </div>
@@ -98,8 +26,8 @@
         </tr>
       </thead>
       <tbody>
-      {% for user in object.users.all %}
-        <tr onclick="window.document.location='{% url 'organization:members_edit' slug=object.slug username=user.username %}';">
+      {% for user in organization.users.all %}
+        <tr onclick="window.document.location='{% url 'organization:members_edit' slug=organization.slug username=user.username %}';">
           <td>{{ user.get_full_name }}</td>
           <td>{{ user.username }}</td>
           <td>{{ user.email }}</td>

--- a/cadasta/templates/organization/organization_members_add.html
+++ b/cadasta/templates/organization/organization_members_add.html
@@ -2,7 +2,7 @@
 
 {% load widget_tweaks %}
 
-{% block title %} | Add member | {{ object.name }}{% endblock %}
+{% block page_title %}Add member | {% endblock %}
 
 {% block modals %}
 
@@ -11,9 +11,9 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <form method="POST"
-              action="{% url 'organization:members_add' object.slug %}">
+              action="{% url 'organization:members_add' organization.slug %}">
           <div class="modal-header">
-            <a class="close" href="{% url 'organization:members' object.slug %}"><span aria-hidden="true">&times;</span></a>
+            <a class="close" href="{% url 'organization:members' organization.slug %}"><span aria-hidden="true">&times;</span></a>
             <h3 class="modal-title">Add member</h3>
           </div>
           <div class="modal-body">
@@ -29,7 +29,7 @@
             </div>
           </div>
           <div class="modal-footer">
-            <a class="btn btn-link" href="{% url 'organization:members' object.slug %}">Cancel</a>
+            <a class="btn btn-link" href="{% url 'organization:members' organization.slug %}">Cancel</a>
             <button type="submit" class="btn btn-primary text-uppercase">Continue</button>
           </div>
         </form>

--- a/cadasta/templates/organization/organization_members_edit.html
+++ b/cadasta/templates/organization/organization_members_edit.html
@@ -1,81 +1,11 @@
-{% extends "core/base.html" %}
+{% extends "organization/organization_wrapper.html" %}
 
 {% load i18n %}
 {% load widget_tweaks %}
-{% load staticfiles %}
 
-{% block title %} | Members | {{ organization.name }}{% endblock %}
+{% block page_title %}Members |{% endblock %}
 
-{% block content %}
-
-<div class="row">
-  <div class="col-md-12">
-    <div class="inner-header">
-      <a class="index-link" href="{% url 'organization:list' %}">
-        <span class="glyphicon glyphicon-step-backward" aria-hidden="true"></span>
-      </a>
-      <div class="org-logo">
-        <p class="category">Organization</p>
-        <img src="{{ organization.logo }}" alt="{{ organization.name }}" class="org-logo" />
-      </div>
-      <div class="top-btn pull-right">
-        <!-- More options menu -->
-        <div class="dropdown pull-right btn-more">
-          <a data-target="#" data-toggle="dropdown" class="dropdown-toggle" role="button">
-            <span class="icon kabob-icon"></span>
-          </a>
-          <ul class="dropdown-menu" aria-labelledby="dLabel">
-            <li><a class="edit" href="#"><!--broken link-->{% trans "Edit organization" %}</a></li>
-            <li role="separator" class="divider"></li>
-            <li>
-              {% if object.archived %}
-              <a class="archive" href="#unarchive_confirm" data-toggle="modal">{% trans "Unarchive organization" %}</a>
-              {% else %}
-              <a class="archive" href="#archive_confirm" data-toggle="modal">{% trans "Archive organization" %}</a>
-              {% endif %}
-            </li>
-          </ul>
-        </div>
-        <!-- Split add button -->
-        <div class="btn-group pull-right btn-add">
-          <button type="button" class="btn btn-primary">
-            <span class="glyphicon glyphicon-plus" aria-hidden=true></span> {% trans "Add project" %}
-          </button>
-          <button type="button" class="btn btn-primary btn-rt dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class="caret"></span>
-            <span class="sr-only">Toggle Add</span>
-          </button>
-          <ul class="dropdown-menu">
-            <li><a href="#">Add new member</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="row">
-  <!-- Sidebar -->
-  <div class="col-md-1 sidebar">
-    <ul class="nav nav-sidebar">
-      <li>
-        {% trans "Overview" %}
-      </li>
-      <li>
-        {% trans "Projects" %}
-      </li>
-      <li class="active">
-        {% trans "Members" %}
-      </li>
-      <li>
-        {% trans "Reports" %}
-      </li>
-      <li>
-        {% trans "Activity" %}
-      </li>
-    </ul>
-  </div>
-  <!-- /.sidebar -->
+{% block organization_main %}
   <!-- Main content -->
   <div class="col-md-11 col-md-offset-1 main col-text">
     <form method="POST" action="" class="org-member-edit">

--- a/cadasta/templates/organization/organization_wrapper.html
+++ b/cadasta/templates/organization/organization_wrapper.html
@@ -1,0 +1,82 @@
+{% extends "core/base.html" %}
+
+{% load i18n %}
+{% load widget_tweaks %}
+{% load staticfiles %}
+
+{% block title %} | {% block page_title %}{% endblock %}{{ organization.name }} {% endblock %}
+
+{% block content %}
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="inner-header">
+      <a class="index-link" href="{% url 'organization:list' %}">
+        <span class="glyphicon glyphicon-step-backward" aria-hidden="true"></span>
+      </a>
+      <div class="org-logo">
+        {% if organization.logo %}
+        <img src="{{ organization.logo }}" alt="{{ organization.name }}" class="org-logo" />
+        {% else %}
+        <h2>{{ organization.name }}</h2>
+        {% endif %}
+      </div>
+      <div class="top-btn pull-right">
+        <!-- More options menu -->
+        <div class="dropdown pull-right btn-more">
+          <a data-target="#" data-toggle="dropdown" class="dropdown-toggle" role="button">
+            <span class="icon kabob-icon"></span>
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="dLabel">
+            <li><a class="edit" href="{% url 'organization:edit' organization.slug %}">{% trans "Edit organization" %}</a></li>
+            <li role="separator" class="divider"></li>
+            <li>
+              {% if organization.archived %}
+              <a class="archive" href="#unarchive_confirm" data-toggle="modal">{% trans "Unarchive organization" %}</a>
+              {% else %}
+              <a class="archive" href="#archive_confirm" data-toggle="modal">{% trans "Archive organization" %}</a>
+              {% endif %}
+            </li>
+          </ul>
+        </div>
+        <!-- Split add button -->
+        <div class="dropdown pull-right btn-add">
+          <button type="button" class="btn btn-primary btn-rt dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="glyphicon glyphicon-plus" aria-hidden=true></span>
+            {% trans "Add" %}
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li><a href="{% url 'organization:project-add' organization.slug %}">{% trans "Add new project" %}</a></li>
+            <li><a href="#">{% trans "Add new member" %}</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <!-- Sidebar -->
+  <div class="col-md-1 sidebar">
+    <ul class="nav nav-sidebar">
+      <li class="active">
+        {% trans "Overview" %}
+      </li>
+      <li>
+        {% trans "Projects" %}
+      </li>
+      <li>
+        {% trans "Members" %}
+      </li>
+      <li>
+        {% trans "Reports" %}
+      </li>
+      <li>
+        {% trans "Activity" %}
+      </li>
+    </ul>
+  </div>
+  <!-- /.sidebar -->
+  {% block organization_main %}{% endblock %}
+  {% endblock %}


### PR DESCRIPTION
Replaced variable context['object'] with context['organization'] where appropriate for consistence across templates