### PR TITLE
Fixes #276 and #377

### DIFF
--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -5,6 +5,7 @@ from django.core.urlresolvers import reverse
 
 from core.mixins import LoginPermissionRequiredMixin
 
+from organization.serializers import ProjectGeometrySerializer
 from resources.forms import AddResourceFromLibraryForm
 from party.models import TenureRelationship
 from party.messages import TENURE_REL_CREATE
@@ -53,6 +54,15 @@ class LocationsAdd(LoginPermissionRequiredMixin,
             )
 
         return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super(LocationsAdd, self).get_context_data(**kwargs)
+        project = self.get_project()
+        context['extent'] = project.extent is not None
+        context['extent_geojson'] = json.dumps(
+            ProjectGeometrySerializer(project).data
+        )
+        return context
 
 
 class LocationDetail(LoginPermissionRequiredMixin,

--- a/cadasta/templates/spatial/location_add.html
+++ b/cadasta/templates/spatial/location_add.html
@@ -28,6 +28,7 @@
       var map = e.originalEvent.detail.map;
       add_map_controls(map);
 
+      // Add locations, if any
       var data = {{ geojson|safe }};
 
       var geoJson = L.geoJson(null, {
@@ -42,12 +43,32 @@
 
       L.Deflate(map, {minSize: 20, layerGroup: geoJson});
       geoJson.addData(data);
-
       var markerGroup = L.markerClusterGroup.layerSupport()
       markerGroup.addTo(map);
       markerGroup.checkIn(geoJson);
       geoJson.addTo(map);
-      map.fitBounds(geoJson.getBounds());
+
+      {% if extent %}
+      // Add project extent
+      var extent = {{ extent_geojson|safe }};
+      var extentGeoJson = L.geoJson(extent, {
+        style: {
+          "color": "#ff0000",
+          "weight": 2,
+          "opacity": 0.4,
+          "fill": true,
+          "fillColor": "#ff0000",
+          "fillOpacity": 0.2,
+        },
+        clickable: false,
+      }).addTo(map);
+
+      map.fitBounds(extentGeoJson.getBounds());
+      {% else %}
+      // TODO: It seems Leaflet has a bug with L.geoJson()
+      // not returning the correct bounds (see #377 for details)
+      map.fitBounds(L.geoJson(data).getBounds());
+      {% endif %}
    });
  });
 </script>

--- a/cadasta/templates/spatial/location_map.html
+++ b/cadasta/templates/spatial/location_map.html
@@ -37,7 +37,9 @@
     markerGroup.addTo(map);
     markerGroup.checkIn(geoJson);
     geoJson.addTo(map);
-    map.fitBounds(geoJson.getBounds());
+    // TODO: It seems Leaflet has a bug with L.geoJson()
+    // not returning the correct bounds (see #377 for details)
+    map.fitBounds(L.geoJson(data).getBounds());
   }
 </script>
 {% endblock %}


### PR DESCRIPTION
- If the project extent exists, add it to the add location page map and fit it to the map view (fixes #276)
- Apply Leaflet workaround to ensure locations fit into the map view (fixes #377)