### PR TITLE
Fixes #319

### DIFF
--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -316,9 +316,14 @@ class ProjectDashboard(PermissionRequiredMixin, generic.DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(ProjectDashboard, self).get_context_data(**kwargs)
-        # TODO: Used for deciding whether to show statistics or
-        # "getting started".  Needs to be set up properly later on.
-        context['has_content'] = False
+        num_locations = self.object.spatial_units.count()
+        num_parties = self.object.parties.count()
+        num_resources = self.object.resource_set.count()
+        context['has_content'] = (
+            num_locations > 0 or num_parties > 0 or num_resources > 0)
+        context['num_locations'] = num_locations
+        context['num_parties'] = num_parties
+        context['num_resources'] = num_resources
         if self.object.extent is None:
             context['extent'] = False
         else:

--- a/cadasta/templates/organization/project_dashboard.html
+++ b/cadasta/templates/organization/project_dashboard.html
@@ -40,19 +40,36 @@
       <section>
         <h2>Project Overview</h2>
         <p>{{ object.description }}</p>
+        <div class="divider-thick"></div>
         {% if has_content %}
-          {% trans "Some statistics here..." %}
+          <h3 style="text-transform: capitalize;">{% trans "Summary" %}</h3>
+          <p>
+          {% blocktrans count counter=num_locations %}
+          This project currently has {{ counter }} location,
+          {% plural %}
+          This project currently has {{ counter }} locations,
+          {% endblocktrans %}
+          {% blocktrans count counter=num_parties %}
+          {{ counter }} party, and
+          {% plural %}
+          {{ counter }} parties, and
+          {% endblocktrans %}
+          {% blocktrans count counter=num_resources %}
+          {{ counter }} resource.
+          {% plural %}
+          {{ counter }} resources.
+          {% endblocktrans %}
+          </p>
         {% else %}
-          <div class="divider-thick"></div>
           <!-- Starter text -->
           <h3 style="text-transform: capitalize;">{% trans "Congratulations!" %}</h3> 
           <p>{% trans "You have successfully created your project.  You're now ready to add your first location." %}</p>
-          <div class="btn-full">
-            <a class="btn btn-primary btn-lg" href="{% url 'locations:add' object.organization.slug object.slug %}">
-              <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add a location" %}
-            </a>
-          </div>
         {% endif %}
+        <div class="btn-full">
+          <a class="btn btn-primary btn-lg" href="{% url 'locations:add' object.organization.slug object.slug %}">
+            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add a location" %}
+          </a>
+        </div>
       </section>
     </div>
     <!-- / overview detail -->


### PR DESCRIPTION
Adds rudimentary statistics (number of locations, parties, and resources) to the project overview page if there are any locations, parties, or resources in the project. Otherwise, the starter text is displayed.

Note that this does not yet implement the nice iconified statistics in the [Project Overview wireframe](https://drive.google.com/file/d/0BzpiEtMtHC3rWU5tQzZTeUFfTG8/view), nor display any data errors/warnings. This can be a future enhancement.