### PR TITLE
Fix #134: DRF docs and API versions

### DIFF
--- a/cadasta/config/urls/default.py
+++ b/cadasta/config/urls/default.py
@@ -48,6 +48,9 @@ api_v1 = [
         '(?P<project>[-\w]+)/relationships/',
         include('party.urls.api.relationships',
                 namespace='relationship')),
+
+    url(r'^docs/',
+        include('rest_framework_docs.urls'))
 ]
 
 api = [

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -13,7 +13,7 @@ django-sass-processor==0.3.4
 djangorestframework-gis==0.10.1
 jsonschema==2.5.1
 rfc3987==1.3.5
-drfdocs==0.0.9
+drfdocs-cadasta==0.0.12
 django-tutelary==0.1.16
 django-audit-log==0.7.0
 django-simple-history==1.8.1


### PR DESCRIPTION
Fixed by switching to drfdocs-cadasta, which includes a fix for nested URLs.