### PR TITLE
More aggressive Squid caching for external URLs

### DIFF
--- a/provision/roles/testing/files/squid.conf
+++ b/provision/roles/testing/files/squid.conf
@@ -23,11 +23,10 @@ http_port 3128
 coredump_dir /var/spool/squid3
 
 refresh_pattern ^http://?.tile.openstreetmap.org	1440	20%	10080	ignore-reload
-refresh_pattern ^ftp:		1440	20%	10080
-refresh_pattern ^gopher:	1440	0%	1440
-refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
-refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
-refresh_pattern .		0	20%	4320
-
-acl local dstdomain localhost
-always_direct allow local
+refresh_pattern ^http://localhost	                1440	20%	0
+refresh_pattern ^http:	                                1440	20%	10080   ignore-reload
+refresh_pattern ^ftp:		                        1440	20%	10080
+refresh_pattern ^gopher:	                        1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?)                       0	0%	0
+refresh_pattern (Release|Packages(.gz)*)$               0       20%     2880
+refresh_pattern .		                        0	20%	4320


### PR DESCRIPTION
This might fix some of these intermittent timeouts we've been seeing in the functional tests on Travis.