### PR TITLE
Fixes #240 + #247 -- Adapt templates to new project wrapper

### DIFF
--- a/cadasta/templates/organization/project_edit_details.html
+++ b/cadasta/templates/organization/project_edit_details.html
@@ -8,54 +8,67 @@
   {{ form.media }}
 {% endblock %}
 
-{% block project_main %}
+{% block left-nav %}overview{% endblock %}
 
-<!-- Main content -->
-  <form class="col-md-11 col-md-offset-1 main" method="POST" action="{% url 'organization:project-edit-details' project.organization.slug project.slug %}">
-    {% csrf_token %}
-    <div class="row">
-      <div class="col-md-9">
-        {{ form.non_field_errors }}
+{% block content %}
 
-        <div class="row">
-          <div class="col-sm-8">
-            <div class="form-group">
-              {{ form.name.errors }}
-              <label for="{{ form.name.id_for_label }}">{% trans "Name" %}</label>
-              {% render_field form.name class+="form-control input-lg" %}
-            </div>    
-          </div>
-          <div class="col-sm-4">
-            {{ form.access }}
-          </div>
+<div class="col-md-11 col-md-offset-1 content-single">
+  <div class="row">
+    <!-- Main text  -->
+    <div class="col-md-12 main-text">
+      <div class="page-title">
+        <h2>{% trans "Edit project details" %}</h2>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <form method="POST" action="{% url 'organization:project-edit-details' project.organization.slug project.slug %}">
+            {% csrf_token %}
+            <div class="row">
+              <div class="col-md-9">
+                {{ form.non_field_errors }}
+
+                <div class="row">
+                  <div class="col-sm-8">
+                    <div class="form-group">
+                      {{ form.name.errors }}
+                      <label for="{{ form.name.id_for_label }}">{% trans "Name" %}</label>
+                      {% render_field form.name class+="form-control input-lg" %}
+                    </div>    
+                  </div>
+                  <div class="col-sm-4">
+                    {{ form.access }}
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  {{ form.description.errors }}
+                  <label for="{{ form.description.id_for_label }}">{% trans "Description" %}</label>
+                  {% render_field form.description class+="form-control input-lg" %}
+                </div>
+
+                <div class="form-group">
+                  {{ form.urls.errors }}
+                  <label for="{{ form.urls.id_for_label }}">{% trans "Url" %}</label>
+                  {% render_field form.urls class+="form-control input-lg" %}
+                </div>
+
+                <div class="form-group">
+                  {{ form.questionnaire.errors }}
+                  <label for="{{ form.questionnaire.id_for_label }}">{% trans "Upload questionnaire" %}</label>
+                  {{ form.questionnaire }}
+                </div>
+
+                {% render_field form.contacts class+="form-control input-lg" %}
+
+                <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
+                <a href="{% url 'organization:project-dashboard' project.organization.slug project.slug %}" class="btn btn-default">{% trans "Cancel" %}</a>
+              </div>
+            </div>
+          </form>    
         </div>
-
-        <div class="form-group">
-          {{ form.description.errors }}
-          <label for="{{ form.description.id_for_label }}">{% trans "Description" %}</label>
-          {% render_field form.description class+="form-control input-lg" %}
-        </div>
-
-        <div class="form-group">
-          {{ form.urls.errors }}
-          <label for="{{ form.urls.id_for_label }}">{% trans "Url" %}</label>
-          {% render_field form.urls class+="form-control input-lg" %}
-        </div>
-
-        <div class="form-group">
-          {{ form.questionnaire.errors }}
-          <label for="{{ form.questionnaire.id_for_label }}">{% trans "Upload questionnaire" %}</label>
-          {{ form.questionnaire }}
-        </div>
-
-        {% render_field form.contacts class+="form-control input-lg" %}
-
-        <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
-        <a href="{% url 'organization:project-dashboard' project.organization.slug project.slug %}" class="btn btn-default">{% trans "Cancel" %}</a>
       </div>
     </div>
-  </form>
-  <!-- /.main -->
+  </div>
 </div>
 
 {% endblock %}

--- a/cadasta/templates/organization/project_edit_geometry.html
+++ b/cadasta/templates/organization/project_edit_geometry.html
@@ -4,6 +4,8 @@
 {% load i18n %}
 {% load leaflet_tags %}
 
+{% block left-nav %}overview{% endblock %}
+
 {% block extra_head %}
 {% leaflet_css plugins="draw,forms" %}
 <style type="text/css">
@@ -27,29 +29,40 @@
 </script>
 {% endblock %}
 
-{% block project_main %}
+{% block content %}
 
-<!-- Main content -->
-  <form class="col-md-11 col-md-offset-1 main main-map" method="POST" action="{% url 'organization:project-edit-geometry' project.organization.slug project.slug %}">
-    {% csrf_token %}
-    <div class="row">
-      <!-- Left column map  -->
-      <div class="col-md-7 col-map">
-        {{ form.extent }}
+<div class="col-md-11 col-md-offset-1 content-single">
+  <div class="row">
+    <!-- Main text  -->
+    <div class="col-md-12 main-text">
+      <div class="page-title">
+        <h2>{% trans "Edit project extent" %}</h2>
       </div>
-      <!-- /.col-map -->
-      <!-- Right column detail  -->
-      <div class="col-md-5 col-detail">
-        <h2 class="page-title">{% trans "Edit project geometry" %}</h2>
-        <p>{% trans "Use the map tools to modify your project geometry. Once complete, select the continue button." %}</p>
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <form method="POST" action="{% url 'organization:project-edit-geometry' project.organization.slug project.slug %}">
+            {% csrf_token %}
+            <div class="row">
+              <!-- Left column map  -->
+              <div class="col-md-7 col-map">
+                {{ form.extent }}
+              </div>
+              <!-- /.col-map -->
+              <!-- Right column detail  -->
+              <div class="col-md-5 col-detail">
+                <h2 class="page-title">{% trans "Edit project geometry" %}</h2>
+                <p>{% trans "Use the map tools to modify your project geometry. Once complete, select the continue button." %}</p>
 
-        <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
-        <a class="btn btn-link" href="{% url 'organization:project-dashboard' project.organization.slug project.slug %}">{% trans "Cancel" %}</a>
+                <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
+                <a class="btn btn-link" href="{% url 'organization:project-dashboard' project.organization.slug project.slug %}">{% trans "Cancel" %}</a>
+              </div>
+              <!-- /.col-detail -->
+            </div>
+          </form>
+        </div>
       </div>
-      <!-- /.col-detail -->
     </div>
-  </form>
-  <!-- /.main -->
+  </div>
 </div>
 
 {% endblock %}

--- a/cadasta/templates/organization/project_edit_permissions.html
+++ b/cadasta/templates/organization/project_edit_permissions.html
@@ -8,25 +8,41 @@
   {{ form.media }}
 {% endblock %}
 
-{% block project_main %}
+{% block left-nav %}overview{% endblock %}
 
-<form class="col-md-11 col-md-offset-1 main" method="POST" action="{% url 'organization:project-edit-permissions' project.organization.slug project.slug %}">
-  {% csrf_token %}
-  <table class="table table-striped datatable" data-paging-type="simple">
-    <thead>
-      <tr>
-        <th class="col-md-2">{% trans "Member" %}</th>
-        <th class="col-md-3">{% trans "Email address" %}</th>
-        <th class="col-md-4">{% trans "Permissions" %}</th>
-      </tr>
-    </thead>
-    {% for field in form %}
-      {% render_field field class+="form-control" %}
-    {% endfor %}
-  </table>
+{% block content %}
 
-  <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
-  <a class="btn btn-default" href="{% url 'organization:project-dashboard' project.organization.slug project.slug %}">{% trans "Cancel" %}</a>
-</form>
+<div class="col-md-11 col-md-offset-1 content-single">
+  <div class="row">
+    <!-- Main text  -->
+    <div class="col-md-12 main-text">
+      <div class="page-title">
+        <h2>{% trans "Edit project permissions" %}</h2>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <form method="POST" action="{% url 'organization:project-edit-permissions' project.organization.slug project.slug %}">
+            {% csrf_token %}
+            <table class="table table-striped datatable" data-paging-type="simple">
+              <thead>
+                <tr>
+                  <th class="col-md-2">{% trans "Member" %}</th>
+                  <th class="col-md-3">{% trans "Email address" %}</th>
+                  <th class="col-md-4">{% trans "Permissions" %}</th>
+                </tr>
+              </thead>
+              {% for field in form %}
+                {% render_field field class+="form-control" %}
+              {% endfor %}
+            </table>
+
+            <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
+            <a class="btn btn-default" href="{% url 'organization:project-dashboard' project.organization.slug project.slug %}">{% trans "Cancel" %}</a>
+          </form>    
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 
 {% endblock %}

--- a/cadasta/templates/resources/edit.html
+++ b/cadasta/templates/resources/edit.html
@@ -1,20 +1,28 @@
 {% extends "organization/project_wrapper.html" %}
 {% load i18n %}
 
+{% block left-nav %}resources{% endblock %}
+
 {% block extra_script %}
   {{ form.media }}
   {% include "resources/scripts.html" %}
 {% endblock %}
 
-{% block project_main %}
-<div class="col-md-11 col-md-offset-1 main col-text">
+{% block content %}
+
+<div class="col-md-11 col-md-offset-1 content-single">
   <div class="row">
-    <div class="col-md-12 page-title">
-      <h2>{% trans "Resources: Edit" %}</h2>
+    <!-- Main text  -->
+    <div class="col-md-12 main-text">
+      <div class="page-title">
+        <h2>{% trans "Resources: Edit" %}</h2>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-body">
+          {% include "resources/form.html" %}
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    {% include "resources/form.html" %}
   </div>
 </div>
 {% endblock %}

--- a/cadasta/templates/resources/project_add_existing.html
+++ b/cadasta/templates/resources/project_add_existing.html
@@ -2,43 +2,50 @@
 {% load i18n %}
 {% load widget_tweaks %}
 
-{% block project_main %}
-<div class="col-md-11 col-md-offset-1 main col-text">
+{% block left-nav %}resources{% endblock %}
+
+{% block content %}
+
+<div class="col-md-11 col-md-offset-1 content-single">
   <div class="row">
-    <div class="col-md-12 page-title">
-      <h2>{% trans "Resources: Add new" %}</h2>
+    <!-- Main text  -->
+    <div class="col-md-12 main-text">
+      <div class="page-title">
+        <h2>{% trans "Resources: Add new" %}</h2>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <!-- Resources index -->
+          <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active"><a href="" role="tab">{% trans "From library" %}</a></li>
+            <li role="presentation"><a href="{% url 'resources:project_add_new' object.organization.slug object.slug %}" role="tab">{% trans "Upload new" %}</a></li>
+          </ul>
+
+          <form class="col-md-12" method="POST">
+            {% csrf_token %}
+            <table class="table table-hover datatable" data-paging-type="simple">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>{% trans "Resource" %}</th>
+                  <th>{% trans "Type" %}</th>
+                  <th>{% trans "Entities associated" %}</th>
+                  <th>{% trans "Contributor" %}</th>
+                  <th>{% trans "Last updated" %}</th>
+                </tr>
+              </thead>
+              <tbody>
+              {% for field in form %}
+                {% render_field field class+="form-control" %}
+              {% endfor %}
+              </tbody>
+            </table>
+            <button type="submit" class="btn btn-primary">Save</button>
+          </form>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <ul class="nav nav-tabs" role="tablist">
-        <li role="presentation" class="active"><a href="" role="tab">{% trans "From library" %}</a></li>
-        <li role="presentation"><a href="{% url 'resources:project_add_new' object.organization.slug object.slug %}" role="tab">{% trans "Upload new" %}</a></li>
-      </ul>
-    </div>
-  </div>
-  <div class="row">
-    <form class="col-md-12" method="POST">
-      {% csrf_token %}
-      <table class="table table-hover datatable" data-paging-type="simple">
-        <thead>
-          <tr>
-            <th></th>
-            <th>{% trans "Resource" %}</th>
-            <th>{% trans "Type" %}</th>
-            <th>{% trans "Entities associated" %}</th>
-            <th>{% trans "Contributor" %}</th>
-            <th>{% trans "Last updated" %}</th>
-          </tr>
-        </thead>
-        <tbody>
-        {% for field in form %}
-          {% render_field field class+="form-control" %}
-        {% endfor %}
-        </tbody>
-      </table>
-      <button type="submit" class="btn btn-primary">Save</button>
-    </form>
   </div>
 </div>
+
 {% endblock %}

--- a/cadasta/templates/resources/project_add_new.html
+++ b/cadasta/templates/resources/project_add_new.html
@@ -1,25 +1,31 @@
 {% extends "organization/project_wrapper.html" %}
 {% load i18n %}
 
+{% block left-nav %}resources{% endblock %}
+
 {% block extra_script %}
   {{ form.media }}
   {% include "resources/scripts.html" %}
 {% endblock %}
 
-{% block project_main %}
-<div class="col-md-11 col-md-offset-1 main col-text">
+{% block content %}
+<div class="col-md-11 col-md-offset-1 content-single">
   <div class="row">
-    <div class="col-md-12 page-title">
-      <h2>{% trans "Resources: Add new" %}</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <ul class="nav nav-tabs" role="tablist">
-        <li role="presentation"><a href="{% url 'resources:project_add_existing' object.organization.slug object.slug %}" role="tab">{% trans "From library" %}</a></li>
-        <li role="presentation" class="active"><a href="" role="tab">{% trans "Upload new" %}</a></li>
-      </ul>
-      {% include "resources/form.html" %}
+    <!-- Main text  -->
+    <div class="col-md-12 main-text">
+      <div class="page-title">
+        <h2>{% trans "Resources: Add new" %}</h2>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <!-- Resources index -->
+          <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation"><a href="{% url 'resources:project_add_existing' object.organization.slug object.slug %}" role="tab">{% trans "From library" %}</a></li>
+            <li role="presentation" class="active"><a href="" role="tab">{% trans "Upload new" %}</a></li>
+          </ul>
+          {% include "resources/form.html" %}
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Forms were not visible because the content block for main content inside `project_wrapper.html` was changed. I changed the name in all affected templates and adapted all templates according to the new layout. 