### PR TITLE
Fixes #369 — Fixes permission denied redirects

### DIFF
--- a/cadasta/core/tests/test_mixins.py
+++ b/cadasta/core/tests/test_mixins.py
@@ -1,0 +1,148 @@
+from django.http import HttpRequest
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.core.urlresolvers import reverse
+
+from tutelary.models import assign_user_policies
+
+from organization.views import default as org_views
+from organization.tests.factories import ProjectFactory, OrganizationFactory
+from spatial.views.default import LocationsAdd
+from accounts.tests.factories import UserFactory
+from core.tests.base_test_case import UserTestCase
+
+
+class PermissionRequiredMixinTest(UserTestCase):
+    def test_login_redirect_to_original_referer(self):
+        user = UserFactory.create()
+        project = ProjectFactory.create()
+
+        view = LocationsAdd.as_view()
+
+        request = HttpRequest()
+        referer = '/organizations/{}/projects/{}'.format(
+            project.organization.slug,
+            project.slug
+        )
+        request.META['HTTP_REFERER'] = referer
+        setattr(request, 'user', user)
+        setattr(request, 'method', 'GET')
+
+        setattr(request, 'session', 'session')
+        self.messages = FallbackStorage(request)
+        setattr(request, '_messages', self.messages)
+
+        kwargs = {
+            'organization': project.organization.slug,
+            'project': project.slug
+        }
+
+        response = view(request, **kwargs)
+        assert response.status_code == 302
+        assert referer == response['location']
+
+    def test_login_redirect_to_project_dashboard(self):
+        user = UserFactory.create()
+        project = ProjectFactory.create()
+
+        view = LocationsAdd.as_view()
+
+        request = HttpRequest()
+        request.META['HTTP_REFERER'] = '/account/login/'
+        setattr(request, 'user', user)
+        setattr(request, 'method', 'GET')
+
+        setattr(request, 'session', 'session')
+        self.messages = FallbackStorage(request)
+        setattr(request, '_messages', self.messages)
+
+        kwargs = {
+            'organization': project.organization.slug,
+            'project': project.slug
+        }
+
+        exp_redirect = reverse('organization:project-dashboard', kwargs=kwargs)
+        response = view(request, **kwargs)
+        assert response.status_code == 302
+        assert exp_redirect == response['location']
+
+    def test_login_redirect_from_project_dashboard_to_org_dashboard(self):
+        user = UserFactory.create()
+        assign_user_policies(user, *[])
+        project = ProjectFactory.create()
+
+        view = org_views.ProjectDashboard.as_view()
+
+        request = HttpRequest()
+        request.META['HTTP_REFERER'] = '/account/login/'
+        setattr(request, 'user', user)
+        setattr(request, 'method', 'GET')
+
+        setattr(request, 'session', 'session')
+        self.messages = FallbackStorage(request)
+        setattr(request, '_messages', self.messages)
+
+        kwargs = {
+            'organization': project.organization.slug,
+            'project': project.slug
+        }
+
+        def get_full_path():
+            return '/organizations/{}/projects/{}/'.format(
+                project.organization.slug,
+                project.slug
+            )
+        setattr(request, 'get_full_path', get_full_path)
+
+        exp_redirect = reverse('organization:dashboard', kwargs={
+            'slug': project.organization.slug})
+        response = view(request, **kwargs)
+        assert response.status_code == 302
+        assert exp_redirect == response['location']
+
+    def test_login_redirect_to_organization_dashboard(self):
+        user = UserFactory.create()
+        org = OrganizationFactory.create()
+
+        view = org_views.OrganizationEdit.as_view()
+
+        request = HttpRequest()
+        request.META['HTTP_REFERER'] = '/account/login/'
+        setattr(request, 'user', user)
+        setattr(request, 'method', 'GET')
+
+        setattr(request, 'session', 'session')
+        self.messages = FallbackStorage(request)
+        setattr(request, '_messages', self.messages)
+
+        kwargs = {'slug': org.slug}
+
+        exp_redirect = reverse('organization:dashboard', kwargs=kwargs)
+        response = view(request, **kwargs)
+        assert response.status_code == 302
+        assert exp_redirect == response['location']
+
+    def test_login_redirect_from_org_dashboard_to_dashboard(self):
+        user = UserFactory.create()
+        assign_user_policies(user, *[])
+        org = OrganizationFactory.create()
+        view = org_views.OrganizationDashboard.as_view()
+
+        request = HttpRequest()
+        request.META['HTTP_REFERER'] = '/account/login/'
+        setattr(request, 'user', user)
+        setattr(request, 'method', 'GET')
+
+        setattr(request, 'session', 'session')
+        self.messages = FallbackStorage(request)
+        setattr(request, '_messages', self.messages)
+
+        kwargs = {'slug': org.slug}
+
+        def get_full_path():
+            return '/organizations/{}/'.format(org.slug)
+        setattr(request, 'get_full_path', get_full_path)
+
+        exp_redirect = reverse('core:dashboard')
+        response = view(request, **kwargs)
+        assert response.status_code == 302
+        assert exp_redirect == response['location']


### PR DESCRIPTION
The following case leads to a redirect loop:

- The user is not authenticated. 
- The user tries to access a page that requires authentication.
- The server redirects to the login page.
- The user authenticates themselves and is redirected to the original page.
- The user does have the required permissions on the original page and is redirected to the referrer, in this case the login page.
- Because the user is now authenticated, the login page again redirects to the original page. The redirect loop is entered.

This PR solves this issue by checking if the referrer is the login page and if a user is authenticated. The redirect as adapted based on the page the user tried to access:

- If the page is below the project dashboard level, the redirect points to the project dashboard.
- If the page is the project dashboard, the redirect points to the organisation dashboard.
- If the page is below the organisation dashboard level, the redirect points to the organisation dashboard.
- If the page is the organisation dashboard, the redirect points to the platform dashboard.

If the referrer is not the login page, the server will redirect to the referrer.
