### PR TITLE
Fix #414: Remove unnecessary slugify() call

### DIFF
--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -5,7 +5,6 @@ from django.db import transaction
 from django.shortcuts import redirect, get_object_or_404
 import django.views.generic as base_generic
 from django.core.urlresolvers import reverse
-from core.util import slugify
 from django.utils.translation import gettext as _
 from django.contrib import messages
 
@@ -441,7 +440,6 @@ class ProjectAddWizard(SuperUserCheckMixin,
         with transaction.atomic():
             project = Project.objects.create(
                 name=name, organization=org,
-                slug=slugify(name, allow_unicode=True),
                 description=description, urls=[url], extent=extent,
                 access=access
             )


### PR DESCRIPTION
This PR fixes #414, which also contains the explanation of the root cause of the bug. Changes:
- Removes unnecessary `slugify()` call in the `ProjectAddWizard.done()` method
- Adds a unit test to catch the bug and confirm the bug fix