### PR TITLE
Fix #406 and #325

### DIFF
--- a/cadasta/core/static/js/map_utils.js
+++ b/cadasta/core/static/js/map_utils.js
@@ -50,7 +50,8 @@ function renderFeatures(map, projectExtent, spatialUnits, trans, fitBounds) {
             weight: 2,
             dashArray: "5, 5",
             opacity: 1,
-            fill: false
+            fill: false,
+            clickable: false,
         }
       }
     );

--- a/cadasta/templates/spatial/location_wrapper.html
+++ b/cadasta/templates/spatial/location_wrapper.html
@@ -41,7 +41,7 @@
       onEachFeature: function(feature, layer) {
         layer.bindPopup("<div class=\"text-wrap\">" +
                        "<h2><span>Location</span>{{ location.get_type_display }}</h2></div>" +
-                       "<div class=\"btn-wrap\"><a href='{% url 'locations:detail' object.organization.slug object.slug location.id %}' class=\"btn btn-primary btn-sm btn-block\">{% trans 'Open location' %}</a>"  +
+                       "<div class=\"btn-wrap\"><span class=\"btn-sm btn-block\">{% trans 'Currently viewing' %}</span>" +
                        "</div>");
       }
     });


### PR DESCRIPTION
- Make the project extent not look like a link on the map
- Make the current location not link to itself on the map

Here's how the second point looks like:

![screen shot 2016-07-26 at 16 07 49](https://cloud.githubusercontent.com/assets/873653/17132374/043e3418-5354-11e6-8a4b-1e0e7c903451.png)
