### PR TITLE
Add templates for new issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,12 @@
+### Steps to reproduce the error
+
+[Please try to describe the actions that led to the incorrect behavior
+in as much detail as possible.]
+
+### Actual behavior
+
+[Please describe the outcome of your actions.]
+
+### Expected behavior
+
+[Please explain what behavior you would have expected instead.]

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,33 @@
+### Proposed changes in this pull request
+
+[List all changes you want to add here. If you fixed an issue, please
+add a reference to that issue as well.]
+
+-
+-
+-
+
+### When should this PR be merged
+
+[Please describe any preconditions that need to be addressed before we
+can merge this pull request.]
+
+
+
+### Risks
+
+[List any risks that could arise from merging your pull request.]
+
+-
+-
+-
+
+### Follow up actions
+
+[List any possible follow-up actions here; for instance, testing data
+migrations, software that we need to install on staging and production
+environments.]
+
+-
+-
+-


### PR DESCRIPTION
This PR adds two templates that will be shown when contributors open new issues or pull requests. 

It would be great if a native speaker can check the wording.
@amplifi — Can you please check the PR template and let me know if we should collect any more information that is of value for Ops