### PR TITLE
Fixes #315 -- Set _errors when contact is removed

### DIFF
--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -7,6 +7,7 @@ from django.contrib.gis import forms as gisforms
 from core.util import slugify
 from django.utils.translation import ugettext as _
 from django.db import transaction
+from django.forms.utils import ErrorDict
 
 from leaflet.forms.widgets import LeafletWidget
 from tutelary.models import Role
@@ -63,6 +64,7 @@ class ContactsForm(forms.Form):
         if self.data.get(self.prefix + '-remove') != 'on':
             super().full_clean()
         else:
+            self._errors = ErrorDict()
             self.cleaned_data = {'remove': True}
 
     def clean(self):

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -4,6 +4,7 @@ from pytest import raises
 from zipfile import ZipFile
 
 from django.conf import settings
+from django.forms.utils import ErrorDict
 
 from buckets.test import utils as bucket_uitls
 from buckets.test.storage import FakeS3Storage
@@ -561,6 +562,7 @@ class ContactsFormTest(UserTestCase):
         form = forms.ContactsForm(data=data, prefix='contacts')
         form.full_clean()
         assert form.cleaned_data == {'remove': True}
+        assert isinstance(form._errors, ErrorDict)
 
     def test_validate_valid_form_with_email(self):
         data = {


### PR DESCRIPTION
The error occurs when an invalid form is submitted, and the template tries to render error messages of all form fields. This fails because of a bug inside `ContactsForm.full_clean()`. `self._errors' is not set when the contact record is removed. 

This PR fixes the issue by ensuring `self._errors` is set in all cases. 