### PR TITLE
Fix permissions policies and tests (fixes #303)

### DIFF
--- a/cadasta/config/permissions/data-collector.json
+++ b/cadasta/config/permissions/data-collector.json
@@ -1,11 +1,9 @@
 {
   "clause": [
-    // In addition to the permissions provided by the default
-    // policy, data collectors are allowed to manage resources for a
-    // specified project within a specified organization.
     {
       "effect": "allow",
-      "action": ["resource.*"],
+      "action": ["resource.*", "spatial.*", "spatial_rel.*",
+                 "party.*", "party_rel.*", "tenure_rel.*"],
       "object": ["project/$organization/$project"]
     },
     {
@@ -16,17 +14,27 @@
 
     {
       "effect": "allow",
-      "action": ["spatial.*"],
+      "action": ["spatial.*", "spatial.resources.*"],
       "object": ["spatial/$organization/$project/*"]
     },
     {
       "effect": "allow",
-      "action": ["party.*"],
+      "action": ["spatial_rel.*"],
+      "object": ["spatial_rel/$organization/*/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["party.*", "party.resources.*"],
       "object": ["party/$organization/$project/*"]
     },
     {
       "effect": "allow",
-      "action": ["tenure_rel.*", "tenure_rel.*.*"],
+      "action": ["party_rel.*"],
+      "object": ["party_rel/$organization/$project/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["tenure_rel.*", "tenure_rel.resources.*"],
       "object": ["tenure_rel/$organization/$project/*"]
     }
   ]

--- a/cadasta/config/permissions/org-admin.json
+++ b/cadasta/config/permissions/org-admin.json
@@ -7,18 +7,20 @@
     // specified organization.
     {
       "effect": "allow",
-      "action": ["org.*", "org.*.*", "project.*", "project.*.*"],
+      "action": ["org.*", "org.users.*", "project.*"],
       "object": ["organization/$organization"]
     },
     {
       "effect": "allow",
-      "action": ["project.*", "project.*.*", "questionaire.*", "resource.*",
-                 "spatial.*", "spatial_rel.*", "party.*", "party_rel.*", "tenure_rel.*"],
+      "action": ["project.*", "project.users.*", "questionaire.*",
+                 "resource.*", "spatial.*", "spatial_rel.*",
+                 "party.*", "party_rel.*", "tenure_rel.*"],
       "object": ["project/$organization/*"]
     },
+
     {
       "effect": "allow",
-      "action": ["spatial.*"],
+      "action": ["spatial.*", "spatial.resources.*"],
       "object": ["spatial/$organization/*/*"]
     },
     {
@@ -28,7 +30,7 @@
     },
     {
       "effect": "allow",
-      "action": ["party.*"],
+      "action": ["party.*", "party.resources.*"],
       "object": ["party/$organization/*/*"]
     },
     {
@@ -38,29 +40,13 @@
     },
     {
       "effect": "allow",
-      "action": ["tenure_rel.*"],
+      "action": ["tenure_rel.*", "tenure_rel.resources.*"],
       "object": ["tenure_rel/$organization/*/*"]
     },
     {
       "effect": "allow",
       "action": ["resource.*"],
       "object": ["resource/$organization/*/*"]
-    },
-
-    {
-      "effect": "allow",
-      "action": ["spatial.*"],
-      "object": ["spatial/$organization/*/*"]
-    },
-    {
-      "effect": "allow",
-      "action": ["party.*"],
-      "object": ["party/$organization/*/*"]
-    },
-    {
-      "effect": "allow",
-      "action": ["tenure_rel.*", "tenure_rel.*.*"],
-      "object": ["tenure_rel/$organization/*/*"]
     }
   ]
 }

--- a/cadasta/config/permissions/org-member.json
+++ b/cadasta/config/permissions/org-member.json
@@ -6,18 +6,40 @@
     {
       "effect": "allow",
       "action": ["project.view_private",
-                 "spatial.list", "spatial.view",
-                 "spatial_rel.list", "spatial_rel.view",
-                 "party.list", "party.view",
-                 "party_rel.list", "party_rel.view",
-                 "tenure_rel.list", "tenure_rel.view"],
-      "object": ["project/$organization/*",
-                 "project/$organization/*/*",
-                 "spatial/$organization/*/*",
-                 "spatial_rel/$organization/*/*",
-                 "party/$organization/*/*",
-                 "party_rel/$organization/*/*",
-                 "tenure_rel/$organization/*/*"]
+                 "spatial.list", "spatial_rel.list",
+                 "party.list", "party_rel.list",
+                 "tenure_rel.list", "resource.list"],
+      "object": ["project/$organization/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["spatial.view"],
+      "object": ["spatial/$organization/*/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["spatial_rel.view"],
+      "object": ["spatial_rel/$organization/*/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["party.view"],
+      "object": ["party/$organization/*/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["party_rel.view"],
+      "object": ["party_rel/$organization/*/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["tenure_rel.view"],
+      "object": ["tenure_rel/$organization/*/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["resource.view"],
+      "object": ["resource/$organization/*/*"]
     }
   ]
 }

--- a/cadasta/config/permissions/project-manager.json
+++ b/cadasta/config/permissions/project-manager.json
@@ -7,13 +7,20 @@
     // organization.
     {
       "effect": "allow",
-      "action": ["project.*", "project.*.*", "questionaire.*", "spatial.*",
-                 "resource.*", "party.*", "tenure_rel.*"],
+      "action": ["project.*", "project.users.*", "questionaire.*",
+                 "resource.*", "spatial.*", "spatial_rel.*",
+                 "party.*", "party_rel.*", "tenure_rel.*"],
       "object": ["project/$organization/$project"]
     },
     {
+      "effect": "deny",
+      "action": ["project.archive", "project.unarchive", "questionaire.add"],
+      "object": ["project/$organization/$project"]
+    },
+
+    {
       "effect": "allow",
-      "action": ["spatial.*"],
+      "action": ["spatial.*", "spatial.resources.*"],
       "object": ["spatial/$organization/$project/*"]
     },
     {
@@ -23,7 +30,7 @@
     },
     {
       "effect": "allow",
-      "action": ["party.*"],
+      "action": ["party.*", "party.resources.*"],
       "object": ["party/$organization/$project/*"]
     },
     {
@@ -33,33 +40,13 @@
     },
     {
       "effect": "allow",
-      "action": ["tenure_rel.*"],
+      "action": ["tenure_rel.*", "tenure_rel.resources.*"],
       "object": ["tenure_rel/$organization/$project/*"]
     },
     {
       "effect": "allow",
       "action": ["resource.*"],
       "object": ["resource/$organization/$project/*"]
-    },
-    {
-      "effect": "deny",
-      "action": ["project.archive", "project.unarchive", "questionaire.add"],
-      "object": ["project/$organization/$project"]
-    },
-    {
-      "effect": "allow",
-      "action": ["spatial.*", "spatial.*.*"],
-      "object": ["spatial/$organization/$project/*"]
-    },
-    {
-      "effect": "allow",
-      "action": ["party.*", "party.*.*"],
-      "object": ["party/$organization/$project/*"]
-    },
-    {
-      "effect": "allow",
-      "action": ["tenure_rel.*", "tenure_rel.*.*"],
-      "object": ["tenure_rel/$organization/$project/*"]
     }
   ]
 }

--- a/cadasta/config/permissions/superuser.json
+++ b/cadasta/config/permissions/superuser.json
@@ -8,42 +8,82 @@
     },
     {
       "effect": "allow",
-      "action": ["org.*", "org.*.*"],
+      "action": ["org.*", "org.users.*"],
+      "object": ["organization/*"]
+    },
+
+    {
+      "effect": "allow",
+      "action": ["project.*"],
       "object": ["organization/*"]
     },
     {
       "effect": "allow",
-      "action": ["project.*", "project.*.*"],
-      "object": ["organization/*"]
+      "action": ["project.*", "project.users.*"],
+      "object": ["project/*/*"]
     },
-    {
-      "effect": "allow",
-      "action": ["project.*", "project.*.*", "resource.*",
-                 "spatial.*", "spatial_rel.*",
-                 "party.*", "party_rel.*", "tenure_rel.*"],
-      "object": ["project/*/*", "spatial/*/*/*", "spatial_rel/*/*/*",
-                 "party/*/*/*", "party_rel/*/*/*", "tenure_rel/*/*/*"]
-    },
+
     {
       "effect": "allow",
       "action": ["resource.*"],
-      "object": ["resource/*/*/*"]
+      "object": ["project/*/*", "resource/*/*/*"]
+    },
+
+    {
+      "effect": "allow",
+      "action": ["spatial.*"],
+      "object": ["project/*/*"]
     },
     {
       "effect": "allow",
-      "action": ["spatial.*", "spatial.*.*"],
+      "action": ["spatial.*", "spatial.resources.*"],
       "object": ["spatial/*/*/*"]
     },
+
     {
       "effect": "allow",
-      "action": ["party.*", "party.*.*"],
+      "action": ["spatial_rel.*"],
+      "object": ["project/*/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["spatial_rel.*"],
+      "object": ["spatial_rel/*/*/*"]
+    },
+
+    {
+      "effect": "allow",
+      "action": ["party.*"],
+      "object": ["project/*/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["party.*", "party.resources.*"],
       "object": ["party/*/*/*"]
     },
+
     {
       "effect": "allow",
-      "action": ["tenure_rel.*", "tenure_rel.*.*"],
+      "action": ["party_rel.*"],
+      "object": ["project/*/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["party_rel.*"],
+      "object": ["party_rel/*/*/*"]
+    },
+
+    {
+      "effect": "allow",
+      "action": ["tenure_rel.*"],
+      "object": ["project/*/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["tenure_rel.*", "tenure_rel.resources.*"],
       "object": ["tenure_rel/*/*/*"]
     },
+
     {
       "effect": "allow",
       "action": ["user.*"]

--- a/cadasta/party/models.py
+++ b/cadasta/party/models.py
@@ -117,6 +117,7 @@ class Party(ResourceModelMixin, RandomIDModel):
 
 
 @fix_model_for_attributes
+@permissioned_model
 class PartyRelationship(RandomIDModel):
     """
     PartyRelationship model.
@@ -182,6 +183,9 @@ class PartyRelationship(RandomIDModel):
         return "<PartyRelationship: <{party1}> {type} <{party2}>>".format(
             party1=self.party1.name, party2=self.party2.name,
             type=dict(self.TYPE_CHOICES).get(self.type))
+
+    def __repr__(self):
+        return str(self)
 
 
 @fix_model_for_attributes
@@ -267,6 +271,9 @@ class TenureRelationship(ResourceModelMixin, RandomIDModel):
         return "<TenureRelationship: <{party}> {type} <{su}>>".format(
             party=self.party.name, su=self.spatial_unit.name,
             type=self.tenure_type.label)
+
+    def __repr__(self):
+        return str(self)
 
 
 class TenureRelationshipType(models.Model):

--- a/cadasta/party/tests/test_models.py
+++ b/cadasta/party/tests/test_models.py
@@ -18,9 +18,6 @@ class PartyTest(TestCase):
     def test_str(self):
         party = PartyFactory.create(name='TeaParty')
         assert str(party) == '<Party: TeaParty>'
-
-    def test_repr(self):
-        party = PartyFactory.create(name='TeaParty')
         assert repr(party) == '<Party: TeaParty>'
 
     def test_has_random_id(self):
@@ -67,6 +64,8 @@ class PartyRelationshipTest(TestCase):
             party2__name='Mufasa',
             type='C')
         assert str(relationship) == (
+            "<PartyRelationship: <Simba> is-child-of <Mufasa>>")
+        assert repr(relationship) == (
             "<PartyRelationship: <Simba> is-child-of <Mufasa>>")
 
     def test_relationships_creation(self):
@@ -136,6 +135,8 @@ class TenureRelationshipTest(TestCase):
             spatial_unit__name='Parcel',
             tenure_type=tenure_type)
         assert str(relationship) == (
+            "<TenureRelationship: <Family> Leasehold <Parcel>>")
+        assert repr(relationship) == (
             "<TenureRelationship: <Family> Leasehold <Parcel>>")
 
     def test_tenure_relationship_creation(self):

--- a/cadasta/party/views/api.py
+++ b/cadasta/party/views/api.py
@@ -127,9 +127,6 @@ class PartyRelationshipCreate(APIPermissionRequiredMixin,
     permission_required = 'party_rel.create'
     serializer_class = serializers.PartyRelationshipWriteSerializer
 
-    def get_perms_objects(self):
-        return [self.get_project()]
-
 
 class PartyRelationshipDetail(APIPermissionRequiredMixin,
                               mixins.PartyRelationshipQuerySetMixin,
@@ -153,9 +150,6 @@ class PartyRelationshipDetail(APIPermissionRequiredMixin,
         self.get_object().delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    def get_perms_objects(self):
-        return [self.get_project()]
-
 
 class TenureRelationshipCreate(APIPermissionRequiredMixin,
                                mixins.TenureRelationshipQuerySetMixin,
@@ -176,9 +170,6 @@ class TenureRelationshipDetail(APIPermissionRequiredMixin,
         'PATCH': 'tenure_rel.update',
         'DELETE': 'tenure_rel.delete'
     }
-
-    def get_perms_objects(self):
-        return [self.get_project()]
 
     def get_serializer_class(self):
         if self.request.method == 'PATCH':

--- a/cadasta/party/views/mixins.py
+++ b/cadasta/party/views/mixins.py
@@ -102,10 +102,6 @@ class PartyRelationshipObjectMixin(ProjectMixin):
 
         return context
 
-    def get_queryset(self):
-        self.proj = self.get_project()
-        return self.proj.tenure_relationships.all()
-
     def get_object(self):
         try:
             return TenureRelationship.objects.get(
@@ -119,8 +115,10 @@ class PartyRelationshipObjectMixin(ProjectMixin):
 
 class PartyRelationshipResourceMixin(ResourceViewMixin,
                                      PartyRelationshipObjectMixin):
-    def get_content_object(self):
-        return self.get_object()
+    # UNUSED until party relationship list view is used
+    #
+    # def get_content_object(self):
+    #     return self.get_object()
 
     def get_form_kwargs(self, *args, **kwargs):
         kwargs = {

--- a/cadasta/spatial/models.py
+++ b/cadasta/spatial/models.py
@@ -87,6 +87,9 @@ class SpatialUnit(ResourceModelMixin, RandomIDModel):
     def __str__(self):
         return "<SpatialUnit: {}>".format(self.name)
 
+    def __repr__(self):
+        return str(self)
+
 
 class SpatialRelationshipManager(managers.BaseRelationshipManager):
     """Check conditions based on spatial unit type before creating
@@ -123,6 +126,7 @@ class SpatialRelationshipManager(managers.BaseRelationshipManager):
 
 
 @fix_model_for_attributes
+@permissioned_model
 class SpatialRelationship(RandomIDModel):
     """A relationship between spatial units: encodes simple logical terms
     like ``su1 is-contained-in su2`` or ``su1 is-split-of su2``.  May
@@ -185,3 +189,6 @@ class SpatialRelationship(RandomIDModel):
         return "<SpatialRelationship: <{su1}> {type} <{su2}>>".format(
             su1=self.su1.name, su2=self.su2.name,
             type=dict(self.TYPE_CHOICES).get(self.type))
+
+    def __repr__(self):
+        return str(self)

--- a/cadasta/spatial/tests/test_models.py
+++ b/cadasta/spatial/tests/test_models.py
@@ -14,6 +14,7 @@ class SpatialUnitTest(TestCase):
     def test_str(self):
         spatial_unit = SpatialUnitFactory.create(name='Disneyland')
         assert str(spatial_unit) == '<SpatialUnit: Disneyland>'
+        assert repr(spatial_unit) == '<SpatialUnit: Disneyland>'
 
     def test_has_random_id(self):
         spatial_unit = SpatialUnitFactory.create()
@@ -79,6 +80,10 @@ class SpatialRelationshipTest(TestCase):
             su2__name='California',
             type='C')
         assert str(relationship) == (
+            "<SpatialRelationship: "
+            "<Los Angeles> is-contained-in <California>>"
+        )
+        assert repr(relationship) == (
             "<SpatialRelationship: "
             "<Los Angeles> is-contained-in <California>>"
         )

--- a/cadasta/spatial/views/api.py
+++ b/cadasta/spatial/views/api.py
@@ -40,11 +40,6 @@ class SpatialUnitDetail(APIPermissionRequiredMixin,
         'DELETE': 'spatial.delete'
     }
 
-    def get_perms_objects(self):
-        # Talk to Brian about this. This should be the Spatial Unit not the
-        # project
-        return [self.get_project()]
-
     def destroy(self, request, *args, **kwargs):
         self.get_object().delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/cadasta/spatial/views/mixins.py
+++ b/cadasta/spatial/views/mixins.py
@@ -44,10 +44,6 @@ class SpatialQuerySetMixin(ProjectMixin):
 
 
 class SpatialRelationshipQuerySetMixin(ProjectMixin):
-
-    def get_perms_objects(self):
-        return [self.get_project()]
-
     def get_queryset(self):
         self.proj = self.get_project()
         return self.proj.spatial_relationships.all()

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -14,7 +14,7 @@ djangorestframework-gis==0.10.1
 jsonschema==2.5.1
 rfc3987==1.3.5
 drfdocs==0.0.9
-django-tutelary==0.1.13
+django-tutelary==0.1.14
 django-audit-log==0.7.0
 django-simple-history==1.8.1
 simplejson==3.8.1


### PR DESCRIPTION
@oliverroick and @wonderchook Could you review the permissions policies (in `cadasta/config/permissions`) to check that they tally with what you think different classes of user should be able to do?  I had to update a number of things, and I think it's now consistent and sensible, but it would be good for someone else to take a look.

By the way, you can get a full list of all the actions that are registered with tutelary by doing the following in the VM:

```
cd /vagrant/cadasta
./manage.py shell
from tutelary.engine import Action
print('\n'.join(sorted([str(a) for a in Action.registered])))
```

I've also had to comment out one method in the party relationships stuff to get the test coverage to 100%,  just because there's no UI to test that stuff against yet, so there's no way to exercise that code path.  (It was previously being incorrectly exercised because of https://github.com/Cadasta/django-tutelary/issues/28 -- that's now fixed, and this PR also updates the tutelary version to get the new behaviour for 404 exceptions and removes some redundant code that was only being called because 404 exceptions were being swallowed by tutelary.)