### PR TITLE
Improved handling of resource files

### DIFF
--- a/cadasta/config/settings/test.py
+++ b/cadasta/config/settings/test.py
@@ -1,0 +1,3 @@
+from .dev import *  # NOQA
+
+MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'core/media/test')

--- a/cadasta/core/tests/util.py
+++ b/cadasta/core/tests/util.py
@@ -1,14 +1,29 @@
+import pytest
+import shutil
+import os
 from django.test import TestCase as DjangoTestCase
 from django.http import HttpRequest
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.template.loader import render_to_string
 from django.core.urlresolvers import reverse
+from django.conf import settings
+from buckets.utils import ensure_dirs
 
 from core.tests.factories import PolicyFactory
 from accounts.tests.factories import UserFactory
 from jsonattrs.models import create_attribute_types
 from party.models import load_tenure_relationship_types
+
+
+@pytest.fixture(scope='class')
+def make_dirs(request):
+    ensure_dirs('uploads/resources', 'uploads/xls-forms', 'uploads/xml-forms',
+                'downloads')
+
+    def teardown():
+        shutil.rmtree(os.path.join(settings.MEDIA_ROOT, 's3'))
+    request.addfinalizer(teardown)
 
 
 class TestCase(DjangoTestCase):

--- a/cadasta/organization/tests/test_downloads.py
+++ b/cadasta/organization/tests/test_downloads.py
@@ -1,17 +1,19 @@
+import pytest
 import time
 import os
 from openpyxl import load_workbook, Workbook
 from zipfile import ZipFile
-from buckets.test import utils as bucket_uitls
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 
 from jsonattrs.models import Attribute, AttributeType, Schema
 
+from core.tests.util import make_dirs  # noqa
 from organization.tests.factories import ProjectFactory
 from spatial.tests.factories import SpatialUnitFactory
 from resources.utils.io import ensure_dirs
 from resources.tests.factories import ResourceFactory
+from resources.tests.utils import clear_temp  # noqa
 from resources.models import ContentObject
 from core.tests.base_test_case import UserTestCase
 from party.tests.factories import TenureRelationshipFactory, PartyFactory
@@ -20,6 +22,7 @@ from ..download.xls import XLSExporter
 from ..download.resources import ResourceExporter
 
 
+@pytest.mark.usefixtures('clear_temp')
 class XLSTest(UserTestCase):
     def test_init(self):
         project = ProjectFactory.build()
@@ -114,6 +117,8 @@ class XLSTest(UserTestCase):
                         'spreadsheetml.sheet')
 
 
+@pytest.mark.usefixtures('clear_temp')
+@pytest.mark.usefixtures('make_dirs')
 class ResourcesTest(UserTestCase):
     def test_init(self):
         project = ProjectFactory.build()
@@ -122,7 +127,6 @@ class ResourcesTest(UserTestCase):
 
     def test_make_resource_worksheet(self):
         ensure_dirs()
-        bucket_uitls.ensure_dirs(add='s3/uploads/resources')
         project = ProjectFactory.create()
         exporter = ResourceExporter(project)
 
@@ -146,7 +150,6 @@ class ResourcesTest(UserTestCase):
             assert sheet[chr(i + 97) + '3'].value == data[1][i]
 
     def test_pack_resource_data(self):
-        bucket_uitls.ensure_dirs(add='s3/uploads/resources')
         project = ProjectFactory.create()
         exporter = ResourceExporter(project)
 
@@ -172,7 +175,7 @@ class ResourcesTest(UserTestCase):
         assert rel.id in packed[6]
 
     def test_make_download(self):
-        bucket_uitls.ensure_dirs(add='s3/uploads/resources')
+        ensure_dirs()
         project = ProjectFactory.create()
         exporter = ResourceExporter(project)
         res = ResourceFactory.create(project=project)

--- a/cadasta/party/tests/test_views_default.py
+++ b/cadasta/party/tests/test_views_default.py
@@ -6,13 +6,14 @@ from django.conf import settings
 from django.contrib.messages.api import get_messages
 from django.contrib.contenttypes.models import ContentType
 
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
+from core.tests.util import make_dirs  # noqa
 from tutelary.models import Policy, assign_user_policies
 from jsonattrs.models import Attribute, AttributeType, Schema
 
 from organization.tests.factories import ProjectFactory
 from resources.tests.factories import ResourceFactory
+from resources.tests.utils import clear_temp  # noqa
 from resources.forms import AddResourceFromLibraryForm, ResourceForm
 from core.tests.util import TestCase
 from spatial.models import SpatialUnit
@@ -421,13 +422,13 @@ class PartiesDeleteTest(TestCase):
         assert TenureRelationship.objects.count() == 1
 
 
+@pytest.mark.usefixtures('make_dirs')
 class PartyResourcesAddTest(TestCase):
     view = default.PartyResourcesAdd
     template = 'party/resources_add.html'
     success_url_name = 'parties:detail'
 
     def set_up_models(self):
-        ensure_dirs(add='s3/uploads/resources')
         self.project = ProjectFactory.create()
         self.party = PartyFactory.create(project=self.project)
         self.assigned = ResourceFactory.create(project=self.project,
@@ -512,6 +513,8 @@ class PartyResourcesAddTest(TestCase):
         assert self.party.resources.first() == self.assigned
 
 
+@pytest.mark.usefixtures('make_dirs')
+@pytest.mark.usefixtures('clear_temp')
 class PartyResourcesNewTest(TestCase):
     view = default.PartyResourcesNew
     template = 'party/resources_new.html'
@@ -543,10 +546,9 @@ class PartyResourcesNewTest(TestCase):
 
     def get_post_data(self):
         path = os.path.dirname(settings.BASE_DIR)
-        ensure_dirs(add='s3/uploads/resources')
         storage = FakeS3Storage()
         file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
-        file_name = storage.save('image.jpg', file)
+        file_name = storage.save('resources/image.jpg', file)
 
         return {
             'name': 'Some name',
@@ -852,13 +854,13 @@ class PartyRelationshipDeleteTest(TestCase):
         assert TenureRelationship.objects.count() == 1
 
 
+@pytest.mark.usefixtures('make_dirs')
 class PartyRelationshipResourceAddTest(TestCase):
     view = default.PartyRelationshipResourceAdd
     template = 'party/relationship_resources_add.html'
     success_url_name = 'parties:relationship_detail'
 
     def set_up_models(self):
-        ensure_dirs(add='s3/uploads/resources')
         self.project = ProjectFactory.create()
         self.relationship = TenureRelationshipFactory.create(
             project=self.project)
@@ -948,6 +950,7 @@ class PartyRelationshipResourceAddTest(TestCase):
         assert self.relationship.resources.first() == self.assigned
 
 
+@pytest.mark.usefixtures('make_dirs')
 class PartyRelationshipResourceNewTest(TestCase):
     view = default.PartyRelationshipResourceNew
     template = 'party/relationship_resources_new.html'
@@ -982,10 +985,9 @@ class PartyRelationshipResourceNewTest(TestCase):
 
     def get_post_data(self):
         path = os.path.dirname(settings.BASE_DIR)
-        ensure_dirs(add='s3/uploads/resources')
         storage = FakeS3Storage()
         file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
-        file_name = storage.save('image.jpg', file)
+        file_name = storage.save('resources/image.jpg', file)
 
         return {
             'name': 'Some name',

--- a/cadasta/pytest.ini
+++ b/cadasta/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ds=config.settings.test

--- a/cadasta/questionnaires/tests/test_attr_schemas.py
+++ b/cadasta/questionnaires/tests/test_attr_schemas.py
@@ -2,13 +2,13 @@ import os
 
 import pytest
 
-from buckets.test.mocks import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from jsonattrs.models import Attribute, Schema
 from core.tests.base_test_case import UserTestCase
+from core.tests.util import make_dirs  # noqa
 from organization.tests.factories import ProjectFactory
 from party.tests.factories import (PartyFactory, PartyRelationshipFactory,
                                    TenureRelationshipFactory)
@@ -25,10 +25,9 @@ from .attr_schemas import (location_relationship_xform_group,
 from .factories import QuestionnaireFactory
 
 path = os.path.dirname(settings.BASE_DIR)
-ensure_dirs(add='s3/uploads/xls-forms')
-ensure_dirs(add='s3/uploads/xml-forms')
 
 
+@pytest.mark.usefixtures('make_dirs')
 class CreateAttributeSchemaTest(UserTestCase):
     def test_create_attribute_schemas(self):
         storage = FakeS3Storage()
@@ -297,8 +296,6 @@ class CreateAttributeSchemaTest(UserTestCase):
             )
 
     def test_update_questionnaire_attribute_schema(self):
-        ensure_dirs()
-
         storage = FakeS3Storage()
         file = open(
             path + '/questionnaires/tests/files/xls-form-attrs.xlsx', 'rb'
@@ -335,11 +332,10 @@ class CreateAttributeSchemaTest(UserTestCase):
         assert s1 != s2
 
 
+@pytest.mark.usefixtures('make_dirs')
 class ConditionalAttributeSchemaTest(UserTestCase):
-
     def setUp(self):
         super().setUp()
-        ensure_dirs()
         storage = FakeS3Storage()
         file = open(
             path + '/questionnaires/tests/files/xls-form-attrs.xlsx', 'rb'

--- a/cadasta/questionnaires/tests/test_serializers.py
+++ b/cadasta/questionnaires/tests/test_serializers.py
@@ -3,24 +3,22 @@ import os
 from django.test import TestCase
 from django.conf import settings
 
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 
 from organization.tests.factories import ProjectFactory
 from questionnaires.exceptions import InvalidXLSForm
+from core.tests.util import make_dirs  # noqa
 
 from . import factories
 from .. import serializers
 from ..models import Questionnaire
 
 path = os.path.dirname(settings.BASE_DIR)
-ensure_dirs(add='s3/uploads/xls-forms')
-ensure_dirs(add='s3/uploads/xml-forms')
 
 
+@pytest.mark.usefixtures('make_dirs')
 class QuestionnaireSerializerTest(TestCase):
     def _get_form(self, form_name):
-        ensure_dirs()
 
         storage = FakeS3Storage()
         file = open(

--- a/cadasta/questionnaires/tests/test_views_api.py
+++ b/cadasta/questionnaires/tests/test_views_api.py
@@ -1,13 +1,14 @@
 import os
 import json
+import pytest
 from django.conf import settings
 
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 from rest_framework.test import APIRequestFactory, force_authenticate
 from tutelary.models import Policy
 
 from core.tests.base_test_case import UserTestCase
+from core.tests.util import make_dirs  # noqa
 from accounts.tests.factories import UserFactory
 from organization.tests.factories import OrganizationFactory, ProjectFactory
 from ..views import api
@@ -15,10 +16,9 @@ from ..models import Questionnaire
 from .factories import QuestionnaireFactory
 
 path = os.path.dirname(settings.BASE_DIR)
-ensure_dirs(add='s3/uploads/xls-forms')
-ensure_dirs(add='s3/uploads/xml-forms')
 
 
+@pytest.mark.usefixtures('make_dirs')
 class QuestionnaireDetailTest(UserTestCase):
     def setUp(self):
         super().setUp()
@@ -44,8 +44,6 @@ class QuestionnaireDetailTest(UserTestCase):
         )
 
     def _get_form(self, form_name):
-        ensure_dirs()
-
         storage = FakeS3Storage()
         file = open(
             path + '/questionnaires/tests/files/{}.xlsx'.format(form_name),

--- a/cadasta/resources/forms.py
+++ b/cadasta/resources/forms.py
@@ -1,16 +1,10 @@
 from django import forms
 from django.contrib.contenttypes.models import ContentType
-from buckets.widgets import S3FileUploadWidget
 from .models import Resource, ContentObject
 from .fields import ResourceField
-from .validators import ACCEPTED_TYPES
 
 
 class ResourceForm(forms.ModelForm):
-    file = forms.CharField(
-        widget=S3FileUploadWidget(upload_to='resources',
-                                  accepted_types=ACCEPTED_TYPES))
-
     class Meta:
         model = Resource
         fields = ['file', 'original_file', 'name', 'description', 'mime_type']

--- a/cadasta/resources/tests/test_fields.py
+++ b/cadasta/resources/tests/test_fields.py
@@ -1,10 +1,13 @@
+import pytest
 from django.test import TestCase
 from django.forms import BooleanField
+from core.tests.util import make_dirs  # noqa
 from ..fields import ResourceField
 from ..widgets import ResourceWidget
 from .factories import ResourceFactory
 
 
+@pytest.mark.usefixtures('make_dirs')
 class ResourceFieldTest(TestCase):
     def test_init_without_widget(self):
         resource = ResourceFactory.build()

--- a/cadasta/resources/tests/test_forms.py
+++ b/cadasta/resources/tests/test_forms.py
@@ -1,24 +1,27 @@
 import os
+import pytest
 from django.conf import settings
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 
 from core.tests.base_test_case import UserTestCase
+from core.tests.util import make_dirs  # noqa
 from accounts.tests.factories import UserFactory
 from organization.tests.factories import ProjectFactory
 from ..forms import ResourceForm, AddResourceFromLibraryForm
 from .factories import ResourceFactory
+from .utils import clear_temp  # noqa
 
 path = os.path.dirname(settings.BASE_DIR)
 
 
+@pytest.mark.usefixtures('make_dirs')
+@pytest.mark.usefixtures('clear_temp')
 class ResourceFormTest(UserTestCase):
     def setUp(self):
         super().setUp()
-        ensure_dirs(add='s3/uploads/resources')
         storage = FakeS3Storage()
         file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
-        file_name = storage.save('image.jpg', file)
+        file_name = storage.save('resources/image.jpg', file)
 
         self.data = {
             'name': 'Some name',
@@ -55,9 +58,9 @@ class ResourceFormTest(UserTestCase):
         assert self.project.resources.first().contributor == user
 
 
+@pytest.mark.usefixtures('make_dirs')
 class AddResourceFromLibraryFormTest(UserTestCase):
     def test_init(self):
-        ensure_dirs(add='s3/uploads/resources')
         prj = ProjectFactory.create()
         prj_res = ResourceFactory.create(project=prj, content_object=prj)
         res = ResourceFactory.create(project=prj)
@@ -69,7 +72,6 @@ class AddResourceFromLibraryFormTest(UserTestCase):
         assert form.fields[res.id].initial is False
 
     def test_save(self):
-        ensure_dirs(add='s3/uploads/resources')
         prj = ProjectFactory.create()
         prj_res = ResourceFactory.create(project=prj, content_object=prj)
         res = ResourceFactory.create(project=prj)

--- a/cadasta/resources/tests/test_managers.py
+++ b/cadasta/resources/tests/test_managers.py
@@ -1,25 +1,26 @@
 import os
+import pytest
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 
 from core.tests.base_test_case import UserTestCase
+from core.tests.util import make_dirs  # noqa
 from organization.tests.factories import ProjectFactory
 from accounts.tests.factories import UserFactory
 
 from ..models import Resource
 
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 path = os.path.dirname(settings.BASE_DIR)
 
-ensure_dirs(add='s3/uploads/resources')
-storage = FakeS3Storage()
-file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
-file_name = storage.save('image.jpg', file)
 
-
+@pytest.mark.usefixtures('make_dirs')
 class ResourceModelTest(UserTestCase):
     def test_project_resource(self):
+        storage = FakeS3Storage()
+        file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
+        file_name = storage.save('resources/image.jpg', file)
+
         project = ProjectFactory.create()
         user = UserFactory.create()
 

--- a/cadasta/resources/tests/test_mixins.py
+++ b/cadasta/resources/tests/test_mixins.py
@@ -1,9 +1,10 @@
+import pytest
 from django.db.models import Model
-from buckets.test.utils import ensure_dirs
 
 from ..mixins import ResourceModelMixin
 from .factories import ResourceFactory
 from core.tests.base_test_case import UserTestCase
+from core.tests.util import make_dirs  # noqa
 
 
 class ResourceModel(ResourceModelMixin, Model):
@@ -11,9 +12,9 @@ class ResourceModel(ResourceModelMixin, Model):
         app_label = 'core'
 
 
+@pytest.mark.usefixtures('make_dirs')
 class ResourceModelMixinTest(UserTestCase):
     def test_resources_property(self):
-        ensure_dirs(add='s3/uploads/resources')
         resource_model_1 = ResourceModel()
         resource_model_1.save()
 
@@ -27,7 +28,6 @@ class ResourceModelMixinTest(UserTestCase):
         assert resource_2 not in resource_model_1.resources
 
     def test_reload_resources(self):
-        ensure_dirs(add='s3/uploads/resources')
         resource_model_1 = ResourceModel()
         resource_model_1.save()
         ResourceFactory.create_batch(2, content_object=resource_model_1)

--- a/cadasta/resources/tests/test_models.py
+++ b/cadasta/resources/tests/test_models.py
@@ -1,29 +1,30 @@
+import pytest
 import os
 
 from django.conf import settings
 
 from core.tests.base_test_case import UserTestCase
+from core.tests.util import make_dirs  # noqa
 from .factories import ResourceFactory
+from .utils import clear_temp  # noqa
 from ..models import ContentObject, Resource, create_thumbnails
 
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 path = os.path.dirname(settings.BASE_DIR)
 
 
+@pytest.mark.usefixtures('make_dirs')
+@pytest.mark.usefixtures('clear_temp')
 class ResourceTest(UserTestCase):
     def test_file_name_property(self):
-        ensure_dirs(add='s3/uploads/resources')
         resource = Resource(file='http://example.com/dir/filename.txt')
         assert resource.file_name == 'filename.txt'
 
     def test_file_type_property(self):
-        ensure_dirs(add='s3/uploads/resources')
         resource = Resource(file='http://example.com/dir/filename.txt')
         assert resource.file_type == 'txt'
 
     def test_thumbnail_img(self):
-        ensure_dirs(add='s3/uploads/resources')
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.jpg',
             mime_type='image/jpg'
@@ -144,7 +145,6 @@ class ResourceTest(UserTestCase):
         assert resource.num_entities == 2
 
     def test_register_file_version(self):
-        ensure_dirs(add='s3/uploads/resources')
         storage = FakeS3Storage()
         file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
         file_name = storage.save('resources/thumb_new.jpg', file)
@@ -157,7 +157,6 @@ class ResourceTest(UserTestCase):
         assert len(resource.file_versions) == 1
 
     def test_create_thumbnail(self):
-        ensure_dirs(add='s3/uploads/resources')
         storage = FakeS3Storage()
         file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
         file_name = storage.save('resources/thumb_test.jpg', file)

--- a/cadasta/resources/tests/test_serializers.py
+++ b/cadasta/resources/tests/test_serializers.py
@@ -4,22 +4,18 @@ from django.conf import settings
 from rest_framework.serializers import ValidationError
 
 from core.tests.base_test_case import UserTestCase
+from core.tests.util import make_dirs  # noqa
 from organization.tests.factories import ProjectFactory
 from accounts.tests.factories import UserFactory
 
 from .factories import ResourceFactory
 from ..serializers import ResourceSerializer
 
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 path = os.path.dirname(settings.BASE_DIR)
 
-ensure_dirs(add='s3/uploads/resources')
-storage = FakeS3Storage()
-file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
-file_name = storage.save('image.jpg', file)
 
-
+@pytest.mark.usefixtures('make_dirs')
 class ResourceSerializerTest(UserTestCase):
     def test_serialize_fields(self):
         resource = ResourceFactory.create()
@@ -33,6 +29,10 @@ class ResourceSerializerTest(UserTestCase):
         assert serialized_resource['file'] == resource.file.url
 
     def test_create_project_resource(self):
+        storage = FakeS3Storage()
+        file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
+        file_name = storage.save('image.jpg', file)
+
         project = ProjectFactory.create()
         user = UserFactory.create()
         data = {

--- a/cadasta/resources/tests/test_views_default.py
+++ b/cadasta/resources/tests/test_views_default.py
@@ -9,18 +9,17 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.api import get_messages
 
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 from tutelary.models import Policy, assign_user_policies
 
 from core.tests.base_test_case import UserTestCase
+from core.tests.util import make_dirs  # noqa
 from organization.tests.factories import ProjectFactory
 from accounts.tests.factories import UserFactory
 from ..views import default
 from ..forms import ResourceForm, AddResourceFromLibraryForm
 from .factories import ResourceFactory
-
-ensure_dirs(add='s3/uploads/resources')
+from .utils import clear_temp  # noqa
 
 path = os.path.dirname(settings.BASE_DIR)
 clauses = {
@@ -39,6 +38,7 @@ clauses = {
 }
 
 
+@pytest.mark.usefixtures('make_dirs')
 class ProjectResourcesTest(UserTestCase):
     def setUp(self):
         super().setUp()
@@ -111,6 +111,7 @@ class ProjectResourcesTest(UserTestCase):
                       organization='some-org', project='some-project')
 
 
+@pytest.mark.usefixtures('make_dirs')
 class ProjectResourcesAddTest(UserTestCase):
     def setUp(self):
         super().setUp()
@@ -227,6 +228,8 @@ class ProjectResourcesAddTest(UserTestCase):
         assert self.project.resources.first() == self.assigned
 
 
+@pytest.mark.usefixtures('clear_temp')
+@pytest.mark.usefixtures('make_dirs')
 class ProjectResourcesNewTest(UserTestCase):
     def setUp(self):
         super().setUp()
@@ -273,7 +276,7 @@ class ProjectResourcesNewTest(UserTestCase):
     def _post(self, user=None, status=None, expected_redirect=None):
         storage = FakeS3Storage()
         file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
-        file_name = storage.save('image.jpg', file)
+        file_name = storage.save('resources/image.jpg', file)
 
         self.data = {
             'name': 'Some name',
@@ -345,6 +348,7 @@ class ProjectResourcesNewTest(UserTestCase):
         assert self.project.resources.count() == 0
 
 
+@pytest.mark.usefixtures('make_dirs')
 class ProjectResourcesDetailTest(UserTestCase):
     def setUp(self):
         super().setUp()
@@ -420,6 +424,7 @@ class ProjectResourcesDetailTest(UserTestCase):
         assert '/account/login/' in response['location']
 
 
+@pytest.mark.usefixtures('make_dirs')
 class ProjectResourcesEditTest(UserTestCase):
     def setUp(self):
         super().setUp()
@@ -471,7 +476,7 @@ class ProjectResourcesEditTest(UserTestCase):
 
         storage = FakeS3Storage()
         file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
-        file_name = storage.save('image.jpg', file)
+        file_name = storage.save('resources/image.jpg', file)
         self.data = {
             'name': 'Some name',
             'description': '',
@@ -561,6 +566,7 @@ class ProjectResourcesEditTest(UserTestCase):
         assert self.project.resources.first().name != self.data['name']
 
 
+@pytest.mark.usefixtures('make_dirs')
 class ResourceArchiveTest(UserTestCase):
     def setUp(self):
         super().setUp()
@@ -646,6 +652,7 @@ class ResourceArchiveTest(UserTestCase):
         assert self.resource.archived is False
 
 
+@pytest.mark.usefixtures('make_dirs')
 class ResourceUnArchiveTest(UserTestCase):
     def setUp(self):
         super().setUp()

--- a/cadasta/resources/tests/test_widgets.py
+++ b/cadasta/resources/tests/test_widgets.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from django.test import TestCase
 from django.template.defaultfilters import date
 
+from core.tests.util import make_dirs  # noqa
 from accounts.tests.factories import UserFactory
 from .factories import ResourceFactory
 from ..widgets import ResourceWidget

--- a/cadasta/resources/tests/utils.py
+++ b/cadasta/resources/tests/utils.py
@@ -1,0 +1,11 @@
+import pytest
+import os
+import shutil
+from django.conf import settings
+
+
+@pytest.fixture(scope='class')
+def clear_temp(request):
+    def teardown():
+        shutil.rmtree(os.path.join(settings.MEDIA_ROOT, 'temp'))
+    request.addfinalizer(teardown)

--- a/cadasta/spatial/tests/test_views_default.py
+++ b/cadasta/spatial/tests/test_views_default.py
@@ -7,14 +7,14 @@ from django.template.loader import render_to_string
 from django.contrib.messages.api import get_messages
 from django.contrib.contenttypes.models import ContentType
 
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 from tutelary.models import Policy, assign_user_policies
 from jsonattrs.models import Attribute, AttributeType, Schema
 
 from organization.tests.factories import ProjectFactory
-from core.tests.util import TestCase
+from core.tests.util import TestCase, make_dirs  # noqa
 from resources.tests.factories import ResourceFactory
+from resources.tests.utils import clear_temp  # noqa
 from resources.forms import AddResourceFromLibraryForm, ResourceForm
 from party.tests.factories import TenureRelationshipFactory
 from party.models import Party, TenureRelationship
@@ -465,6 +465,7 @@ class LocationDelete(TestCase):
         assert TenureRelationship.objects.count() == 1
 
 
+@pytest.mark.usefixtures('make_dirs')
 class LocationResourceAddTest(TestCase):
     view = default.LocationResourceAdd
     template = 'spatial/resources_add.html'
@@ -556,6 +557,8 @@ class LocationResourceAddTest(TestCase):
         assert self.location.resources.first() == self.assigned
 
 
+@pytest.mark.usefixtures('make_dirs')
+@pytest.mark.usefixtures('clear_temp')
 class LocationResourceNewTest(TestCase):
     view = default.LocationResourceNew
     template = 'spatial/resources_new.html'
@@ -588,10 +591,9 @@ class LocationResourceNewTest(TestCase):
 
     def get_post_data(self):
         path = os.path.dirname(settings.BASE_DIR)
-        ensure_dirs(add='s3/uploads/resources')
         storage = FakeS3Storage()
         file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
-        file_name = storage.save('image.jpg', file)
+        file_name = storage.save('resources/image.jpg', file)
 
         return {
             'name': 'Some name',

--- a/cadasta/xforms/tests/test_serializers.py
+++ b/cadasta/xforms/tests/test_serializers.py
@@ -1,11 +1,12 @@
+import pytest
 import os
 from django.conf import settings
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 
 from core.tests.base_test_case import UserTestCase
+from core.tests.util import make_dirs  # noqa
 from organization.tests.factories import ProjectFactory
 from questionnaires.serializers import QuestionnaireSerializer
 from questionnaires.models import Questionnaire
@@ -15,16 +16,15 @@ from .. import serializers
 path = os.path.dirname(settings.BASE_DIR)
 
 
+@pytest.mark.usefixtures('make_dirs')
 class XFormListSerializerTest(UserTestCase):
     def _get_form(self, form_name):
-        ensure_dirs()
-
         storage = FakeS3Storage()
         file = open(
             path + '/questionnaires/tests/files/{}.xlsx'.format(form_name),
             'rb'
         ).read()
-        form = storage.save('{}.xlsx'.format(form_name), file)
+        form = storage.save('xls-forms/{}.xlsx'.format(form_name), file)
         return form
 
     def _test_serialize(self, https=False):

--- a/cadasta/xforms/tests/test_views_api.py
+++ b/cadasta/xforms/tests/test_views_api.py
@@ -6,12 +6,12 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 
-from buckets.test.utils import ensure_dirs
 from buckets.test.storage import FakeS3Storage
 from rest_framework.test import APIRequestFactory, force_authenticate
 from tutelary.models import Role
 
 from core.tests.base_test_case import UserTestCase
+from core.tests.util import make_dirs  # noqa
 from accounts.tests.factories import UserFactory
 from organization.tests.factories import OrganizationFactory, ProjectFactory
 from questionnaires.tests.factories import (QuestionnaireFactory,
@@ -30,8 +30,8 @@ from ..views import api
 path = os.path.dirname(settings.BASE_DIR)
 
 
+@pytest.mark.usefixtures('make_dirs')
 class XFormListTest(UserTestCase):
-
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create()
@@ -43,8 +43,6 @@ class XFormListTest(UserTestCase):
         self.superuser_role = Role.objects.get(name='superuser')
 
     def _get_form(self, form_name):
-        ensure_dirs()
-
         storage = FakeS3Storage()
         file = open(
             path + '/questionnaires/tests/files/{}.xlsx'.format(form_name),
@@ -105,8 +103,8 @@ class XFormListTest(UserTestCase):
         assert 'hash' not in content
 
 
+@pytest.mark.usefixtures('make_dirs')
 class XFormSubmissionTest(UserTestCase):
-
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create()
@@ -149,8 +147,6 @@ class XFormSubmissionTest(UserTestCase):
                 app_label='party', model='tenurerelationship'), errors=[])
 
     def _get_form(self, form_name):
-        ensure_dirs()
-
         storage = FakeS3Storage()
         file = open(
             path + '/questionnaires/tests/files/{}.xlsx'.format(form_name),
@@ -160,8 +156,6 @@ class XFormSubmissionTest(UserTestCase):
         return form
 
     def _get_resource(self, form_name):
-        ensure_dirs()
-
         storage = FakeS3Storage()
         file = open(
             path + '/xforms/tests/files/{}.jpg'.format(form_name),

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,7 +19,7 @@ django-audit-log==0.7.0
 django-simple-history==1.8.1
 simplejson==3.8.1
 django-widget-tweaks==1.4.1
-django-buckets==0.1.13
+django-buckets==0.1.15
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.2.0

--- a/runtests.py
+++ b/runtests.py
@@ -129,6 +129,10 @@ if __name__ == "__main__":
         pytest_args_functional = pytest_args
     else:
         pytest_args = PYTEST_ARGS[style]
+
+        if os.environ['DJANGO_SETTINGS_MODULE'] == 'config.settings.travis':
+            pytest_args = pytest_args + ['--ds=config.settings.travis']
+
         pytest_args_functional = PYTEST_ARGS_FUNCTIONAL[style]
 
     if run_tests:


### PR DESCRIPTION
### Proposed changes in this pull request

- Bump django-buckets to 0.1.15
  - Ensures that all necessary directories are created at run time (Fixes #434).
  - Make S3UploadWidget default for S3FileFields
- Makes file handling consistent across all tests. Two pytest fixtures are added that create directories and delete files after before and after tests if necessary.
- Adds new test settings. Test settings adopt all dev settings; only the `MEDIA_ROOT` location is overwritten, so tests use a directory different from the dev server. Files uploaded to the dev server will not be removed anymore.
- Removes explicit `file` field declaration from `resources.forms`.
- Adds accepted types to resource models.

### When should this PR be merged

PR can be merged immediately.

### Risks

Low risk. Nothing I am aware of.

### Follow up actions

- @oliverroick will document the use of the new pytest fixtures for file handling in the wiki and the dev newsletter
- @Cadasta/cadasta-dev make sure you all update django-buckets to 0.1.15 if you don't reprovision your development VM