### PR TITLE
Make OSM tile access be over HTTPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - mkdir cadasta/geography/data
   - export WBDATA=ne_10m_admin_0_countries.zip
   - export DATADIR=cadasta/geography/data
-  - wget -O $DATADIR/$WBDATA http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/$WBDATA
+  - wget -O $DATADIR/$WBDATA https://cadasta-miscellaneous.s3.amazonaws.com/$WBDATA
   - unzip $DATADIR/$WBDATA -d $DATADIR
 
 env:

--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -157,7 +157,7 @@ ACCOUNT_LOGOUT_REDIRECT_URL = LOGIN_URL
 
 LEAFLET_CONFIG = {
     'TILES': [('OpenStreetMap',
-               'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+               'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                {'attribution':
                 'Map data &copy; <a href="http://openstreetmap.org">'
                 'OpenStreetMap</a> contributors, '

--- a/cadasta/config/settings/dev.py
+++ b/cadasta/config/settings/dev.py
@@ -58,3 +58,11 @@ ROOT_URLCONF = 'config.urls.dev'
 DEFAULT_FILE_STORAGE = 'buckets.test.storage.FakeS3Storage'
 MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'core/media')
 MEDIA_URL = '/media/'
+
+# Use HTTP for OSM for testing only, to make caching tiles for
+# functional tests a bit simpler.
+LEAFLET_CONFIG['TILES'][0] = (
+    LEAFLET_CONFIG['TILES'][0][0],
+    'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    LEAFLET_CONFIG['TILES'][0][2]
+)

--- a/cadasta/config/settings/travis.py
+++ b/cadasta/config/settings/travis.py
@@ -23,3 +23,11 @@ ROOT_URLCONF = 'config.urls.dev'
 DEFAULT_FILE_STORAGE = 'buckets.test.storage.FakeS3Storage'
 MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'core/media')
 MEDIA_URL = '/media/'
+
+# Use HTTP for OSM for testing only, to make caching tiles for
+# functional tests a bit simpler.
+LEAFLET_CONFIG['TILES'][0] = (
+    LEAFLET_CONFIG['TILES'][0][0],
+    'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    LEAFLET_CONFIG['TILES'][0][2]
+)

--- a/provision/roles/cadasta/application/tasks/main.yml
+++ b/provision/roles/cadasta/application/tasks/main.yml
@@ -66,7 +66,7 @@
 - name: Download world boundary data files
   become: yes
   become_user: "{{ app_user }}"
-  get_url: url=http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_0_countries.zip
+  get_url: url=https://cadasta-miscellaneous.s3.amazonaws.com/ne_10m_admin_0_countries.zip
            dest="{{ application_path }}cadasta/geography/data/ne_10m_admin_0_countries.zip"
 
 - name: Unzip world boundary data files


### PR DESCRIPTION
### Proposed changes in this pull request

Change the URL for the OSM tile server in the default settings to be an HTTPS URL instead of HTTP.  Add code to the development and Travis settings to make these environments still use HTTP URLs for OSM tiles.  (Rationale: @amplifi has now set up HTTPS on our production and production-like environments, and loading OSM tiles from the HTTP servers thus triggers a "page has insecure content" warning in the browser.  This change fixes that.  However, in development and staging, we use the Squid web cache to make sure that we only hit the OSM servers once for each tile that we need.  This is particularly important during functional testing, because we experienced multiple intermittent errors in the past because of throttling of requests on the OSM end.  Caching HTTPS requests appears to be quite a bit more complicated than caching HTTP requests, so requiring the use of HTTP URLs in the development and Travis environments is the simplest way to keep everything working.)

### When should this PR be merged

I think this can be merged right away.

### Risks

Few/none.

### Follow up actions

None.
