### PR TITLE
Fix #327: Allow Unicode slugs

### DIFF
--- a/cadasta/core/models.py
+++ b/cadasta/core/models.py
@@ -34,7 +34,7 @@ class SlugModel:
 
     def save(self, *args, **kwargs):
         if not self.slug:
-            self.slug = slugify(self.name)
+            self.slug = slugify(self.name, allow_unicode=True)
 
         orig = self.slug
 

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -106,7 +106,7 @@ class OrganizationForm(forms.ModelForm):
         is_create = not self.instance.id
         name = self.cleaned_data['name']
         invalid_names = settings.CADASTA_INVALID_ENTITY_NAMES
-        if is_create and slugify(name) in invalid_names:
+        if is_create and slugify(name, allow_unicode=True) in invalid_names:
             raise forms.ValidationError(
                 _("Organization name cannot be “Add” or “New”."))
         return name
@@ -225,7 +225,8 @@ class ProjectAddDetails(forms.Form):
 
     def clean_name(self):
         name = self.cleaned_data['name']
-        if slugify(name) in settings.CADASTA_INVALID_ENTITY_NAMES:
+        invalid_names = settings.CADASTA_INVALID_ENTITY_NAMES
+        if slugify(name, allow_unicode=True) in invalid_names:
             raise forms.ValidationError(
                 _("Project name cannot be “Add” or “New”."))
         return name

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -30,7 +30,7 @@ class OrganizationSerializer(DetailSerializer, FieldSelectorSerializer,
     def validate_name(self, value):
         is_create = not self.instance
         invalid_names = settings.CADASTA_INVALID_ENTITY_NAMES
-        if is_create and slugify(value) in invalid_names:
+        if is_create and slugify(value, allow_unicode=True) in invalid_names:
             raise serializers.ValidationError(
                 _("Organization name cannot be “Add” or “New”."))
         return value
@@ -55,7 +55,7 @@ class ProjectSerializer(DetailSerializer, serializers.ModelSerializer):
     def validate_name(self, value):
         is_create = not self.instance
         invalid_names = settings.CADASTA_INVALID_ENTITY_NAMES
-        if is_create and slugify(value) in invalid_names:
+        if is_create and slugify(value, allow_unicode=True) in invalid_names:
             raise serializers.ValidationError(
                 _("Project name cannot be “Add” or “New”."))
         return value

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -46,7 +46,6 @@ class OrganizationTest(UserTestCase):
     def test_add_organization(self):
         self._save(self.data)
         org = Organization.objects.first()
-
         assert org.slug == 'org'
         assert OrganizationRole.objects.filter(organization=org).count() == 1
 
@@ -69,16 +68,22 @@ class OrganizationTest(UserTestCase):
         assert org.urls == ['http://example.com']
 
     def test_add_organization_with_contact(self):
-        self.data['contacts-0-name'] = 'Ringo Starr'
+        self.data['contacts-0-name'] = "Ringo Starr"
         self.data['contacts-0-email'] = 'ringo@beatles.uk'
         self.data['contacts-0-tel'] = '555-5555'
         self._save(self.data)
         org = Organization.objects.first()
         assert org.contacts == [{
-            'name': 'Ringo Starr',
+            'name': "Ringo Starr",
             'tel': '555-5555',
             'email': 'ringo@beatles.uk'
         }]
+
+    def test_add_organization_with_unicode_slug(self):
+        self.data['name'] = "東京プロジェクト 2016"
+        self._save(self.data)
+        org = Organization.objects.first()
+        assert org.slug == '東京プロジェクト-2016'
 
     def test_add_organization_with_restricted_name(self):
         invalid_names = ('add', 'ADD', 'Add', 'new', 'NEW', 'New')

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -452,7 +452,8 @@ class ProjectAddWizard(LoginPermissionRequiredMixin, wizard.SessionWizardView):
 
         with transaction.atomic():
             project = Project.objects.create(
-                name=name, organization=org, slug=slugify(name),
+                name=name, organization=org,
+                slug=slugify(name, allow_unicode=True),
                 description=description, urls=[url], extent=extent,
                 access=access
             )


### PR DESCRIPTION
- Add `allow_unicode=True` option to all `slugify()` calls
- Add a few unit tests to check that this option is being applied