### PR TITLE
Resolve #295 and #407: Improve the UI/UX in adding/uploading resources

### DIFF
--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -4228,18 +4228,8 @@ ul.resource-actions > li {
   margin-left: auto;
   margin-right: auto; }
 
-.content-single .detail .tab-pane .top-btn {
-  margin-top: 0;
-  margin-bottom: 0;
-  width: 100%;
-  text-align: right;
-  background: #f2f4f7;
-  padding: 10px;
-  position: relative;
-  top: -20px; }
-
-.content-single .detail .tab-pane .top-btn .btn-group {
-  margin-bottom: 0; }
+.content-single .detail .top-add {
+  margin-bottom: -30px; }
 
 #project-map h2 {
   padding-bottom: 0; }
@@ -5505,6 +5495,12 @@ main.container-fluid {
       .content-single .detail ul.list-divider li:last-child {
         border-bottom: 0;
         padding-bottom: 6px; }
+    .content-single .detail .nav-tabs li > a {
+      font-size: 13px;
+      padding: 10px; }
+    .content-single .detail .nav-tabs li.active > a, .content-single .detail .nav-tabs li.active > a:hover, .content-single .detail .nav-tabs li.active > a:focus {
+      border-color: #e7e8ea;
+      border-bottom-color: transparent; }
   .content-single .row-height .detail {
     padding-top: 0; }
   .content-single .detail-edit {
@@ -5522,6 +5518,8 @@ main.container-fluid {
       margin-bottom: 10px;
       padding-bottom: 10px;
       border-bottom: solid 1px #d9dadb; }
+    .content-single .panel .panel-body .top-add {
+      margin-bottom: -30px; }
     .content-single .panel .panel-buttons {
       padding: 20px 15px; }
       .content-single .panel .panel-buttons .btn {
@@ -5531,12 +5529,6 @@ main.container-fluid {
           margin-right: 0; }
   .content-single .nav-tabs {
     margin-bottom: 20px; }
-  .content-single .detail .nav-tabs li > a {
-    font-size: 13px;
-    padding: 10px; }
-  .content-single .detail .nav-tabs li.active > a, .content-single .detail .nav-tabs li.active > a:hover, .content-single .detail .nav-tabs li.active > a:focus {
-    border-color: #e7e8ea;
-    border-bottom-color: transparent; }
 
 body.map .content-single {
   overflow-y: hidden; }
@@ -5635,7 +5627,7 @@ textarea.form-control {
   .dataTables_wrapper table.dataTable thead .sorting_desc::after {
     content: "\e252"; }
 
-.tab-content div.dataTables_wrapper div.dataTables_filter input {
+.detail div.dataTables_wrapper div.dataTables_filter input {
   max-width: 100px; }
 
 @media (max-width: 500px) {
@@ -5905,6 +5897,13 @@ div.add-btn-btm {
   margin-bottom: 10px;
   padding-bottom: 10px;
   border-bottom: solid 1px #d9dadb; }
+
+.modal .modal-header .nav-tabs {
+  position: relative;
+  top: 16px;
+  left: 15px; }
+  .modal .modal-header .nav-tabs li.active a {
+    background: #fff; }
 
 .modal .modal-body {
   max-height: calc(100vh - 200px);

--- a/cadasta/core/static/css/main.scss
+++ b/cadasta/core/static/css/main.scss
@@ -735,7 +735,17 @@ main.container-fluid {
         border-bottom: 0;
         padding-bottom: 6px;
       }
-    } 
+    }
+    .nav-tabs {
+      li > a {
+        font-size: 13px;
+        padding: 10px;
+      }
+      li.active > a, li.active > a:hover, li.active > a:focus {
+        border-color: $table-border-color;
+        border-bottom-color: transparent;
+      }
+    }
   }
   .row-height .detail { // columns fixed to match heights like org overview 
     padding-top: 0;
@@ -761,6 +771,9 @@ main.container-fluid {
         padding-bottom: 10px;
         border-bottom: solid 1px $gray-light;
       }
+      .top-add {
+        margin-bottom: -30px;
+      }
     }
     .panel-buttons { // buttons at bottom of panels containing forms
       padding: 20px 15px;
@@ -775,16 +788,6 @@ main.container-fluid {
   }
   .nav-tabs {
     margin-bottom: 20px;
-  }
-  .detail .nav-tabs {
-    li > a {
-      font-size: 13px;
-      padding: 10px;
-    }
-    li.active > a, li.active > a:hover, li.active > a:focus {
-      border-color: $table-border-color;
-      border-bottom-color: transparent;
-    }
   }
 }
 
@@ -924,7 +927,7 @@ textarea.form-control {
   }
 }
 
-.tab-content div.dataTables_wrapper div.dataTables_filter input {
+.detail div.dataTables_wrapper div.dataTables_filter input {
   max-width: 100px;
 }
 
@@ -1264,6 +1267,14 @@ div.add-btn-btm { // add party link at bottom of table
     margin-bottom: 10px;
     padding-bottom: 10px;
     border-bottom: solid 1px #d9dadb;
+  }
+  .modal-header .nav-tabs {
+    position: relative;
+    top: $modal-title-padding + 1px;
+    left: 30px - $modal-title-padding;
+    li.active a {
+      background: $modal-content-bg;
+    }
   }
   .modal-body {
     max-height: calc(100vh - 200px);

--- a/cadasta/core/static/css/single.scss
+++ b/cadasta/core/static/css/single.scss
@@ -231,18 +231,8 @@
     margin-left: auto;
     margin-right: auto;
   }
-  .tab-pane .top-btn {
-    margin-top: 0;
-    margin-bottom: 0;
-    width: 100%;
-    text-align: right;
-    background: $body-bg;
-    padding: 10px;
-    position: relative;
-    top: -20px;
-  }
-  .tab-pane .top-btn .btn-group {
-    margin-bottom: 0;
+  .top-add {
+    margin-bottom: -30px;
   }
 }
 

--- a/cadasta/party/views/default.py
+++ b/cadasta/party/views/default.py
@@ -5,6 +5,7 @@ from jsonattrs.mixins import JsonAttrsMixin
 from core.mixins import LoginPermissionRequiredMixin
 
 from resources.forms import AddResourceFromLibraryForm
+from resources.views.mixins import ProjectHasResourcesMixin
 from . import mixins
 from .. import forms
 from .. import messages as error_messages
@@ -39,6 +40,7 @@ class PartiesAdd(LoginPermissionRequiredMixin,
 class PartiesDetail(LoginPermissionRequiredMixin,
                     JsonAttrsMixin,
                     mixins.PartyObjectMixin,
+                    ProjectHasResourcesMixin,
                     generic.DetailView):
     template_name = 'party/party_detail.html'
     permission_required = 'party.view'
@@ -87,6 +89,7 @@ class PartyResourcesAdd(LoginPermissionRequiredMixin,
 
 class PartyResourcesNew(LoginPermissionRequiredMixin,
                         mixins.PartyResourceMixin,
+                        ProjectHasResourcesMixin,
                         generic.CreateView):
     template_name = 'party/resources_new.html'
     permission_required = 'party.resources.add'
@@ -96,6 +99,7 @@ class PartyResourcesNew(LoginPermissionRequiredMixin,
 class PartyRelationshipDetail(LoginPermissionRequiredMixin,
                               JsonAttrsMixin,
                               mixins.PartyRelationshipObjectMixin,
+                              ProjectHasResourcesMixin,
                               generic.DetailView):
     template_name = 'party/relationship_detail.html'
     permission_required = 'tenure_rel.view'
@@ -130,6 +134,7 @@ class PartyRelationshipDelete(LoginPermissionRequiredMixin,
 
 class PartyRelationshipResourceNew(LoginPermissionRequiredMixin,
                                    mixins.PartyRelationshipResourceMixin,
+                                   ProjectHasResourcesMixin,
                                    generic.CreateView):
     template_name = 'party/relationship_resources_new.html'
     permission_required = 'tenure_rel.resources.add'

--- a/cadasta/resources/tests/test_views_default.py
+++ b/cadasta/resources/tests/test_views_default.py
@@ -87,8 +87,12 @@ class ProjectResourcesTest(UserTestCase):
             content = response.render().content.decode('utf-8')
             expected = render_to_string(
                 'resources/project_list.html',
-                {'object_list': resources,
-                 'object': self.project},
+                {
+                    'object_list': resources,
+                    'object': self.project,
+                    'project_has_resources': (
+                        self.project.resource_set.exists()),
+                },
                 request=self.request
             )
             assert expected == content

--- a/cadasta/resources/views/default.py
+++ b/cadasta/resources/views/default.py
@@ -4,13 +4,14 @@ from core.views.mixins import ArchiveMixin
 
 from core.mixins import LoginPermissionRequiredMixin
 
-from .mixins import ProjectResourceMixin, ResourceObjectMixin
+from . import mixins
 from ..forms import AddResourceFromLibraryForm
 from .. import messages as error_messages
 
 
 class ProjectResources(LoginPermissionRequiredMixin,
-                       ProjectResourceMixin,
+                       mixins.ProjectResourceMixin,
+                       mixins.ProjectHasResourcesMixin,
                        generic.ListView):
     template_name = 'resources/project_list.html'
     permission_required = 'resource.list'
@@ -19,7 +20,7 @@ class ProjectResources(LoginPermissionRequiredMixin,
 
 
 class ProjectResourcesAdd(LoginPermissionRequiredMixin,
-                          ProjectResourceMixin,
+                          mixins.ProjectResourceMixin,
                           base_generic.edit.FormMixin,
                           generic.DetailView):
     template_name = 'resources/project_add_existing.html'
@@ -39,7 +40,8 @@ class ProjectResourcesAdd(LoginPermissionRequiredMixin,
 
 
 class ProjectResourcesNew(LoginPermissionRequiredMixin,
-                          ProjectResourceMixin,
+                          mixins.ProjectResourceMixin,
+                          mixins.ProjectHasResourcesMixin,
                           generic.CreateView):
     template_name = 'resources/project_add_new.html'
     permission_required = 'resource.add'
@@ -50,7 +52,7 @@ class ProjectResourcesNew(LoginPermissionRequiredMixin,
 
 
 class ProjectResourcesDetail(LoginPermissionRequiredMixin,
-                             ResourceObjectMixin,
+                             mixins.ResourceObjectMixin,
                              generic.DetailView):
     template_name = 'resources/project_detail.html'
     permission_required = 'resource.view'
@@ -63,7 +65,7 @@ class ProjectResourcesDetail(LoginPermissionRequiredMixin,
 
 
 class ProjectResourcesEdit(LoginPermissionRequiredMixin,
-                           ResourceObjectMixin,
+                           mixins.ResourceObjectMixin,
                            generic.UpdateView):
     template_name = 'resources/edit.html'
     permission_required = 'resource.edit'
@@ -72,7 +74,7 @@ class ProjectResourcesEdit(LoginPermissionRequiredMixin,
 
 class ResourceArchive(LoginPermissionRequiredMixin,
                       ArchiveMixin,
-                      ResourceObjectMixin,
+                      mixins.ResourceObjectMixin,
                       generic.UpdateView):
     do_archive = True
     permission_required = 'resource.archive'
@@ -81,7 +83,7 @@ class ResourceArchive(LoginPermissionRequiredMixin,
 
 class ResourceUnarchive(LoginPermissionRequiredMixin,
                         ArchiveMixin,
-                        ResourceObjectMixin,
+                        mixins.ResourceObjectMixin,
                         generic.UpdateView):
     do_archive = False
     permission_required = 'resource.unarchive'

--- a/cadasta/resources/views/mixins.py
+++ b/cadasta/resources/views/mixins.py
@@ -82,3 +82,12 @@ class ResourceObjectMixin(ProjectResourceMixin):
         context = super().get_context_data(*args, **kwargs)
         context['resource'] = self.get_object()
         return context
+
+
+class ProjectHasResourcesMixin(ProjectMixin):
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context['project_has_resources'] = (
+            self.get_project().resource_set.exists()
+        )
+        return context

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import reverse
 from core.mixins import LoginPermissionRequiredMixin
 
 from resources.forms import AddResourceFromLibraryForm
+from resources.views.mixins import ProjectHasResourcesMixin
 from party.messages import TENURE_REL_CREATE
 from . import mixins
 from .. import forms
@@ -58,6 +59,7 @@ class LocationsAdd(LoginPermissionRequiredMixin,
 class LocationDetail(LoginPermissionRequiredMixin,
                      JsonAttrsMixin,
                      mixins.SpatialUnitObjectMixin,
+                     ProjectHasResourcesMixin,
                      generic.DetailView):
     template_name = 'spatial/location_detail.html'
     permission_required = 'spatial.view'
@@ -66,9 +68,7 @@ class LocationDetail(LoginPermissionRequiredMixin,
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context['relationships'] = (
-            context['location'].tenurerelationship_set.all()
-        )
+        context['relationships'] = self.object.tenurerelationship_set.all()
         return context
 
 
@@ -113,6 +113,7 @@ class LocationResourceAdd(LoginPermissionRequiredMixin,
 
 class LocationResourceNew(LoginPermissionRequiredMixin,
                           mixins.SpatialUnitResourceMixin,
+                          ProjectHasResourcesMixin,
                           generic.CreateView):
     template_name = 'spatial/resources_new.html'
     permission_required = 'spatial.resources.add'

--- a/cadasta/templates/party/party_detail.html
+++ b/cadasta/templates/party/party_detail.html
@@ -54,17 +54,25 @@
           <!-- /party information -->
           <!-- Party resources -->
           <h3>{% trans "Resources" %}</h3>
-          <div class="top-btn pull-right">
-            <div class="btn-group">
+          {% if party.resources %}
+            <div class="top-btn pull-right top-add">
               <a class="btn btn-primary btn-sm" href="{% url 'parties:resource_add' object.organization.slug object.slug party.id %}">
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
-                {% trans "Add from library" %}</a>
-              <a class="btn btn-primary btn-sm" href="{% url 'parties:resource_new' object.organization.slug object.slug party.id %}">
-                <span class="glyphicon glyphicon-upload" aria-hidden="true"></span>
-                {% trans "Upload new" %}</a>
+                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add" %}</a>
             </div>
-          </div>
-          {% include 'resources/table.html' with object_list=party.resources %}
+            {% include 'resources/table.html' with object_list=party.resources %}
+          {% else %}
+            <div>
+              <p>{% trans "This party does not have any connected resources. To add a resource, select the button below." %}</p>
+              <div class="btn-full">
+                {% if project_has_resources %}
+                <a class="btn btn-primary" href="{% url 'parties:resource_add' object.organization.slug object.slug party.id %}">
+                {% else %}
+                <a class="btn btn-primary" href="{% url 'parties:resource_new' object.organization.slug object.slug party.id %}">
+                {% endif %}
+                  <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add" %}</a>
+              </div>
+            </div>
+          {% endif %}
           <!-- /party resources -->
         </div>
       </div>

--- a/cadasta/templates/party/relationship_detail.html
+++ b/cadasta/templates/party/relationship_detail.html
@@ -26,7 +26,7 @@
           </div>
       </div>
     </div>
-    
+
     <!-- Relationship information -->
     <h3>{% trans "Details" %}</h3>
     <table class="table table-location">
@@ -46,20 +46,28 @@
       {% endfor %}
     </table>
     <!-- /relationship information -->
-    
+
     <!-- Relationship resources -->
     <h3>{% trans "Resources" %}</h3>
-    <div class="top-btn pull-right">
-      <div class="btn-group">
+    {% if relationship.resources %}
+      <div class="top-btn pull-right top-add">
         <a class="btn btn-primary btn-sm" href="{% url 'parties:relationship_resource_add' object.organization.slug object.slug relationship.id %}">
-          <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
-          {% trans "Add from library" %}</a>
-        <a class="btn btn-primary btn-sm" href="{% url 'parties:relationship_resource_new' object.organization.slug object.slug relationship.id %}">
-          <span class="glyphicon glyphicon-upload" aria-hidden="true"></span>
-          {% trans "Upload new" %}</a>
+          <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add" %}</a>
       </div>
-    </div>
-    {% include 'resources/table_sm.html' with object_list=relationship.resources %}
+      {% include 'resources/table_sm.html' with object_list=relationship.resources %}
+    {% else %}
+      <div>
+        <p>{% trans "This relationship does not have any connected resources. To add a resource, select the button below." %}</p>
+        <div class="btn-full">
+          {% if project_has_resources %}
+          <a class="btn btn-primary" href="{% url 'parties:relationship_resource_add' object.organization.slug object.slug relationship.id %}">
+          {% else %}
+          <a class="btn btn-primary" href="{% url 'parties:relationship_resource_new' object.organization.slug object.slug relationship.id %}">
+          {% endif %}
+            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add" %}</a>
+        </div>
+      </div>
+    {% endif %}
     <!-- /relationship resources -->
   </section>
 </div>

--- a/cadasta/templates/party/relationship_resources_add.html
+++ b/cadasta/templates/party/relationship_resources_add.html
@@ -1,37 +1,10 @@
 {% extends "party/relationship_detail.html" %}
 {% load i18n %}
 
+{% block page_title %}Add new resource for relationship | {% endblock %}
+
 {% block modals %}
-
-<div class="modal-backdrop">
-  <div class="modal show" data-backdrop="true">
-    <div class="modal-dialog modal-lg">
-      <div class="modal-content">
-        <form method="POST">
-          <div class="modal-header">
-            <a class="close" href="{% url 'parties:relationship_detail' object.organization.slug object.slug relationship.id %}">
-              <span aria-hidden="true">&times;</span>
-            </a>
-            <h3 class="modal-title">{% trans "Add resource from library" %}</h3>
-          </div>
-
-          <div class="modal-body">
-            {% include 'resources/table_add_lib.html' %}
-          </div>
-
-          <div class="modal-footer">
-            <a class="btn btn-link cancel"
-               href="{% url 'parties:relationship_detail' object.organization.slug object.slug relationship.id %}">
-              {% trans "Cancel" %}
-            </a>
-            <button type="submit" class="btn btn-primary" name="submit">
-              {% trans "Save" %}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-</div>
-
+{% url 'parties:relationship_detail' object.organization.slug object.slug relationship.id as cancel_url %}
+{% url 'parties:relationship_resource_new' object.organization.slug object.slug relationship.id as upload_url %}
+{% include 'resources/modal_add_lib.html' %}
 {% endblock %}

--- a/cadasta/templates/party/relationship_resources_new.html
+++ b/cadasta/templates/party/relationship_resources_new.html
@@ -1,37 +1,15 @@
 {% extends "party/relationship_detail.html" %}
 {% load i18n %}
 
+{% block page_title %}Upload new resource for relationship | {% endblock %}
+
+{% block extra_script %}
+  {{ form.media }}
+  {% include "resources/scripts.html" %}
+{% endblock %}
+
 {% block modals %}
-
-<div class="modal-backdrop">
-  <div class="modal show" data-backdrop="true">
-    <div class="modal-dialog modal-lg">
-      <div class="modal-content">
-        <form method="POST">
-          <div class="modal-header">
-            <a class="close" href="{% url 'parties:relationship_detail' object.organization.slug object.slug relationship.id %}">
-              <span aria-hidden="true">&times;</span>
-            </a>
-            <h3 class="modal-title">{% trans "Upload new resource" %}</h3>
-          </div>
-
-          <div class="modal-body">
-            {% include 'resources/form.html' %}
-          </div>
-
-          <div class="modal-footer">
-            <a class="btn btn-link cancel"
-               href="{% url 'parties:relationship_detail' object.organization.slug object.slug relationship.id %}">
-              {% trans "Cancel" %}
-            </a>
-            <button type="submit" class="btn btn-primary" name="submit">
-              {% trans "Submit" %}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-</div>
-
+{% url 'parties:relationship_detail' object.organization.slug object.slug relationship.id as cancel_url %}
+{% url 'parties:relationship_resource_add' object.organization.slug object.slug relationship.id as add_lib_url %}
+{% include 'resources/modal_upload.html' %}
 {% endblock %}

--- a/cadasta/templates/party/resources_add.html
+++ b/cadasta/templates/party/resources_add.html
@@ -1,37 +1,11 @@
 {% extends "party/party_detail.html" %}
 {% load i18n %}
 
+{% block page_title %}Add new resource for party | {% endblock %}
+
 {% block modals %}
-
-<div class="modal-backdrop">
-  <div class="modal show" data-backdrop="true">
-    <div class="modal-dialog modal-lg">
-      <div class="modal-content">
-        <form method="POST">
-          <div class="modal-header">
-            <a class="close" href="{% url 'parties:detail' object.organization.slug object.slug party.id %}">
-              <span aria-hidden="true">&times;</span>
-            </a>
-            <h3 class="modal-title">{% trans "Add resource from library" %}</h3>
-          </div>
-
-          <div class="modal-body">
-            {% include 'resources/table_add_lib.html' %}
-          </div>
-
-          <div class="modal-footer">
-            <a class="btn btn-link cancel"
-               href="{% url 'parties:detail' object.organization.slug object.slug party.id %}">
-              {% trans "Cancel" %}
-            </a>
-            <button type="submit" class="btn btn-primary" name="submit">
-              {% trans "Save" %}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-</div>
-
+{% url 'parties:detail' object.organization.slug object.slug party.id as cancel_url %}
+{% url 'parties:resource_new' object.organization.slug object.slug party.id as upload_url %}
+{% include 'resources/modal_add_lib.html' %}
 {% endblock %}
+

--- a/cadasta/templates/party/resources_new.html
+++ b/cadasta/templates/party/resources_new.html
@@ -1,42 +1,15 @@
 {% extends "party/party_detail.html" %}
 {% load i18n %}
 
+{% block page_title %}Upload new resource for party | {% endblock %}
+
 {% block extra_script %}
   {{ form.media }}
   {% include "resources/scripts.html" %}
 {% endblock %}
 
 {% block modals %}
-
-<div class="modal-backdrop">
-  <div class="modal show" data-backdrop="true">
-    <div class="modal-dialog modal-lg">
-      <div class="modal-content">
-        <form method="POST">
-          <div class="modal-header">
-            <a class="close" href="{% url 'parties:detail' object.organization.slug object.slug party.id %}">
-              <span aria-hidden="true">&times;</span>
-            </a>
-            <h3 class="modal-title">{% trans "Add new resource" %}</h3>
-          </div>
-
-          <div class="modal-body">
-              {% include "resources/form.html" %}  
-          </div>
-
-          <div class="modal-footer">
-            <a class="btn btn-link cancel"
-               href="{% url 'parties:detail' object.organization.slug object.slug party.id %}">
-              {% trans "Cancel" %}
-            </a>
-            <button type="submit" class="btn btn-primary" name="submit">
-              {% trans "Save" %}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-</div>
-
+{% url 'parties:detail' object.organization.slug object.slug party.id as cancel_url %}
+{% url 'parties:resource_add' object.organization.slug object.slug party.id as add_lib_url %}
+{% include 'resources/modal_upload.html' %}
 {% endblock %}

--- a/cadasta/templates/resources/modal_add_lib.html
+++ b/cadasta/templates/resources/modal_add_lib.html
@@ -1,0 +1,35 @@
+{% load i18n %}
+
+<div class="modal-backdrop">
+  <div class="modal show" data-backdrop="true">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <form method="POST">
+          <div class="modal-header">
+            <a class="close" href="{{ cancel_url }}{{ cancel_url_hash }}">
+              <span aria-hidden="true">&times;</span>
+            </a>
+            <h3 class="modal-title">{% trans "Add resource from library" %}</h3>
+            <ul class="nav nav-tabs" role="tablist">
+              <li role="presentation" class="active"><a href="" role="tab">{% trans "Add from library" %}</a></li>
+              <li role="presentation"><a href="{{ upload_url }}" role="tab">{% trans "Upload new" %}</a></li>
+            </ul>
+          </div>
+
+          <div class="modal-body">
+            {% include 'resources/table_add_lib.html' %}
+          </div>
+
+          <div class="modal-footer">
+            <a class="btn btn-link cancel" href="{{ cancel_url }}{{ cancel_url_hash }}">
+              {% trans "Cancel" %}
+            </a>
+            <button type="submit" class="btn btn-primary" name="submit">
+              {% trans "Save" %}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cadasta/templates/resources/modal_upload.html
+++ b/cadasta/templates/resources/modal_upload.html
@@ -1,0 +1,37 @@
+{% load i18n %}
+
+<div class="modal-backdrop">
+  <div class="modal show" data-backdrop="true">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <form method="POST">
+          <div class="modal-header">
+            <a class="close" href="{{ cancel_url }}{{ cancel_url_hash }}">
+              <span aria-hidden="true">&times;</span>
+            </a>
+            <h3 class="modal-title">{% trans "Upload new resource" %}</h3>
+            {% if project_has_resources %}
+            <ul class="nav nav-tabs" role="tablist">
+              <li role="presentation"><a href="{{ add_lib_url }}" role="tab">{% trans "Add from library" %}</a></li>
+              <li role="presentation" class="active"><a href="" role="tab">{% trans "Upload new" %}</a></li>
+            </ul>
+            {% endif %}
+          </div>
+
+          <div class="modal-body modal-6-12">
+            {% include "resources/form.html" %}
+          </div>
+
+          <div class="modal-footer">
+            <a class="btn btn-link cancel" href="{{ cancel_url }}{{ cancel_url_hash }}">
+              {% trans "Cancel" %}
+            </a>
+            <button type="submit" class="btn btn-primary" name="submit">
+              {% trans "Submit" %}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cadasta/templates/resources/project_add_existing.html
+++ b/cadasta/templates/resources/project_add_existing.html
@@ -1,39 +1,10 @@
-{% extends "organization/project_wrapper.html" %}
+{% extends "resources/project_list.html" %}
 {% load i18n %}
-{% load widget_tweaks %}
 
-{% block page_title %}Add new resource | {% endblock %}
-{% block left-nav %}resources{% endblock %}
+{% block page_title %}Add new resource for project | {% endblock %}
 
-{% block content %}
-
-<div class="col-md-12 content-single">
-  <div class="row">
-    <!-- Main text  -->
-    <div class="col-md-12 main-text">
-      <div class="page-title">
-        <h2>{% trans "Resources: Add" %}</h2>
-      </div>
-      <form method="POST">
-      {% csrf_token %}
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <!-- Resources index -->
-            <ul class="nav nav-tabs" role="tablist">
-              <li role="presentation" class="active"><a href="" role="tab">{% trans "From library" %}</a></li>
-              <li role="presentation"><a href="{% url 'resources:project_add_new' object.organization.slug object.slug %}" role="tab">{% trans "Upload new" %}</a></li>
-            </ul>
-            <h3>{% trans "Select files from library" %}</h3>
-            <p>{% trans "Resources in the library are able to be connected to locations, relationships, parties, and the project.  To add a connection, select the checkbox in the left column and select the 'Save' button.  If you would like to upload a new resource, select the 'Upload new' tab." %}<br /><br /></p>
-            {% include 'resources/table_add_lib.html' %}
-          </div>
-          <div class="panel-footer panel-buttons">
-            <button type="submit" class="btn btn-primary">Save</button>
-            <a href="{% url 'resources:project_list' object.organization.slug object.slug %}" class="btn btn-default">{% trans "Cancel" %}</a>
-          </div>
-        </div>
-      </form>
-    </div>
-  </div>
-
+{% block modals %}
+{% url 'resources:project_list' object.organization.slug object.slug as cancel_url %}
+{% url 'resources:project_add_new' object.organization.slug object.slug as upload_url %}
+{% include 'resources/modal_add_lib.html' %}
 {% endblock %}

--- a/cadasta/templates/resources/project_add_new.html
+++ b/cadasta/templates/resources/project_add_new.html
@@ -1,43 +1,15 @@
-{% extends "organization/project_wrapper.html" %}
+{% extends "resources/project_list.html" %}
 {% load i18n %}
 
-{% block page_title %}Upload new resource | {% endblock %}
-{% block left-nav %}resources{% endblock %}
+{% block page_title %}Upload new resource for project | {% endblock %}
 
 {% block extra_script %}
   {{ form.media }}
   {% include "resources/scripts.html" %}
 {% endblock %}
 
-{% block content %}
-
-<div class="col-md-12 content-single">
-  <div class="row">
-    <!-- Main text  -->
-    <div class="col-md-12 main-text">
-      <div class="page-title">
-        <h2>{% trans "Resources: Add" %}</h2>
-      </div>
-      <form method="POST">
-      {% csrf_token %}
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <ul class="nav nav-tabs" role="tablist">
-              <li role="presentation"><a href="{% url 'resources:project_add_existing' object.organization.slug object.slug %}" role="tab">{% trans "From library" %}</a></li>
-              <li role="presentation" class="active"><a href="" role="tab">{% trans "Upload new" %}</a></li>
-            </ul>
-            <h3>{% trans "Upload new file" %}</h3>
-            <p>{% trans "To upload a new resource, select the file and provide the name and description below. Once complete, select the 'Save' button" %}.<br /><br /></p>
-            {% include "resources/form.html" %}
-          </div>
-          <div class="panel-footer panel-buttons">
-            <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
-            <a href="{% url 'resources:project_list' object.organization.slug object.slug %}" class="btn btn-default">{% trans "Cancel" %}</a>
-          </div>
-        </div>
-      </form>
-    </div>
-  </div>
-</div>
-
+{% block modals %}
+{% url 'resources:project_list' object.organization.slug object.slug as cancel_url %}
+{% url 'resources:project_add_existing' object.organization.slug object.slug as add_lib_url %}
+{% include 'resources/modal_upload.html' %}
 {% endblock %}

--- a/cadasta/templates/resources/project_list.html
+++ b/cadasta/templates/resources/project_list.html
@@ -12,14 +12,17 @@
     <div class="col-md-12 main-text">
       <div class="page-title">
         <h2>{% trans "Resources" %}</h2>
-        <div class="top-btn pull-right">
-          <a class="btn btn-primary" href="{% url 'resources:project_add_existing' project=object.slug organization=object.organization.slug %}">
-            <span class="glyphicon glyphicon-plus" aria-hidden=true></span> {% trans "Add" %}
-          </a>
-        </div>
       </div>
       <div class="panel panel-default">
         <div class="panel-body">
+          <div class="top-btn pull-right top-add">
+            {% if project_has_resources %}
+            <a class="btn btn-primary btn-sm" href="{% url 'resources:project_add_existing' project=object.slug organization=object.organization.slug %}">
+            {% else %}
+            <a class="btn btn-primary btn-sm" href="{% url 'resources:project_add_new' project=object.slug organization=object.organization.slug %}">
+            {% endif %}
+              <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add" %}</a>
+          </div>
           {% include 'resources/table.html' %}
         </div>
       </div>

--- a/cadasta/templates/spatial/location_detail.html
+++ b/cadasta/templates/spatial/location_detail.html
@@ -24,13 +24,13 @@
           </div>
       </div>
     </div>
-    
+
     <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a href="#overview" aria-controls="overview" role="tab" data-toggle="tab">{% trans "Overview" %}</a></li>
       <li role="presentation"><a href="#relationships" aria-controls="relationships" role="tab" data-toggle="tab">{% trans "Relationships" %}</a></li>
       <li role="presentation"><a  href="#resources" aria-controls="resources" role="tab" data-toggle="tab">{% trans "Resources" %}</a></li>
     </ul>
-    
+
     <div class="tab-content">
       <!-- Overview tab -->
       <div role="tabpanel" class="tab-pane active" id="overview">
@@ -50,12 +50,12 @@
         </table>
       </div>
       <!-- /overview tab -->
-    
+
       <!-- Relationship tab -->
       <div role="tabpanel" class="tab-pane" id="relationships">
         {% if relationships %}
-          <div class="top-btn">
-            <a href="{% url 'locations:relationship_add' object.organization.slug object.slug location.id %}" class="btn btn-primary btn-sm">
+          <div class="top-btn pull-right top-add">
+            <a class="btn btn-primary btn-sm" href="{% url 'locations:relationship_add' object.organization.slug object.slug location.id %}">
             <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
             {% trans "Add" %}
             </a>
@@ -80,7 +80,7 @@
           <div>
             <p>{% trans "This location does not have any relationships and is not connected to any parties. To add your first relationship, select the button below." %}</p>
             <div class="btn-full">
-              <a href="{% url 'locations:relationship_add' object.organization.slug object.slug location.id %}" class="btn btn-primary">
+              <a class="btn btn-primary" href="{% url 'locations:relationship_add' object.organization.slug object.slug location.id %}">
               <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
               {% trans "Add relationship" %}
               </a>
@@ -89,37 +89,25 @@
         {% endif %}
       </div>
       <!-- /relationship tab -->
-    
+
       <!-- Resources tab -->
       <div role="tabpanel" class="tab-pane" id="resources">
         {% if location.resources %}
-          <div class="top-btn">
-            <div class="btn-group">
-              <a class="btn btn-primary btn-sm" href="{% url 'locations:resource_add' object.organization.slug object.slug location.id %}">
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
-                {% trans "Add from library" %}
-              </a>
-              <a class="btn btn-primary btn-sm" href="{% url 'locations:resource_new' object.organization.slug object.slug location.id %}">
-                <span class="glyphicon glyphicon-upload" aria-hidden="true"></span>
-                {% trans "Upload new" %}
-              </a>
-            </div>
+          <div class="top-btn pull-right top-add">
+            <a class="btn btn-primary btn-sm" href="{% url 'locations:resource_add' object.organization.slug object.slug location.id %}">
+              <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add" %}</a>
           </div>
           {% include 'resources/table_sm.html' with object_list=location.resources %}
         {% else %}
           <div>
-            <p>{% trans "This location does not have any connected resources. To add a resource, select from the options below." %}</p>
+            <p>{% trans "This location does not have any connected resources. To add a resource, select the button below." %}</p>
             <div class="btn-full">
-              <div class="btn-group">
-                <a class="btn btn-primary" href="{% url 'locations:resource_add' object.organization.slug object.slug location.id %}">
-                  <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
-                  {% trans "Add from library" %}
-                </a>
-                <a class="btn btn-primary" href="{% url 'locations:resource_new' object.organization.slug object.slug location.id %}">
-                  <span class="glyphicon glyphicon-upload" aria-hidden="true"></span>
-                {% trans "Upload new" %}
-                </a>
-              </div>
+              {% if project_has_resources %}
+              <a class="btn btn-primary" href="{% url 'locations:resource_add' object.organization.slug object.slug location.id %}">
+              {% else %}
+              <a class="btn btn-primary" href="{% url 'locations:resource_new' object.organization.slug object.slug location.id %}">
+              {% endif %}
+                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add" %}</a>
             </div>
           </div>
         {% endif %}

--- a/cadasta/templates/spatial/resources_add.html
+++ b/cadasta/templates/spatial/resources_add.html
@@ -1,39 +1,10 @@
 {% extends "spatial/location_wrapper.html" %}
 {% load i18n %}
-{% load widget_tweaks %}
 
-{% block page_title %}Add new resource | {% endblock %}
+{% block page_title %}Add new resource for location | {% endblock %}
 
 {% block modals %}
-<div class="modal-backdrop">
-  <div class="modal show" data-backdrop="true">
-    <div class="modal-dialog modal-lg">
-      <div class="modal-content">
-        <form method="POST">
-          <div class="modal-header">
-            <a class="close" href="{% url 'locations:detail' object.organization.slug object.slug location.id %}#resources">
-              <span aria-hidden="true">&times;</span>
-            </a>
-            <h3 class="modal-title">{% trans "Add resource from library" %}</h3>
-          </div>
-
-          <div class="modal-body">
-            {% include 'resources/table_add_lib.html' %}
-          </div>
-
-          <div class="modal-footer">
-            <a class="btn btn-link cancel"
-               href="{% url 'locations:detail' object.organization.slug object.slug location.id %}#resources">
-              {% trans "Cancel" %}
-            </a>
-            <button type="submit" class="btn btn-primary" name="submit">
-              {% trans "Save" %}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-</div>
-
+{% url 'locations:detail' object.organization.slug object.slug location.id as cancel_url %}
+{% url 'locations:resource_new' object.organization.slug object.slug location.id as upload_url %}
+{% include 'resources/modal_add_lib.html' with cancel_url_hash="#resources" %}
 {% endblock %}

--- a/cadasta/templates/spatial/resources_new.html
+++ b/cadasta/templates/spatial/resources_new.html
@@ -1,45 +1,15 @@
 {% extends "spatial/location_wrapper.html" %}
 {% load i18n %}
-{% load widget_tweaks %}
 
-{% block page_title %}Upload new resource | {% endblock %}
+{% block page_title %}Upload new resource for location | {% endblock %}
 
-{% block form_script %}
+{% block extra_script %}
   {{ form.media }}
   {% include "resources/scripts.html" %}
 {% endblock %}
 
 {% block modals %}
-
-<div class="modal-backdrop">
-  <div class="modal show" data-backdrop="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <form method="POST">
-          <div class="modal-header">
-            <a class="close" href="{% url 'locations:detail' object.organization.slug object.slug location.id %}">
-              <span aria-hidden="true">&times;</span>
-            </a>
-            <h3 class="modal-title">{% trans "Upload new resource" %}</h3>
-          </div>
-
-          <div class="modal-body modal-6-12">
-            {% include 'resources/form.html' %}
-          </div>
-
-          <div class="modal-footer">
-            <a class="btn btn-link cancel"
-               href="{% url 'locations:detail' object.organization.slug object.slug location.id %}">
-              {% trans "Cancel" %}
-            </a>
-            <button type="submit" class="btn btn-primary" name="submit">
-              {% trans "Submit" %}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-</div>
-
+{% url 'locations:detail' object.organization.slug object.slug location.id as cancel_url %}
+{% url 'locations:resource_add' object.organization.slug object.slug location.id as add_lib_url %}
+{% include 'resources/modal_upload.html' with cancel_url_hash="#resources" %}
 {% endblock %}


### PR DESCRIPTION
### Proposed changes in this pull request
- Make adding resources to projects, locations, parties, and relationships use modals consistently:
    - Add two new templates: **resources/modal_add_lib.html** and **resources/modal_upload.html**
    - Use these two new templates as a template for the 8 resource-adding/uploading templates
    - Add a tab bar to these modals to switch between adding a resource from the library or uploading a new resource
- Resolve #295:
    - Remove the tab bar mentioned above from the upload resource modals if there are no resources in the library
    - The changes above are facilitated by adding a `project_has_resources` context variable to all affected views, where the attribute is true if there are any resources belonging under the project
    - Update the view unit tests to reflect the new context variable
- Resolve #407:
    - Convert the 2-set "Add from library"/"Upload new" buttons into a single "Add" button
    - Depending on whether the project library is empty or not (using the `project_has_resources` context variable mentioned above), this single "Add" button either links to the "Add from library" modal or the "Upload new" modal
- Make the messaging consistent for when there are no connected resources for locations, parties, and relationships in the place where resources are listed
- Improve styling of the add button associated with project data tables

### Screenshots
#### Project that has resources in the library
![screen shot 2016-07-28 at 22 07 29](https://cloud.githubusercontent.com/assets/873653/17215598/fcb6cc92-550f-11e6-929a-c330655c48c9.png)
![screen shot 2016-07-28 at 22 07 37](https://cloud.githubusercontent.com/assets/873653/17215596/fbc442ba-550f-11e6-9d63-cc30f5279a96.png)
![screen shot 2016-07-28 at 22 07 41](https://cloud.githubusercontent.com/assets/873653/17215595/fbc3a364-550f-11e6-968d-de8162280085.png)
![screen shot 2016-07-28 at 22 07 54](https://cloud.githubusercontent.com/assets/873653/17215597/fc9d5a14-550f-11e6-9b91-e87b0ba76b6d.png)
![screen shot 2016-07-28 at 22 08 00](https://cloud.githubusercontent.com/assets/873653/17215594/fbbcae1a-550f-11e6-9b56-0d9144390b3c.png)
![screen shot 2016-07-28 at 22 08 03](https://cloud.githubusercontent.com/assets/873653/17215588/fa2a7e42-550f-11e6-9775-258135418a30.png)

#### Project that has an empty library
![screen shot 2016-07-28 at 22 17 56](https://cloud.githubusercontent.com/assets/873653/17215932/3d34fdce-5511-11e6-8285-838c55fb4bc3.png)
![screen shot 2016-07-28 at 22 18 14](https://cloud.githubusercontent.com/assets/873653/17215937/41bc7804-5511-11e6-9d03-3638c4257e3d.png)

### When should this PR be merged
- Needs manual functional testing:
    - Check all 8 modals for projects that have resources
    - Check 4 modals (only uploading new resources) for projects that don't have any resources
    - Check that the URL for canceling the 8 modals and switching tabs on the 8 modals are correct
    - Check that the resource-list messaging is consistent for locations, parties, and relationships that have no connected resources
- @clash99 should first review the UI/UX aspects of this PR (or it can be done as a follow-up action after the PR instead)

### Risks
- No risks foreseen

### Follow-up actions
- UI/UX review by @clash99, if not done before the PR is merged
