### PR TITLE
Add records API URL unit tests

### DIFF
--- a/cadasta/config/urls.py
+++ b/cadasta/config/urls.py
@@ -27,6 +27,9 @@ api_v1 = [
     url(r'^projects/',
         include('organization.urls.api.projects',
                 namespace='project')),
+    url(r'^users/',
+        include('organization.urls.api.users',
+                namespace='user')),
     url(r'^organizations/(?P<organization>[-\w]+)/projects/'
         '(?P<project_id>[-\w]+)/',
         include('questionnaires.urls.api',
@@ -35,8 +38,10 @@ api_v1 = [
         '(?P<project>[-\w]+)/',
         include('resources.urls.api',
                 namespace='resources')),
-    url(r'^users/',
-        include('organization.urls.api.users', namespace='user')),
+    url(r'^organizations/(?P<organization>[-\w]+)/projects/'
+        '(?P<project>[-\w]+)/spatial/',
+        include('spatial.urls.api.spatial',
+                namespace='spatial')),
     url(r'^organizations/(?P<organization>[-\w]+)/projects/'
         '(?P<project>[-\w]+)/parties/',
         include('party.urls.api.parties',

--- a/cadasta/organization/urls/api/organizations.py
+++ b/cadasta/organization/urls/api/organizations.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
 
 from ...views import api
 
@@ -36,8 +36,4 @@ urlpatterns = [
         '(?P<project>[-\w]+)/users/(?P<username>[-\w]+)/$',
         api.ProjectUsersDetail.as_view(),
         name='project_users_detail'),
-    url(
-        r'^(?P<organization>[-\w]+)/projects/'
-        '(?P<project_slug>[-\w]+)/spatial/',
-        include('spatial.urls.api.spatial', namespace='spatial_urls')),
 ]

--- a/cadasta/party/tests/test_urls_api.py
+++ b/cadasta/party/tests/test_urls_api.py
@@ -1,0 +1,141 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse, resolve
+from core.tests.url_utils import version_ns, version_url
+
+from ..views import api
+from spatial.views import api as api2
+
+
+class PartyUrlTest(TestCase):
+
+    def test_project_party_list(self):
+        actual = reverse(
+            version_ns('party:list'),
+            kwargs={
+                'organization': 'habitat',
+                'project': '123abc',
+            }
+        )
+        expected = version_url(
+            '/organizations/habitat/projects/123abc/parties/')
+        assert actual == expected
+
+        resolved = resolve(version_url(
+            '/organizations/habitat/projects/123abc/parties/'))
+        assert resolved.func.__name__ == api.PartyList.__name__
+        assert resolved.kwargs['organization'] == 'habitat'
+        assert resolved.kwargs['project'] == '123abc'
+
+    def test_project_party_detail(self):
+        actual = reverse(
+            version_ns('party:detail'),
+            kwargs={
+                'organization': 'habitat',
+                'project': '123abc',
+                'party': '123456123456123456123456',
+            }
+        )
+        expected = version_url(
+            '/organizations/habitat/projects/123abc/'
+            'parties/123456123456123456123456/')
+        assert actual == expected
+
+        resolved = resolve(version_url(
+            '/organizations/habitat/projects/123abc/'
+            'parties/123456123456123456123456/'))
+        assert resolved.func.__name__ == api.PartyDetail.__name__
+        assert resolved.kwargs['organization'] == 'habitat'
+        assert resolved.kwargs['project'] == '123abc'
+        assert resolved.kwargs['party'] == '123456123456123456123456'
+
+    def test_project_party_relationships_list(self):
+        actual = reverse(
+            version_ns('party:rel_list'),
+            kwargs={
+                'organization': 'habitat',
+                'project': '123abc',
+                'party': '123456123456123456123456',
+            }
+        )
+        expected = version_url(
+            '/organizations/habitat/projects/123abc/'
+            'parties/123456123456123456123456/relationships/')
+        assert actual == expected
+
+        resolved = resolve(version_url(
+            '/organizations/habitat/projects/123abc/'
+            'parties/123456123456123456123456/relationships/'))
+        assert resolved.func.__name__ == api.RelationshipList.__name__
+        assert resolved.kwargs['organization'] == 'habitat'
+        assert resolved.kwargs['project'] == '123abc'
+        assert resolved.kwargs['party'] == '123456123456123456123456'
+
+
+class RelationshipUrlTest(TestCase):
+
+    def generic_test_project_relationship_create(self, rel_class, view):
+        actual = reverse(
+            version_ns('relationship:{}_rel_create'.format(rel_class)),
+            kwargs={
+                'organization': 'habitat',
+                'project': '123abc',
+            }
+        )
+        expected = version_url(
+            '/organizations/habitat/projects/123abc/'
+            'relationships/{}/'.format(rel_class))
+        assert actual == expected
+
+        resolved = resolve(version_url(
+            '/organizations/habitat/projects/123abc/'
+            'relationships/{}/'.format(rel_class)))
+        assert resolved.func.__name__ == view.__name__
+        assert resolved.kwargs['organization'] == 'habitat'
+        assert resolved.kwargs['project'] == '123abc'
+
+    def generic_test_project_relationship_detail(self, rel_class, view):
+        actual = reverse(
+            version_ns('relationship:{}_rel_detail'.format(rel_class)),
+            kwargs={
+                'organization': 'habitat',
+                'project': '123abc',
+                '{}_rel_id'.format(rel_class): '654321654321654321654321',
+            }
+        )
+        expected = version_url(
+            '/organizations/habitat/projects/123abc/'
+            'relationships/{}/654321654321654321654321/'.format(rel_class))
+        assert actual == expected
+
+        resolved = resolve(version_url(
+            '/organizations/habitat/projects/123abc/'
+            'relationships/{}/654321654321654321654321/'.format(rel_class)))
+        assert resolved.func.__name__ == view.__name__
+        assert resolved.kwargs['organization'] == 'habitat'
+        assert resolved.kwargs['project'] == '123abc'
+        assert resolved.kwargs['{}_rel_id'.format(rel_class)] == (
+            '654321654321654321654321')
+
+    def test_project_spatial_relationship_create(self):
+        self.generic_test_project_relationship_create(
+            'spatial', api2.SpatialRelationshipCreate)
+
+    def test_project_party_relationship_create(self):
+        self.generic_test_project_relationship_create(
+            'party', api.PartyRelationshipCreate)
+
+    def test_project_tenure_relationship_create(self):
+        self.generic_test_project_relationship_create(
+            'tenure', api.TenureRelationshipCreate)
+
+    def test_project_spatial_relationship_detail(self):
+        self.generic_test_project_relationship_detail(
+            'spatial', api2.SpatialRelationshipDetail)
+
+    def test_project_party_relationship_detail(self):
+        self.generic_test_project_relationship_detail(
+            'party', api.PartyRelationshipDetail)
+
+    def test_project_tenure_relationship_detail(self):
+        self.generic_test_project_relationship_detail(
+            'tenure', api.TenureRelationshipDetail)

--- a/cadasta/party/urls/api/parties.py
+++ b/cadasta/party/urls/api/parties.py
@@ -8,11 +8,11 @@ urlpatterns = [
         api.PartyList.as_view(),
         name='list'),
     url(
-        r'^(?P<party>[-\w]+)/relationships/$',
-        api.RelationshipList.as_view(),
-        name='rel_list'),
-    url(
         r'^(?P<party>[-\w]+)/$',
         api.PartyDetail.as_view(),
         name='detail'),
+    url(
+        r'^(?P<party>[-\w]+)/relationships/$',
+        api.RelationshipList.as_view(),
+        name='rel_list'),
 ]

--- a/cadasta/spatial/tests/test_urls_api.py
+++ b/cadasta/spatial/tests/test_urls_api.py
@@ -1,0 +1,71 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse, resolve
+from core.tests.url_utils import version_ns, version_url
+
+from ..views import api
+from party.views.api import RelationshipList
+
+
+class SpatialUrlTest(TestCase):
+
+    def test_project_spatial_unit_list(self):
+        actual = reverse(
+            version_ns('spatial:list'),
+            kwargs={
+                'organization': 'habitat',
+                'project': '123abc',
+            }
+        )
+        expected = version_url(
+            '/organizations/habitat/projects/123abc/spatial/')
+        assert actual == expected
+
+        resolved = resolve(version_url(
+            '/organizations/habitat/projects/123abc/spatial/'))
+        assert resolved.func.__name__ == api.SpatialUnitList.__name__
+        assert resolved.kwargs['organization'] == 'habitat'
+        assert resolved.kwargs['project'] == '123abc'
+
+    def test_project_spatial_unit_detail(self):
+        actual = reverse(
+            version_ns('spatial:detail'),
+            kwargs={
+                'organization': 'habitat',
+                'project': '123abc',
+                'spatial_id': '123456123456123456123456',
+            }
+        )
+        expected = version_url(
+            '/organizations/habitat/projects/123abc/'
+            'spatial/123456123456123456123456/')
+        assert actual == expected
+
+        resolved = resolve(version_url(
+            '/organizations/habitat/projects/123abc/'
+            'spatial/123456123456123456123456/'))
+        assert resolved.func.__name__ == api.SpatialUnitDetail.__name__
+        assert resolved.kwargs['organization'] == 'habitat'
+        assert resolved.kwargs['project'] == '123abc'
+        assert resolved.kwargs['spatial_id'] == '123456123456123456123456'
+
+    def test_project_spatial_unit_relationships_list(self):
+        actual = reverse(
+            version_ns('spatial:rel_list'),
+            kwargs={
+                'organization': 'habitat',
+                'project': '123abc',
+                'spatial_id': '123456123456123456123456',
+            }
+        )
+        expected = version_url(
+            '/organizations/habitat/projects/123abc/'
+            'spatial/123456123456123456123456/relationships/')
+        assert actual == expected
+
+        resolved = resolve(version_url(
+            '/organizations/habitat/projects/123abc/'
+            'spatial/123456123456123456123456/relationships/'))
+        assert resolved.func.__name__ == RelationshipList.__name__
+        assert resolved.kwargs['organization'] == 'habitat'
+        assert resolved.kwargs['project'] == '123abc'
+        assert resolved.kwargs['spatial_id'] == '123456123456123456123456'

--- a/cadasta/spatial/urls/api/spatial.py
+++ b/cadasta/spatial/urls/api/spatial.py
@@ -9,11 +9,11 @@ urlpatterns = [
         api.SpatialUnitList.as_view(),
         name='list'),
     url(
-        r'^(?P<spatial_id>[-\w]+)/relationships/$',
-        RelationshipList.as_view(),
-        name='rel_list'),
-    url(
         r'^(?P<spatial_id>[-\w]+)/$',
         api.SpatialUnitDetail.as_view(),
         name='detail'),
+    url(
+        r'^(?P<spatial_id>[-\w]+)/relationships/$',
+        RelationshipList.as_view(),
+        name='rel_list'),
 ]


### PR DESCRIPTION
- Move the spatial unit API URL patterns from organization/urls/api/organizations.py to config/urls.py to be consistent with the other record URLs
- Add unit tests for the records API URLs