### PR TITLE
Fix for #205: "Users" menu visibility

### DIFF
--- a/cadasta/accounts/load.py
+++ b/cadasta/accounts/load.py
@@ -19,4 +19,9 @@ def run(verbose=True):
             body=open(PERMISSIONS_DIR + pol + '.json').read()
         )
 
+    models.Role.objects.create(
+        name='superuser',
+        policies=[pols['default'], pols['superuser']]
+    )
+
     models.assign_user_policies(None, pols['default'])

--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -44,6 +44,7 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
     REQUIRED_FIELDS = ['email', 'full_name']
 
     class Meta:
+        ordering = ('username',)
         verbose_name = _('user')
         verbose_name_plural = _('users')
 

--- a/cadasta/config/permissions/data-collector.json
+++ b/cadasta/config/permissions/data-collector.json
@@ -20,7 +20,7 @@
     {
       "effect": "allow",
       "action": ["spatial_rel.*"],
-      "object": ["spatial_rel/$organization/*/*"]
+      "object": ["spatial_rel/$organization/$project/*"]
     },
     {
       "effect": "allow",

--- a/cadasta/core/fixtures.py
+++ b/cadasta/core/fixtures.py
@@ -2,15 +2,15 @@ from datetime import datetime, timezone
 
 from accounts.models import User
 from accounts.tests.factories import UserFactory
-from core.tests.factories import RoleFactory
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.geos import GEOSGeometry
 from faker import Factory
 from jsonattrs.models import Attribute, Schema, AttributeType
 from organization.models import Organization, OrganizationRole, Project
 from organization.tests.factories import OrganizationFactory, ProjectFactory
-from spatial.tests.factories import (SpatialUnitFactory,
-                                     SpatialRelationshipFactory)
+from spatial.tests.factories import (
+    SpatialUnitFactory, SpatialRelationshipFactory
+)
 from tutelary.models import Policy, PolicyInstance, Role, RolePolicyAssign
 
 
@@ -62,10 +62,7 @@ class FixturesData:
             pols[pol] = Policy.objects.get(name=pol)
 
         roles = {}
-        roles['superuser'] = RoleFactory.create(
-            name='superuser',
-            policies=[pols['default'], pols['superuser']]
-        )
+        roles['superuser'] = Role.objects.get(name='superuser')
         users[0].assign_policies(roles['superuser'])
         users[1].assign_policies(roles['superuser'])
 

--- a/cadasta/core/tests/test_views_default.py
+++ b/cadasta/core/tests/test_views_default.py
@@ -6,9 +6,8 @@ from django.template import RequestContext
 from django.template.loader import render_to_string
 
 from core.tests.base_test_case import UserTestCase
-from tutelary.models import Policy
+from tutelary.models import Role
 from accounts.tests.factories import UserFactory
-from core.tests.factories import RoleFactory
 from organization.tests.factories import OrganizationFactory, ProjectFactory
 from organization.models import OrganizationRole, Project
 from organization.serializers import ProjectGeometrySerializer
@@ -77,6 +76,7 @@ class DashboardTest(UserTestCase):
         context['geojson'] = json.dumps(
             ProjectGeometrySerializer(projects, many=True).data
         )
+        context['is_superuser'] = superuser
         expected = render_to_string(
             'core/dashboard.html',
             context
@@ -111,10 +111,7 @@ class DashboardTest(UserTestCase):
 
     def test_get_with_superuser(self):
         superuser = UserFactory.create()
-        superuser_pol = Policy.objects.get(name='superuser')
-        self.superuser_role = RoleFactory.create(
-            name='superuser', policies=[superuser_pol]
-        )
+        self.superuser_role = Role.objects.get(name='superuser')
         superuser.assign_policies(self.superuser_role)
         setattr(self.request, 'user', superuser)
         response = self.view(self.request).render()

--- a/cadasta/core/views/default.py
+++ b/cadasta/core/views/default.py
@@ -1,7 +1,7 @@
 import json
 
 from django.shortcuts import redirect
-from django.views.generic import TemplateView
+from core.views.generic import TemplateView
 from organization.models import Project, Organization
 from tutelary.models import Role
 

--- a/cadasta/core/views/generic.py
+++ b/cadasta/core/views/generic.py
@@ -1,0 +1,27 @@
+import django.views.generic as base
+
+from .mixins import SuperUserCheckMixin
+
+
+class TemplateView(SuperUserCheckMixin, base.TemplateView):
+    pass
+
+
+class ListView(SuperUserCheckMixin, base.ListView):
+    pass
+
+
+class DetailView(SuperUserCheckMixin, base.DetailView):
+    pass
+
+
+class CreateView(SuperUserCheckMixin, base.CreateView):
+    pass
+
+
+class UpdateView(SuperUserCheckMixin, base.UpdateView):
+    pass
+
+
+class DeleteView(SuperUserCheckMixin, base.DeleteView):
+    pass

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -262,10 +262,7 @@ class ProjectEditDetails(forms.ModelForm):
 class PermissionsForm:
     def check_admin(self, user):
         if not hasattr(self, 'su_role'):
-            try:
-                self.su_role = Role.objects.get(name='superuser')
-            except Role.DoesNotExist:
-                self.su_role = None
+            self.su_role = Role.objects.get(name='superuser')
 
         if not hasattr(self, 'admins'):
             self.admins = [

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -7,14 +7,13 @@ from django.conf import settings
 
 from buckets.test import utils as bucket_uitls
 from buckets.test.storage import FakeS3Storage
-from tutelary.models import Policy
+from tutelary.models import Role
 
 from .. import forms
 from ..models import Organization, OrganizationRole, ProjectRole
 from .factories import OrganizationFactory, ProjectFactory
 
 from core.tests.base_test_case import UserTestCase
-from core.tests.factories import RoleFactory
 from questionnaires.tests.factories import QuestionnaireFactory
 from questionnaires.exceptions import InvalidXLSForm
 from accounts.tests.factories import UserFactory
@@ -425,11 +424,7 @@ class ProjectEditPermissionsTest(UserTestCase):
         OrganizationRole.objects.create(user=self.super_user,
                                         organization=self.project.organization,
                                         admin=False)
-        su_pol = Policy.objects.get(name='superuser')
-        su_role = RoleFactory.create(
-            name='superuser',
-            policies=[su_pol]
-        )
+        su_role = Role.objects.get(name='superuser')
         self.super_user.assign_policies(su_role)
 
         self.org_admin = UserFactory.create()

--- a/cadasta/organization/tests/test_views_api_projects.py
+++ b/cadasta/organization/tests/test_views_api_projects.py
@@ -9,10 +9,11 @@ from tutelary.models import Policy, assign_user_policies
 
 from core.tests.base_test_case import UserTestCase
 from accounts.tests.factories import UserFactory
-from core.tests.factories import RoleFactory
 from .factories import OrganizationFactory, ProjectFactory, clause
 from ..models import Project, ProjectRole, OrganizationRole
 from ..views import api
+
+from tutelary.models import Role
 
 
 class ProjectUsersAPITest(UserTestCase):
@@ -385,8 +386,7 @@ class ProjectListAPITest(UserTestCase):
         assign_user_policies(self.user, policy)
 
         self.super_user = UserFactory.create()
-        su_pol = Policy.objects.get(name='superuser')
-        su_role = RoleFactory.create(name='superuser', policies=[su_pol])
+        su_role = Role.objects.get(name='superuser')
         self.super_user.assign_policies(su_role)
 
     def _get(self, user=None, query=None, status=None, length=None):

--- a/cadasta/organization/tests/test_views_default_users.py
+++ b/cadasta/organization/tests/test_views_default_users.py
@@ -65,10 +65,16 @@ class UserListTest(UserTestCase):
         expected = render_to_string(
             'organization/user_list.html',
             {'object_list': users,
-             'user': self.request.user},
+             'user': self.request.user,
+             'is_superuser': False},
             request=self.request)
 
         assert response.status_code == 200
+        if expected != content:
+            with open('expected.txt', 'w') as fp:
+                print(expected, file=fp)
+            with open('content.txt', 'w') as fp:
+                print(content, file=fp)
         assert expected == content
 
     def test_get_with_unauthorized_user(self):

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -1,16 +1,16 @@
 import os
 from django.http import Http404, HttpResponse
 from django.db import transaction
-import django.views.generic as generic
 from django.shortcuts import redirect, get_object_or_404
+import django.views.generic as base_generic
 from django.core.urlresolvers import reverse
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
 from django.contrib import messages
 
 import formtools.wizard.views as wizard
-from tutelary.models import Role
 
+import core.views.generic as generic
 from core.mixins import PermissionRequiredMixin, LoginPermissionRequiredMixin
 from core.views.mixins import ArchiveMixin
 from accounts.models import User
@@ -21,14 +21,6 @@ from ..models import Organization, Project, OrganizationRole, ProjectRole
 from . import mixins
 from .. import forms
 from .. import messages as error_messages
-
-
-def check_if_superuser(self):
-    superuser = Role.objects.filter(name='superuser')
-    if len(superuser) > 0:
-        if hasattr(self.request.user, 'assigned_policies'):
-            return superuser[0] in self.request.user.assigned_policies()
-    return False
 
 
 class OrganizationList(PermissionRequiredMixin, generic.ListView):
@@ -59,7 +51,8 @@ class OrganizationAdd(LoginPermissionRequiredMixin, generic.CreateView):
         return kwargs
 
 
-class OrganizationDashboard(PermissionRequiredMixin, generic.DetailView):
+class OrganizationDashboard(PermissionRequiredMixin,
+                            generic.DetailView):
     model = Organization
     template_name = 'organization/organization_dashboard.html'
     permission_required = 'org.view'
@@ -67,7 +60,7 @@ class OrganizationDashboard(PermissionRequiredMixin, generic.DetailView):
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
         context = self.get_context_data()
-        if check_if_superuser(self):
+        if self.is_superuser:
             projects = self.object.all_projects()
         else:
             projects = self.object.public_projects()
@@ -158,7 +151,7 @@ class OrganizationMembersAdd(mixins.OrganizationMixin,
 
 class OrganizationMembersEdit(mixins.OrganizationMixin,
                               LoginPermissionRequiredMixin,
-                              generic.edit.FormMixin,
+                              base_generic.edit.FormMixin,
                               generic.DetailView):
     slug_field = 'username'
     slug_url_kwarg = 'username'
@@ -245,7 +238,7 @@ class UserList(LoginPermissionRequiredMixin, generic.ListView):
         return context
 
 
-class UserActivation(LoginPermissionRequiredMixin, generic.View):
+class UserActivation(LoginPermissionRequiredMixin, base_generic.View):
     permission_required = 'user.update'
     permission_denied_message = error_messages.USERS_UPDATE
     new_state = None
@@ -260,8 +253,8 @@ class UserActivation(LoginPermissionRequiredMixin, generic.View):
         return redirect('user:list')
 
 
-class ProjectList(PermissionRequiredMixin, mixins.ProjectQuerySetMixin,
-                  generic.ListView):
+class ProjectList(PermissionRequiredMixin,
+                  mixins.ProjectQuerySetMixin, generic.ListView):
     model = Project
     template_name = 'organization/project_list.html'
     permission_required = 'project.list'
@@ -276,7 +269,7 @@ class ProjectList(PermissionRequiredMixin, mixins.ProjectQuerySetMixin,
 
     def get(self, request, *args, **kwargs):
         if (hasattr(self.request.user, 'assigned_policies') and
-           check_if_superuser(self)):
+           self.is_superuser):
                 projects = Project.objects.all()
         else:
             projects = []
@@ -363,6 +356,8 @@ def add_wizard_permission_required(self, view, request):
     else:
         return 'project.create'
 
+
+# ===> TODO: ADD SUPER-USER CHECK HERE
 
 class ProjectAddWizard(LoginPermissionRequiredMixin, wizard.SessionWizardView):
     permission_required = add_wizard_permission_required
@@ -548,7 +543,7 @@ class ProjectUnarchive(ProjectEdit, ArchiveMixin, generic.DetailView):
 
 class ProjectDataDownload(mixins.ProjectMixin,
                           LoginPermissionRequiredMixin,
-                          generic.edit.FormMixin,
+                          base_generic.edit.FormMixin,
                           generic.DetailView):
     template_name = 'organization/project_download.html'
     permission_required = 'project.download'

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -68,10 +68,7 @@ class ProjectRoles(ProjectMixin):
 class ProjectQuerySetMixin:
     def get_queryset(self):
         if not hasattr(self, 'su_role'):
-            try:
-                self.su_role = Role.objects.get(name='superuser')
-            except Role.DoesNotExist:
-                self.su_role = None
+            self.su_role = Role.objects.get(name='superuser')
 
         if (not isinstance(self.request.user, AnonymousUser) and
             any([isinstance(pol, Role) and pol == self.su_role

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -74,12 +74,14 @@
                 <a href="{% url 'organization:list' %}">
                   {% trans "Organizations" %}
                 </a>
-              </li><!--
-              --><li class="users">
+              </li>
+              {% if is_superuser %}
+              <li class="users">
                 <a href="{% url 'user:list' %}">
                   {% trans "Users" %}
                 </a>
               </li>
+              {% endif %}
             </ul>
             <!-- Hamburger -->
             <div class="dropdown pull-right btn-group btn-hamburger visible-xs-inline visible-sm-inline">

--- a/functional_tests/base.py
+++ b/functional_tests/base.py
@@ -1,5 +1,4 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from django.conf import settings
 
 import time
 import re
@@ -10,7 +9,6 @@ import random
 
 from urllib.parse import urlparse
 from selenium import webdriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.common.exceptions import (
     NoSuchElementException, WebDriverException, TimeoutException,
     ElementNotVisibleException
@@ -19,9 +17,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-from tutelary.models import Policy
+from tutelary.models import Role
 from accounts.tests.factories import UserFactory
-from core.tests.factories import PolicyFactory, RoleFactory
 from organization.tests.factories import OrganizationFactory, ProjectFactory
 from organization.models import OrganizationRole
 
@@ -38,7 +35,7 @@ class FunctionalTest(StaticLiveServerTestCase):
         super(FunctionalTest, cls).setUpClass()
 
         # IMPORTANT: Make sure the window size is big enough to see
-        # everything (e.g. links in the nav bar).  
+        # everything (e.g. links in the nav bar).
         cls.browser = webdriver.Firefox()
         cls.browser.set_window_size(1024, 768)
 
@@ -305,10 +302,7 @@ class FunctionalTest(StaticLiveServerTestCase):
 
         # Create superuser policy and role if not yet created
         if not self.superuser_role:
-            superuser_pol = Policy.objects.get(name='superuser')
-            self.superuser_role = RoleFactory.create(
-                name='superuser', policies=[superuser_pol]
-            )
+            self.superuser_role = Role.objects.get(name='superuser')
 
         superuser.assign_policies(self.superuser_role)
         return superuser

--- a/functional_tests/pages/Dashboard.py
+++ b/functional_tests/pages/Dashboard.py
@@ -1,3 +1,5 @@
+from selenium.common.exceptions import NoSuchElementException
+
 from .base import Page
 
 
@@ -19,3 +21,11 @@ class DashboardPage(Page):
 
     def get_dashboard_map(self):
         return self.browser.find_element_by_id('dashboard-map')
+
+    def has_nav_link(self, title):
+        try:
+            return self.browser.find_element_by_xpath(
+                '//nav'
+            ).find_element_by_link_text(title)
+        except NoSuchElementException:
+            return None

--- a/functional_tests/projects/test_project_list_contents.py
+++ b/functional_tests/projects/test_project_list_contents.py
@@ -4,6 +4,8 @@ from pages.Login import LoginPage
 from common_test_data.common_test_data_1 import get_test_data
 from core.tests.factories import PolicyFactory
 
+# from accounts.models import User
+
 
 class ProjectListContentsTest(FunctionalTest):
 
@@ -83,6 +85,8 @@ class ProjectListContentsTest(FunctionalTest):
 
             # Log in as the selected user, check the list, log out
             LoginPage(self).login(user['username'], user['password'])
+            # u = User.objects.get(username=user['username'])
+            # print(user['username'], '=>', u.assigned_policies())
             self.check_project_list(user_type, parent_org_idxs)
             self.logout()
 

--- a/functional_tests/users/test_page_access.py
+++ b/functional_tests/users/test_page_access.py
@@ -6,7 +6,6 @@ from core.tests.factories import PolicyFactory
 
 
 class PageAccessTest(FunctionalTest):
-
     def setUp(self):
         super().setUp()
         PolicyFactory.load_policies()
@@ -61,3 +60,39 @@ class PageAccessTest(FunctionalTest):
         )
         UsersPage(self).go_to()
         assert UsersPage(self).is_on_page()
+
+    def test_user_list_link_nonloggedin_user(self):
+        """A non-logged-in superuser should NOT see the "Users" link in the
+        navbar.
+
+        """
+        DashboardPage(self).go_to()
+        self.get_screenshot('dash')
+        ulink = DashboardPage(self).has_nav_link('Users')
+        print(ulink)
+        plink = DashboardPage(self).has_nav_link('Projects')
+        print(plink)
+        assert not DashboardPage(self).has_nav_link('Users')
+
+    def test_user_list_link_nonsuperuser(self):
+        """A logged-in non-superuser should NOT see the "Users" link in the
+        navbar.
+
+        """
+        LoginPage(self).login(
+            self.test_data['user1']['username'],
+            self.test_data['user1']['password'],
+        )
+        DashboardPage(self).go_to()
+        assert not DashboardPage(self).has_nav_link('Users')
+
+    def test_user_list_link_superuser(self):
+        """A logged-in superuser should see the "Users" link in the navbar.
+
+        """
+        LoginPage(self).login(
+            self.test_data['superuser']['username'],
+            self.test_data['superuser']['password'],
+        )
+        DashboardPage(self).go_to()
+        assert DashboardPage(self).has_nav_link('Users')

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -14,7 +14,7 @@ djangorestframework-gis==0.10.1
 jsonschema==2.5.1
 rfc3987==1.3.5
 drfdocs==0.0.9
-django-tutelary==0.1.14
+django-tutelary==0.1.16
 django-audit-log==0.7.0
 django-simple-history==1.8.1
 simplejson==3.8.1


### PR DESCRIPTION
This required adding a "superuser check" mixin to many of the view classes.  That turned up a problem in django-tutelary that meant that the superuser checks added in the mixin slowed the platform down a lot.
The tutelary bug was fixed and the tutelary version bumped here to take account of that.