### PR TITLE
Add support for Django debug toolbar

### DIFF
--- a/cadasta/config/settings/dev_debug.py
+++ b/cadasta/config/settings/dev_debug.py
@@ -1,0 +1,31 @@
+from .dev import *  # NOQA
+
+
+INSTALLED_APPS = (
+    'debug_toolbar',
+) + INSTALLED_APPS  # NOQA
+
+MIDDLEWARE_CLASSES = (
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+) + MIDDLEWARE_CLASSES  # NOQA
+
+
+INTERNAL_IPS = ('0.0.0.0',)
+
+DEBUG_TOOLBAR_PANELS = (
+    'debug_toolbar.panels.version.VersionDebugPanel',
+    'debug_toolbar.panels.timer.TimerDebugPanel',
+    'debug_toolbar.panels.headers.HeaderDebugPanel',
+    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+    'debug_toolbar.panels.template.TemplateDebugPanel',
+    'debug_toolbar.panels.sql.SQLDebugPanel',
+    'debug_toolbar.panels.signals.SignalDebugPanel',
+)
+
+
+def always(*args):
+    return True
+
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': always,
+}

--- a/cadasta/runserver
+++ b/cadasta/runserver
@@ -1,2 +1,19 @@
 #!/bin/bash
+
+if [[ $# == 0 ]]
+then
+    mode=DEFAULT
+elif [[ $# == 1 && "$1" == '--debug' ]]
+then
+    mode=DEBUG
+else
+    echo "Usage: runserver [--debug]"
+    exit 1
+fi
+
+if [ $mode == DEBUG ]
+then
+    export DJANGO_SETTINGS_MODULE=config.settings.dev_debug
+fi
+
 exec ./manage.py runserver 0.0.0.0:8000

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,3 +7,4 @@ transifex-client==0.11
 django-compressor==2.0
 tox==2.3.1
 flake8==2.5.4
+django-debug-toolbar==1.5


### PR DESCRIPTION
Fixes issue 489.  You can now do "./runserver --debug", and the Django debug toolbar will be loaded, giving you performance information on every page view.  (I'll document this in the development newsletter when it's merged.)