### PR TITLE
Set up to use wheelhouse for PIP packages

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 module_lang = en_US.UTF-8
+allow_world_readable_tmpfiles = True

--- a/provision/roles/cadasta/application/tasks/main.yml
+++ b/provision/roles/cadasta/application/tasks/main.yml
@@ -51,6 +51,7 @@
   become_user: "{{ app_user }}"
   pip: virtualenv="{{ virtualenv_path }}"
        requirements="{{ application_path }}requirements/common.txt"
+       extra_args="--find-links https://s3.amazonaws.com:443/cadasta-wheelhouse/index.html"
 
 - name: Set up logging directory
   become: yes

--- a/provision/roles/cadasta/development/tasks/main.yml
+++ b/provision/roles/cadasta/development/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: Install requirements
-  pip: virtualenv={{ virtualenv_path }} requirements={{ application_path }}requirements/dev.txt
+  pip: virtualenv="{{ virtualenv_path }}"
+       requirements="{{ application_path }}requirements/dev.txt"
+       extra_args="--find-links https://s3.amazonaws.com:443/cadasta-wheelhouse/index.html"
 
 - name: Activate virtual environment on VM login
   become: yes

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
 passenv = DJANGO_SETTINGS_MODULE
 setenv = PYTHONDONTWRITEBYTECODE=1
 deps = -r{toxinidir}/requirements/dev.txt
+install_command = pip install --find-links https://s3.amazonaws.com:443/cadasta-wheelhouse/index.html {opts} {packages}
 
 [testenv:py35-django1.9-unit]
 commands = ./runtests.py


### PR DESCRIPTION
Use --find-links option to preferentially pull PIP packages from the
wheelhouse in the cadasta-wheelhouse S3 bucket (maintained by the code
in the Cadasta/wheelhouse repo).

For the moment, keeping the requirements files consistent between the
main repo and the wheelhouse repo has to be done manually, but this is
not a problem because PIP is conservative, in the sense that if it
doesn't find a package in the wheelhouse it will just download it via
the main package index.