### PR TITLE
Fix the Unicode!

### DIFF
--- a/cadasta/config/wsgi.py
+++ b/cadasta/config/wsgi.py
@@ -8,9 +8,11 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
 
 import os
+import locale
 
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.dev")
+locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
 
 application = get_wsgi_application()


### PR DESCRIPTION
Attempt to fix these Unicode errors by explicitly setting the locale in the Python WSGI startup script.