### PR TITLE
Fixes #285

### DIFF
--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.utils.translation import ugettext as _
 
 from .models import User
@@ -14,11 +15,17 @@ class RegisterForm(forms.ModelForm):
         fields = ['username', 'email', 'password1', 'password2',
                   'full_name']
 
+    def clean_username(self):
+        username = self.data.get('username')
+        if username.lower() in settings.CADASTA_INVALID_ENTITY_NAMES:
+            raise forms.ValidationError(
+                _("Username cannot be “add” or “new”."))
+        return username
+
     def clean_password1(self):
         password = self.data.get('password1')
         if password != self.data.get('password2'):
             raise forms.ValidationError(_("Passwords do not match"))
-
         return password
 
     def clean_email(self):
@@ -26,7 +33,6 @@ class RegisterForm(forms.ModelForm):
         if User.objects.filter(email=email).exists():
             raise forms.ValidationError(
                 _("Another user with this email already exists"))
-
         return email
 
     def save(self, *args, **kwargs):
@@ -47,7 +53,9 @@ class ProfileForm(forms.ModelForm):
                 User.objects.filter(username=username).exists()):
             raise forms.ValidationError(
                 _("Another user with this username already exists"))
-
+        if username.lower() in settings.CADASTA_INVALID_ENTITY_NAMES:
+            raise forms.ValidationError(
+                _("Username cannot be “add” or “new”."))
         return username
 
     def clean_email(self):
@@ -56,5 +64,4 @@ class ProfileForm(forms.ModelForm):
                 User.objects.filter(email=email).exists()):
             raise forms.ValidationError(
                 _("Another user with this email already exists"))
-
         return email

--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -1,5 +1,5 @@
+from django.conf import settings
 from django.utils import timezone
-
 from django.utils.translation import ugettext as _
 
 from rest_framework.serializers import EmailField, ValidationError
@@ -33,6 +33,12 @@ class RegistrationSerializer(djoser_serializers.UserRegistrationSerializer):
             'email': {'required': True, 'unique': True}
         }
 
+    def validate_username(self, username):
+        if username.lower() in settings.CADASTA_INVALID_ENTITY_NAMES:
+            raise ValidationError(
+                _("Username cannot be “add” or “new”."))
+        return username
+
 
 class UserSerializer(djoser_serializers.UserSerializer):
     email = EmailField(
@@ -64,6 +70,9 @@ class UserSerializer(djoser_serializers.UserSerializer):
                username != instance.username and
                self.context['request'].user != instance):
                 raise ValidationError('Cannot update username')
+        if username.lower() in settings.CADASTA_INVALID_ENTITY_NAMES:
+            raise ValidationError(
+                _("Username cannot be “add” or “new”."))
         return username
 
     def validate_last_login(self, last_login):

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -1,3 +1,5 @@
+import random
+
 from django.utils.translation import gettext as _
 
 from ..models import User
@@ -55,6 +57,22 @@ class RegisterFormTest(UserTestCase):
                 in form.errors.get('email'))
         assert User.objects.count() == 1
 
+    def test_signup_with_restricted_username(self):
+        invalid_usernames = ('add', 'ADD', 'Add', 'new', 'NEW', 'New')
+        data = {
+            'username': random.choice(invalid_usernames),
+            'email': 'john@beatles.uk',
+            'password1': 'iloveyoko79',
+            'password2': 'iloveyoko68',
+            'full_name': 'John Lennon',
+        }
+        form = RegisterForm(data)
+
+        assert form.is_valid() is False
+        assert (_("Username cannot be “add” or “new”.")
+                in form.errors.get('username'))
+        assert User.objects.count() == 0
+
 
 class ProfileFormTest(UserTestCase):
     def test_update_user(self):
@@ -90,6 +108,18 @@ class ProfileFormTest(UserTestCase):
         data = {
             'username': 'imagine71',
             'email': 'existing@example.com',
+            'full_name': 'John Lennon',
+        }
+        form = ProfileForm(data, instance=user)
+        assert form.is_valid() is False
+
+    def test_update_user_with_restricted_username(self):
+        user = UserFactory.create(username='imagine71',
+                                  email='john@beatles.uk')
+        invalid_usernames = ('add', 'ADD', 'Add', 'new', 'NEW', 'New')
+        data = {
+            'username': random.choice(invalid_usernames),
+            'email': 'john@beatles.uk',
             'full_name': 'John Lennon',
         }
         form = ProfileForm(data, instance=user)

--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -178,6 +178,9 @@ LEAFLET_CONFIG = {
     }
 }
 
+# Invalid names for Cadasta organizations, projects, and usernames
+CADASTA_INVALID_ENTITY_NAMES = ['add', 'new']
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
 

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db.models import Q
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
+from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.template.loader import get_template
 from django.template import Context
@@ -26,6 +27,14 @@ class OrganizationSerializer(DetailSerializer, FieldSelectorSerializer,
         read_only_fields = ('id', 'slug',)
         detail_only_fields = ('users',)
 
+    def validate_name(self, value):
+        is_create = not self.instance
+        invalid_names = settings.CADASTA_INVALID_ENTITY_NAMES
+        if is_create and slugify(value) in invalid_names:
+            raise serializers.ValidationError(
+                _("Organization name cannot be “Add” or “New”."))
+        return value
+
     def create(self, *args, **kwargs):
         org = super(OrganizationSerializer, self).create(*args, **kwargs)
 
@@ -42,6 +51,14 @@ class ProjectSerializer(DetailSerializer, serializers.ModelSerializer):
     users = UserSerializer(many=True, read_only=True)
     organization = OrganizationSerializer(read_only=True)
     country = CountryField(required=False)
+
+    def validate_name(self, value):
+        is_create = not self.instance
+        invalid_names = settings.CADASTA_INVALID_ENTITY_NAMES
+        if is_create and slugify(value) in invalid_names:
+            raise serializers.ValidationError(
+                _("Project name cannot be “Add” or “New”."))
+        return value
 
     class Meta:
         model = Project


### PR DESCRIPTION
Added validation in the organization, project, and user forms and serializers to prevent names and usernames equal to “Add” or “New”.