### PR TITLE
Organization page titles

### DIFF
--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 
+{% block page_title %}Overview | {% endblock %}
 {% block left-nav %}overview{% endblock %}
 
 {% block content %}
@@ -26,7 +27,7 @@
               </thead>
               <tbody>
                 {% for prj in projects %}
-                <tr onclick="window.document.location='{% url 'organization:project-dashboard' organization=organization.slug project=prj.slug %}';">
+                <tr class="linked" onclick="window.document.location='{% url 'organization:project-dashboard' organization=organization.slug project=prj.slug %}';">
                   <td>{{ prj.name }}</td>
                   <td>{{ prj.country }}</td>
                   <td>{{ prj.last_updated }}</td>

--- a/cadasta/templates/organization/organization_members.html
+++ b/cadasta/templates/organization/organization_members.html
@@ -33,7 +33,7 @@
         </thead>
         <tbody>
         {% for user in organization.users.all %}
-          <tr onclick="window.document.location='{% url 'organization:members_edit' slug=organization.slug username=user.username %}';">
+          <tr class="linked" onclick="window.document.location='{% url 'organization:members_edit' slug=organization.slug username=user.username %}';">
             <td>{{ user.get_full_name }}
               <div class="hidden-sm hidden-md hidden-lg">
                 {{ user.username }}<br />

--- a/cadasta/templates/organization/organization_members_edit.html
+++ b/cadasta/templates/organization/organization_members_edit.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load widget_tweaks %}
 
-{% block page_title %}Members |{% endblock %}
+{% block page_title %}Edit member | {% endblock %}
 
 {% block left-nav %}members{% endblock %}
 

--- a/cadasta/templates/organization/project_add_details.html
+++ b/cadasta/templates/organization/project_add_details.html
@@ -3,6 +3,8 @@
 {% load widget_tweaks %}
 {% load i18n %}
 
+{% block page_title %}| Add details{% endblock %}
+
 {% block extra_script %}
 {{ form.media }}
 <script>

--- a/cadasta/templates/organization/project_add_extents.html
+++ b/cadasta/templates/organization/project_add_extents.html
@@ -4,6 +4,8 @@
 {% load leaflet_tags %}
 {% load i18n %}
 
+{% block page_title %}| Draw map{% endblock %}
+
 {% block extra_head %}
 {% leaflet_css plugins="draw,forms" %}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.css">
@@ -51,7 +53,7 @@
 {% block step_instructions %}
     <p>
       {% blocktrans %}
-      Use the map tools to outline your project location boundaries. Once complete, select the "Save and continue" button below.
+      Use the map tools to outline your project location boundaries. Once complete, select the save button below.
       {% endblocktrans %}
     </p>
 {% endblock %}

--- a/cadasta/templates/organization/project_add_permissions.html
+++ b/cadasta/templates/organization/project_add_permissions.html
@@ -3,6 +3,8 @@
 {% load i18n %}
 {% load widget_tweaks %}
 
+{% block page_title %}| Assign team{% endblock %}
+
 {% block step_content_1 %}
 
     <div class="row">

--- a/cadasta/templates/organization/project_add_wrapper.html
+++ b/cadasta/templates/organization/project_add_wrapper.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 
+{% block title %} | Add new project {% block page_title %}{% endblock %} {% endblock %}
 {% block top-nav %}project-wizard{% endblock %}
 
 {% block content %}

--- a/cadasta/templates/organization/project_dashboard.html
+++ b/cadasta/templates/organization/project_dashboard.html
@@ -23,6 +23,7 @@
 </script>
 {% endblock %}
 
+{% block page_title %}Overview | {% endblock %}
 {% block left-nav %}overview{% endblock %}
 
 {% block content %}

--- a/cadasta/templates/organization/project_edit_details.html
+++ b/cadasta/templates/organization/project_edit_details.html
@@ -8,6 +8,7 @@
   {{ form.media }}
 {% endblock %}
 
+{% block page_title %}Edit project details | {% endblock %}
 {% block left-nav %}overview{% endblock %}
 
 {% block content %}

--- a/cadasta/templates/organization/project_edit_geometry.html
+++ b/cadasta/templates/organization/project_edit_geometry.html
@@ -4,6 +4,8 @@
 {% load i18n %}
 {% load leaflet_tags %}
 
+{% block page_title %}Edit project location | {% endblock %}
+
 {% block extra_head %}
 {% leaflet_css plugins="draw,forms" %}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.css">

--- a/cadasta/templates/organization/project_edit_permissions.html
+++ b/cadasta/templates/organization/project_edit_permissions.html
@@ -4,6 +4,8 @@
 {% load i18n %}
 {% load widget_tweaks %}
 
+{% block page_title %}Edit member permissions | {% endblock %}
+
 {% block extra_head %}
   {{ form.media }}
 {% endblock %}

--- a/cadasta/templates/organization/project_wrapper.html
+++ b/cadasta/templates/organization/project_wrapper.html
@@ -4,7 +4,7 @@
 
 {% block top-nav %}project-single{% endblock %}
 
-{% block title %} | {{ object.name }}{% endblock %}
+{% block title %} | {% block page_title %}{% endblock %} {{ object.name }}{% endblock %}
 
 {% block page-header %}
 

--- a/cadasta/templates/party/party_list.html
+++ b/cadasta/templates/party/party_list.html
@@ -19,7 +19,7 @@
               </tr>
             </thead>
             {% for party in object_list %}
-            <tr onclick="window.document.location='{% url 'parties:detail' object.organization.slug object.slug party.id %}';">
+            <tr class="linked" onclick="window.document.location='{% url 'parties:detail' object.organization.slug object.slug party.id %}';">
               <td>{{ party.name }}</td>
               <td>{{ party.get_type_display }}</td>
             </tr>

--- a/cadasta/templates/resources/edit.html
+++ b/cadasta/templates/resources/edit.html
@@ -1,6 +1,7 @@
 {% extends "organization/project_wrapper.html" %}
 {% load i18n %}
 
+{% block page_title %}Edit resource | {% endblock %}
 {% block left-nav %}resources{% endblock %}
 
 {% block extra_script %}

--- a/cadasta/templates/resources/project_add_existing.html
+++ b/cadasta/templates/resources/project_add_existing.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load widget_tweaks %}
 
+{% block page_title %}Add new resource | {% endblock %}
 {% block left-nav %}resources{% endblock %}
 
 {% block content %}

--- a/cadasta/templates/resources/project_add_new.html
+++ b/cadasta/templates/resources/project_add_new.html
@@ -1,6 +1,7 @@
 {% extends "organization/project_wrapper.html" %}
 {% load i18n %}
 
+{% block page_title %}Upload new resource | {% endblock %}
 {% block left-nav %}resources{% endblock %}
 
 {% block extra_script %}

--- a/cadasta/templates/resources/project_detail.html
+++ b/cadasta/templates/resources/project_detail.html
@@ -1,6 +1,8 @@
 {% extends "organization/project_wrapper.html" %}
 {% load i18n %}
 
+{% block page_title %}Resource detail | {% endblock %}
+
 {% block content %}
 
 <div class="col-md-12 content-single">

--- a/cadasta/templates/resources/project_list.html
+++ b/cadasta/templates/resources/project_list.html
@@ -1,6 +1,7 @@
 {% extends "organization/project_wrapper.html" %}
 {% load i18n %}
 
+{% block page_title %}Resources | {% endblock %}
 {% block left-nav %}resources{% endblock %}
 
 {% block content %}

--- a/cadasta/templates/resources/table.html
+++ b/cadasta/templates/resources/table.html
@@ -6,14 +6,14 @@
     <tr>
       <th class="col-md-4">{% trans "Resource" %}</th>
       <th class="col-md-2 hidden-xs hidden-sm">{% trans "Type" %}</th>
-      <th class="col-md-2 hidden-xs hidden-sm">{% trans "Entities associated" %}</th>
+      <th class="col-md-2 hidden-xs hidden-sm">{% trans "Connections" %}</th>
       <th class="col-md-2">{% trans "Contributor" %}</th>
       <th class="col-md-2 hidden-xs hidden-sm">{% trans "Last updated" %}</th>
     </tr>
   </thead>
   <tbody>
   {% for resource in object_list %}
-    <tr onclick="window.document.location='{% url 'resources:project_detail' project=object.slug organization=object.organization.slug resource=resource.id %}';">
+    <tr class="linked" onclick="window.document.location='{% url 'resources:project_detail' project=object.slug organization=object.organization.slug resource=resource.id %}';">
       <td>
         <div class="resource-60">
           <img src="{{ resource.thumbnail }}" class="thumb-60">

--- a/cadasta/templates/resources/table_add_lib.html
+++ b/cadasta/templates/resources/table_add_lib.html
@@ -7,7 +7,7 @@
       <th class="col-md-1"></th>
       <th class="col-md-4">{% trans "Resource" %}</th>
       <th class="col-md-1">{% trans "Type" %}</th>
-      <th class="col-md-2">{% trans "Entities associated" %}</th>
+      <th class="col-md-2">{% trans "Connections" %}</th>
       <th class="col-md-2">{% trans "Contributor" %}</th>
       <th class="col-md-2">{% trans "Last updated" %}</th>
     </tr>

--- a/cadasta/templates/resources/table_sm.html
+++ b/cadasta/templates/resources/table_sm.html
@@ -4,14 +4,13 @@
 <table class="table table-hover datatable" data-paging-type="simple">
   <thead>
     <tr>
-      <th class="col-md-8">{% trans "Resource" %}</th>
+      <th class="col-md-10">{% trans "Resource" %}</th>
       <th class="col-md-2">{% trans "Connections" %}</th>
-      <th class="col-md-2">{% trans "Contributor" %}</th>
     </tr>
   </thead>
   <tbody>
   {% for resource in object_list %}
-    <tr onclick="window.document.location='{% url 'resources:project_detail' project=object.slug organization=object.organization.slug resource=resource.id %}';">
+    <tr class="linked" onclick="window.document.location='{% url 'resources:project_detail' project=object.slug organization=object.organization.slug resource=resource.id %}';">
       <td>
         <div class="resource-60">
           <img src="{{ resource.thumbnail }}" class="thumb-60">
@@ -21,7 +20,6 @@
         </div>
       </td>
       <td>{{ resource.num_entities }}</td>
-      <td>{{ resource.contributor.full_name }}<br>{{ resource.contributor.username }}</td>
     </tr>
   {% endfor %}
   </tbody>

--- a/cadasta/templates/spatial/location_add.html
+++ b/cadasta/templates/spatial/location_add.html
@@ -6,6 +6,8 @@
 {% load staticfiles %}
 {% load leaflet_tags %}
 
+{% block page_title %}Add new location | {% endblock %}
+
 {% block extra_head %}
 {% leaflet_css plugins="draw,forms" %}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.css">

--- a/cadasta/templates/spatial/location_delete.html
+++ b/cadasta/templates/spatial/location_delete.html
@@ -1,6 +1,8 @@
 {% extends "spatial/location_detail.html" %}
 {% load i18n %}
 
+{% block page_title %}Delete location | {% endblock %}
+
 {% block modals %}
 
 <form method="POST" class="modal-backdrop">

--- a/cadasta/templates/spatial/location_detail.html
+++ b/cadasta/templates/spatial/location_detail.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load widget_tweaks %}
 
+{% block page_title %}Location detail | {% endblock %}
 
 {% block location_panel %}
 
@@ -50,7 +51,7 @@
       </thead>
       <tbody>
         {% for rel in relationships %}
-        <tr onclick="window.document.location='{% url 'parties:relationship_detail' object.organization.slug object.slug rel.id %}';">
+        <tr class="linked" onclick="window.document.location='{% url 'parties:relationship_detail' object.organization.slug object.slug rel.id %}';">
           <td>{{ rel.tenure_type.label }}</td>
           <td><a href="{% url 'parties:detail' object.organization.slug object.slug rel.party.id %}">{{ rel.party.name }}</a></td>
         </tr>

--- a/cadasta/templates/spatial/location_edit.html
+++ b/cadasta/templates/spatial/location_edit.html
@@ -4,6 +4,8 @@
 {% load widget_tweaks %}
 {% load staticfiles %}
 
+{% block page_title %}Edit location | {% endblock %}
+
 {% block extra_head %}
 {% leaflet_css plugins="draw,forms" %}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.css">

--- a/cadasta/templates/spatial/location_form.html
+++ b/cadasta/templates/spatial/location_form.html
@@ -16,7 +16,7 @@
         <div class="panel panel-default">
           <div class="panel-body">
 
-          <h3>Create location on map</h3>
+          <h3>Draw location on map</h3>
           <p>
             {% blocktrans %}Use the map tools to mark your new location. Next select the location type below.  Once complete, select the save button.<br /><br />{% endblocktrans %}
           </p>

--- a/cadasta/templates/spatial/location_map.html
+++ b/cadasta/templates/spatial/location_map.html
@@ -1,6 +1,7 @@
 {% extends "organization/project_wrapper.html" %}
 {% load i18n %}
 
+{% block page_title %}Project Map | {% endblock %}
 {% block left-nav %}map{% endblock %}
 
 {% load leaflet_tags %}

--- a/cadasta/templates/spatial/relationship_add.html
+++ b/cadasta/templates/spatial/relationship_add.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load widget_tweaks %}
 
+{% block page_title %}Add new relationship | {% endblock %}
+
 {% block form_script %}
   {{ form.media }}
 {% endblock %}

--- a/cadasta/templates/spatial/resources_add.html
+++ b/cadasta/templates/spatial/resources_add.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load widget_tweaks %}
 
+{% block page_title %}Add new resource | {% endblock %}
+
 {% block modals %}
 <div class="modal-backdrop">
   <div class="modal show" data-backdrop="true">

--- a/cadasta/templates/spatial/resources_new.html
+++ b/cadasta/templates/spatial/resources_new.html
@@ -2,11 +2,12 @@
 {% load i18n %}
 {% load widget_tweaks %}
 
+{% block page_title %}Upload new resource | {% endblock %}
+
 {% block form_script %}
   {{ form.media }}
   {% include "resources/scripts.html" %}
 {% endblock %}
-
 
 {% block modals %}
 


### PR DESCRIPTION
Completes #198, #301, #306.

Updates page titles.
Adds cursor to clickable rows.
Updates "entities associated" header to "connections".

--------------------------------------------

New project wizard page titles

Project area titles work

Resources title - removed project titles

Resources & Map page title

Add relationships and resources to location titles

Change title to test tests

Page title changes

Project dashboard title - remove duplicate

Add records API URL unit tests

Update small table