### PR TITLE
Fixes #387: new command to replace default site object

### DIFF
--- a/cadasta/core/management/commands/loadeverything.py
+++ b/cadasta/core/management/commands/loadeverything.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+
+from core.management.commands import loadfixtures, loadsite
+from accounts.management.commands import loadpolicies
+from geography.management.commands import loadcountries
+
+
+class Command(BaseCommand):
+    help = """Load in all site, country, policy and test data."""
+
+    def handle(self, *args, **options):
+        loadsite.Command().handle()
+        loadcountries.Command().handle()
+        loadpolicies.Command().handle()
+        loadfixtures.Command().handle(delete=False)

--- a/cadasta/core/management/commands/loadsite.py
+++ b/cadasta/core/management/commands/loadsite.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+from django.contrib.sites.models import Site
+
+
+class Command(BaseCommand):
+    help = """Loads initial site object for Cadasta.org."""
+
+    def handle(self, *args, **options):
+        if not Site.objects.filter(name='Cadasta').exists():
+            site = Site.objects.get(name='example.com')
+            site.name = 'Cadasta'
+            site.domain = 'platform.cadasta.org'
+            site.save()
+            return "Successfully loaded Cadasta.org object"
+        else:
+            return "Cadasta.org object already exists."

--- a/cadasta/core/tests/test_management_commands.py
+++ b/cadasta/core/tests/test_management_commands.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.contrib.sites.models import Site
 
 from core.tests.factories import PolicyFactory
 from ..fixtures import FixturesData
@@ -6,6 +7,7 @@ from tutelary.models import Policy
 from accounts.models import User
 from organization.models import Organization, Project
 from spatial.models import SpatialUnit, SpatialRelationship
+from core.management.commands import loadsite
 
 
 class FixturesTest(TestCase):
@@ -36,3 +38,14 @@ class FixturesTest(TestCase):
         assert Project.objects.count() == 0
         assert SpatialUnit.objects.count() == 0
         assert SpatialRelationship.objects.count() == 0
+
+
+class LoadSiteTest(TestCase):
+    def test_default_site_replacement(self):
+        assert Site.objects.filter(name='example.com').exists()
+        loadsite.Command().handle()
+        assert len(Site.objects.all()) == 1
+        assert Site.objects.filter(name='Cadasta').exists()
+        response = loadsite.Command().handle()
+        assert len(Site.objects.all()) == 1
+        assert response == "Cadasta.org object already exists."

--- a/provision/roles/cadasta/application/tasks/main.yml
+++ b/provision/roles/cadasta/application/tasks/main.yml
@@ -99,6 +99,22 @@
                  virtualenv="{{ virtualenv_path }}"
                  settings="{{ django_settings }}"
 
+- name: Load site object
+  become: yes
+  become_user: "{{ app_user }}"
+  django_manage: command=loadsite
+                 app_path="{{ application_path }}cadasta"
+                 virtualenv="{{ virtualenv_path }}"
+                 settings="{{ django_settings }}"
+
+- name: Load all data
+  become: yes
+  become_user: "{{ app_user }}"
+  django_manage: command=loadeverything
+                 app_path="{{ application_path }}cadasta"
+                 virtualenv="{{ virtualenv_path }}"
+                 settings="{{ django_settings }}"
+
 - name: Install Bootstrap for SASS processing
   become: yes
   become_user: "{{ app_user }}"


### PR DESCRIPTION
added `loadeverything` command which runs:
```
loadsite
loadcountries
loadpolicies
loadfixtures(delete=false)
```
It can be run after dropping the database and migrating.