### PR TITLE
Add conditional paging for datatables

### DIFF
--- a/cadasta/core/static/js/dataTables.conditionalPaging.js
+++ b/cadasta/core/static/js/dataTables.conditionalPaging.js
@@ -1,0 +1,82 @@
+/**
+ * @summary     ConditionalPaging
+ * @description Hide paging controls when the amount of pages is <= 1
+ * @version     1.0.0
+ * @file        dataTables.conditionalPaging.js
+ * @author      Matthew Hasbach (https://github.com/mjhasbach)
+ * @contact     hasbach.git@gmail.com
+ * @copyright   Copyright 2015 Matthew Hasbach
+ *
+ * License      MIT - http://datatables.net/license/mit
+ *
+ * This feature plugin for DataTables hides paging controls when the amount
+ * of pages is <= 1. The controls can either appear / disappear or fade in / out
+ *
+ * @example
+ *    $('#myTable').DataTable({
+ *        conditionalPaging: true
+ *    });
+ *
+ * @example
+ *    $('#myTable').DataTable({
+ *        conditionalPaging: {
+ *            style: 'fade',
+ *            speed: 500 // optional
+ *        }
+ *    });
+ */
+
+(function(window, document, $) {
+    $(document).on('init.dt', function(e, dtSettings) {
+        if ( e.namespace !== 'dt' ) {
+            return;
+        }
+
+        var options = dtSettings.oInit.conditionalPaging;
+
+        if ($.isPlainObject(options) || options === true) {
+            var config = $.isPlainObject(options) ? options : {},
+                api = new $.fn.dataTable.Api(dtSettings),
+                speed = 'slow',
+                conditionalPaging = function(e) {
+                    var $paging = $(api.table().container()).find('div.dataTables_paginate'),
+                        pages = api.page.info().pages;
+
+                    if (e instanceof $.Event) {
+                        if (pages <= 1) {
+                            if (config.style === 'fade') {
+                                $paging.stop().fadeTo(speed, 0);
+                            }
+                            else {
+                                $paging.css('visibility', 'hidden');
+                            }
+                        }
+                        else {
+                            if (config.style === 'fade') {
+                                $paging.stop().fadeTo(speed, 1);
+                            }
+                            else {
+                                $paging.css('visibility', '');
+                            }
+                        }
+                    }
+                    else if (pages <= 1) {
+                        if (config.style === 'fade') {
+                            $paging.css('opacity', 0);
+                        }
+                        else {
+                            $paging.css('visibility', 'hidden');
+                        }
+                    }
+                };
+
+            if ($.isNumeric(config.speed) || $.type(config.speed) === 'string') {
+                speed = config.speed;
+            }
+
+            conditionalPaging();
+
+            api.on('draw.dt', conditionalPaging);
+        }
+    });
+})(window, document, jQuery);

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -34,7 +34,7 @@
             {% if user.is_authenticated %}
             <!-- User menu -->
             <div class="btn-group divider" role="group">
-              <button type="button" class="btn btn-user dropdown-toggle" data-toggle="dropdown" 
+              <button type="button" class="btn btn-user dropdown-toggle" data-toggle="dropdown"
               aria-haspopup="true" aria-expanded="false">
                 <img src="/static/img/avatar.jpg" class="avatar thumbnail">
                 {{ user.full_name }} <span class="caret"></span>
@@ -53,7 +53,7 @@
             <!-- New user menu -->
             <div class="divider pull-left"></div>
             <div class="btn-group" role="group">
-              <a href="{% url 'account_login' %}" class="btn btn-reg" aria-label="Sign in">{% trans "Sign in" %}</a> 
+              <a href="{% url 'account_login' %}" class="btn btn-reg" aria-label="Sign in">{% trans "Sign in" %}</a>
               <a href="{% url 'account_signup' %}" class="btn btn-reg" aria-label="Register">{% trans "Register" %}</a>
             </div>
             {% endif %}
@@ -170,10 +170,12 @@
     <script type="text/javascript"
             src="https://cdn.datatables.net/r/bs-3.3.5/jqc-1.11.3,dt-1.10.8/datatables.min.js">
     </script>
+    <script type="text/javascript" src="{% static 'js/dataTables.conditionalPaging.js' %}">
+    </script>
     {% block extra_script %}{% endblock %}
     <script>
      $(document).ready(function () {
-       $('.datatable').DataTable();
+       $('.datatable').DataTable({ conditionalPaging: true });
        $('.dropdown-toggle').dropdown();
        $('#language').change(function() { this.form.submit(); });
      });


### PR DESCRIPTION
Hides "Previous" and "Next" buttons when there's only one page of data to display in all datatables.  Item count is still displayed, so you see something like "Showing 1 to 3 of 3 entries" to confirm that you're seeing all the entries on a single page.