### PR TITLE
Fix #328: Slug length control with custom slugify

### DIFF
--- a/cadasta/core/models.py
+++ b/cadasta/core/models.py
@@ -1,4 +1,5 @@
 import itertools
+import math
 from core.util import slugify
 from django.db import models
 
@@ -45,11 +46,8 @@ class SlugModel:
             for x in itertools.count(1):
                 if not type(self).objects.filter(slug=self.slug).exists():
                     break
-                if x == 1 or x % 10 == 0:
-                    max_length -= 1
-                    if x == 1:
-                        max_length -= 1
-                    orig = self.slug[:max_length]
+                slug_length = max_length - int(math.log10(x)) - 2
+                orig = self.slug[:slug_length]
                 self.slug = '{}-{}'.format(orig, x)
 
         self.__original_slug = self.slug

--- a/cadasta/core/tests/test_models.py
+++ b/cadasta/core/tests/test_models.py
@@ -135,3 +135,18 @@ class SlugModelTest(TestCase):
         assert instance2.slug[-2:] == '-1'
         print(instance1.slug)
         print(instance2.slug)
+
+    def test_duplicate_slug_long_name_ten_times(self):
+        for i in range(0, 100):
+            instance = MySlugModel()
+            instance.name = ('Very Long Name For The Purposes of Testing '
+                             'That Slug Truncation Functions Correctly')
+            instance.save()
+
+        instance = MySlugModel()
+        instance.name = ('Very Long Name For The Purposes of '
+                         'Testing That Slug Truncation Functions Correctly')
+        instance.save()
+
+        assert MySlugModel.objects.count() == 101
+        assert instance.slug[-4:] == '-100'

--- a/cadasta/core/tests/test_models.py
+++ b/cadasta/core/tests/test_models.py
@@ -28,7 +28,7 @@ class RandomIDModelTest(TestCase):
 
 
 class MySlugModel(SlugModel, Model):
-    name = CharField(max_length=50)
+    name = CharField(max_length=100)
     slug = SlugField(max_length=50, unique=True)
 
     class Meta:
@@ -109,3 +109,29 @@ class SlugModelTest(TestCase):
         instance.refresh_from_db()
         assert instance.name == 'Other Name'
         assert instance.slug == 'test-name'
+
+    def test_create_with_long_name(self):
+        instance = MySlugModel()
+        instance.name = ('Very Long Name For The Purposes of '
+                         'Testing That Slug Truncation Functions Correctly')
+        instance.save()
+
+        assert len(instance.slug) == 50
+
+    def test_duplicate_slug_long_name(self):
+        instance1 = MySlugModel()
+        instance1.name = ('Very Long Name For The Purposes of '
+                          'Testing That Slug Truncation Functions Correctly')
+        instance1.save()
+
+        instance2 = MySlugModel()
+        instance2.name = ('Very Long Name For The Purposes of '
+                          'Testing That Slug Truncation Functions Correctly')
+        instance2.save()
+
+        instance1.refresh_from_db()
+        instance2.refresh_from_db()
+        assert instance1.slug != instance2.slug
+        assert instance2.slug[-2:] == '-1'
+        print(instance1.slug)
+        print(instance2.slug)

--- a/cadasta/core/util.py
+++ b/cadasta/core/util.py
@@ -1,5 +1,6 @@
 import random
 import string
+import django.utils.text as base_utils
 
 
 ID_FIELD_LENGTH = 24
@@ -17,3 +18,10 @@ def byte_to_base32_chr(byte):
 def random_id():
     rand_id = [random.randint(0, 0xFF) for i in range(ID_FIELD_LENGTH)]
     return ''.join(map(byte_to_base32_chr, rand_id))
+
+
+def slugify(text, max_length=None, allow_unicode=False):
+    slug = base_utils.slugify(text, allow_unicode=allow_unicode)
+    if max_length is not None:
+        slug = slug[:max_length]
+    return slug

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -4,7 +4,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.postgres import forms as pg_forms
 from django.contrib.gis import forms as gisforms
-from django.utils.text import slugify
+from core.util import slugify
 from django.utils.translation import ugettext as _
 from django.db import transaction
 

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.db.models import Q
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
-from django.utils.text import slugify
+from core.util import slugify
 from django.utils.translation import ugettext as _
 from django.template.loader import get_template
 from django.template import Context

--- a/cadasta/organization/tests/test_serializers.py
+++ b/cadasta/organization/tests/test_serializers.py
@@ -1,7 +1,7 @@
 import random
 import pytest
 from datetime import datetime
-from django.utils.text import slugify
+from core.util import slugify
 from django.test import TestCase
 from django.utils.translation import gettext as _
 from django.core import mail

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -4,7 +4,7 @@ from django.db import transaction
 import django.views.generic as generic
 from django.shortcuts import redirect, get_object_or_404
 from django.core.urlresolvers import reverse
-from django.utils.text import slugify
+from core.util import slugify
 from django.utils.translation import gettext as _
 from django.contrib import messages
 


### PR DESCRIPTION
Slugs are only allowed to have the maximum length specified in the `SlugField` field, with uniqueness maintained at the same time as the length constraint.