### PR TITLE
Test + production URL configs

### DIFF
--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -94,7 +94,6 @@ REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'core.views.api.exception_handler'
 }
 
-ROOT_URLCONF = 'config.urls'
 SITE_NAME = 'Cadasta'
 
 BASE_TEMPLATE_DIR = os.path.join(os.path.dirname(BASE_DIR), 'templates')

--- a/cadasta/config/settings/dev.py
+++ b/cadasta/config/settings/dev.py
@@ -54,6 +54,7 @@ EMAIL_HOST_PASSWORD = ''
 EMAIL_USE_TLS = False
 DEFAULT_FROM_EMAIL = 'testing@example.com'
 
+ROOT_URLCONF = 'config.urls.dev'
 DEFAULT_FILE_STORAGE = 'buckets.test.storage.FakeS3Storage'
 MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'core/media')
 MEDIA_URL = '/media/'

--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -31,6 +31,7 @@ EMAIL_HOST_USER = os.environ['EMAIL_HOST_USER']
 EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
 SERVER_EMAIL = 'platform-errors@cadasta.org'
 DEFAULT_FROM_EMAIL = 'platform@cadasta.org'
+ROOT_URLCONF = 'config.urls.production'
 
 # Debug logging...
 LOGGING = {

--- a/cadasta/config/settings/travis.py
+++ b/cadasta/config/settings/travis.py
@@ -19,6 +19,7 @@ DJOSER.update({  # NOQA
     'SEND_ACTIVATION_EMAIL': False,
 })
 
+ROOT_URLCONF = 'config.urls.dev'
 DEFAULT_FILE_STORAGE = 'buckets.test.storage.FakeS3Storage'
 MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'core/media')
 MEDIA_URL = '/media/'

--- a/cadasta/config/urls/default.py
+++ b/cadasta/config/urls/default.py
@@ -14,8 +14,6 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
 from django.conf.urls import include, url
-from django.conf import settings
-from django.conf.urls.static import static
 
 api_v1 = [
     url(r'^account/', include('accounts.urls.api', namespace='accounts')),
@@ -92,6 +90,4 @@ urlpatterns = [
 
     url(r'^i18n/',
         include('django.conf.urls.i18n')),
-
-    url(r'', include('buckets.test.urls')),
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+]

--- a/cadasta/config/urls/dev.py
+++ b/cadasta/config/urls/dev.py
@@ -1,0 +1,9 @@
+from django.conf.urls import include, url
+from django.conf import settings
+from django.conf.urls.static import static
+
+
+urlpatterns = [
+    url(r'', include('config.urls.default')),
+    url(r'', include('buckets.test.urls')),
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/cadasta/config/urls/production.py
+++ b/cadasta/config/urls/production.py
@@ -1,0 +1,7 @@
+from django.conf.urls import include, url
+
+
+urlpatterns = [
+    url(r'', include('config.urls.default')),
+    url(r'', include('buckets.urls')),
+]


### PR DESCRIPTION
- Separates URL config into `dev` and `production` config, mainly because we can now include the correct URL config for dev and production from _django-buckets_
- Removes `ROOT_URLCONF` from default settings and adds specific `ROOT_URLCONF` to production, travis and dev configs