### PR TITLE
Fixes #374 -- Check mime type of uploaded file

### DIFF
--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -21,6 +21,11 @@ from .download.xls import XLSExporter
 from .download.resources import ResourceExporter
 
 FORM_CHOICES = ROLE_CHOICES + (('Pb', _('Public User')),)
+QUESTIONNAIRE_TYPES = [
+    'application/msexcel',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+]
 
 
 def create_update_or_delete_project_role(project, user, role):
@@ -213,7 +218,10 @@ class ProjectAddDetails(forms.Form):
     description = forms.CharField(required=False, widget=forms.Textarea)
     access = PublicPrivateField(initial='public')
     url = forms.URLField(required=False)
-    questionaire = forms.CharField(required=False, widget=S3FileUploadWidget)
+    questionaire = forms.CharField(
+        required=False,
+        widget=S3FileUploadWidget(upload_to='xls-forms',
+                                  accepted_types=QUESTIONNAIRE_TYPES))
     contacts = ContactsField(form=ContactsForm, required=False)
 
     def __init__(self, *args, **kwargs):
@@ -234,7 +242,10 @@ class ProjectAddDetails(forms.Form):
 
 class ProjectEditDetails(forms.ModelForm):
     urls = pg_forms.SimpleArrayField(forms.URLField(), required=False)
-    questionnaire = forms.CharField(required=False, widget=S3FileUploadWidget)
+    questionnaire = forms.CharField(
+        required=False,
+        widget=S3FileUploadWidget(upload_to='xls-forms',
+                                  accepted_types=QUESTIONNAIRE_TYPES))
     access = PublicPrivateField()
     contacts = ContactsField(form=ContactsForm, required=False)
 

--- a/cadasta/resources/forms.py
+++ b/cadasta/resources/forms.py
@@ -3,10 +3,13 @@ from django.contrib.contenttypes.models import ContentType
 from buckets.widgets import S3FileUploadWidget
 from .models import Resource, ContentObject
 from .fields import ResourceField
+from .validators import ACCEPTED_TYPES
 
 
 class ResourceForm(forms.ModelForm):
-    file = forms.CharField(widget=S3FileUploadWidget(upload_to='resources'))
+    file = forms.CharField(
+        widget=S3FileUploadWidget(upload_to='resources',
+                                  accepted_types=ACCEPTED_TYPES))
 
     class Meta:
         model = Resource

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,7 +19,7 @@ django-audit-log==0.7.0
 django-simple-history==1.8.1
 simplejson==3.8.1
 django-widget-tweaks==1.4.1
-django-buckets==0.1.10
+django-buckets==0.1.11
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.2.0


### PR DESCRIPTION
- Upgrades django-buckets to 0.1.11, which introduces client-side file type validation
- Adapts questionnaire and resources forms by add `accepted_types` to the file upload widget