### PR TITLE
Resolve #324: Prevent duplicate org and project names

### DIFF
--- a/cadasta/organization/migrations/0002_unique_org_project_names.py
+++ b/cadasta/organization/migrations/0002_unique_org_project_names.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import itertools
+import math
+from django.db import migrations, models
+
+
+def make_org_names_unique(apps, schema_editor):
+    Organization = apps.get_model('organization', 'Organization')
+    names = {}
+    max_length = Organization._meta.get_field('name').max_length
+    for org in Organization.objects.all():
+        orig_name = org.name
+        for x in itertools.count(1):
+            if not org.name in names:
+                names[org.name] = True
+                org.save()
+                break
+            name_length = max_length - int(math.log10(x)) - 2
+            trunc_name = orig_name[:name_length]
+            org.name = '{} {}'.format(trunc_name, x)
+
+def make_project_names_unique(apps, schema_editor):
+    Project = apps.get_model('organization', 'Project')
+    names = {}
+    max_length = Project._meta.get_field('name').max_length
+    for project in Project.objects.all():
+        if not project.organization in names:
+            names[project.organization] = {}
+        orig_name = project.name
+        for x in itertools.count(1):
+            if not project.name in names[project.organization]:
+                names[project.organization][project.name] = True
+                project.save()
+                break
+            name_length = max_length - int(math.log10(x)) - 2
+            trunc_name = orig_name[:name_length]
+            project.name = '{} {}'.format(trunc_name, x)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('organization', '0001_initial'),
+    ]
+
+    operations = [
+
+        # Run database modifications to ensure that names are unique
+        migrations.RunPython(
+            make_org_names_unique,
+            reverse_code=migrations.RunPython.noop
+        ),
+        migrations.RunPython(
+            make_project_names_unique,
+            reverse_code=migrations.RunPython.noop
+        ),
+
+        # Run actual database schema modifications
+        migrations.AlterField(
+            model_name='historicalorganization',
+            name='name',
+            field=models.CharField(db_index=True, max_length=200),
+        ),
+        migrations.AlterField(
+            model_name='organization',
+            name='name',
+            field=models.CharField(max_length=200, unique=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='project',
+            unique_together=set([('organization', 'name')]),
+        ),
+    ]

--- a/cadasta/organization/models.py
+++ b/cadasta/organization/models.py
@@ -30,7 +30,7 @@ def get_policy_instance(policy_name, variables):
 
 @permissioned_model
 class Organization(SlugModel, RandomIDModel):
-    name = models.CharField(max_length=200)
+    name = models.CharField(max_length=200, unique=True)
     slug = models.SlugField(max_length=50, unique=True)
     description = models.TextField(null=True, blank=True)
     archived = models.BooleanField(default=False)
@@ -175,6 +175,7 @@ class Project(ResourceModelMixin, SlugModel, RandomIDModel):
 
     class Meta:
         ordering = ('organization', 'name')
+        unique_together = ('organization', 'name')
 
     class TutelaryMeta:
         perm_type = 'project'

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -406,7 +406,8 @@ class ProjectAddWizard(SuperUserCheckMixin,
         result = self.get_form_step_data(form)
 
         if 'details-organization' in result:
-            self.organization = result['details-organization']
+            self.storage.extra_data['organization'] = (
+                result['details-organization'])
 
         return result
 
@@ -417,8 +418,7 @@ class ProjectAddWizard(SuperUserCheckMixin,
             }
         elif step == 'permissions':
             return {
-                'organization': self.get_cleaned_data_for_step(
-                    'details').get('organization')
+                'organization': self.storage.extra_data['organization'],
             }
         else:
             return {}

--- a/functional_tests/pages/Project.py
+++ b/functional_tests/pages/Project.py
@@ -1,5 +1,4 @@
 from .base import Page
-from selenium.common.exceptions import NoSuchElementException
 
 
 class ProjectPage(Page):

--- a/functional_tests/pages/ProjectAdd.py
+++ b/functional_tests/pages/ProjectAdd.py
@@ -257,24 +257,33 @@ class ProjectAddPage(Page):
         submit_button.click()
 
     def try_submit_details(self):
-        """This method should be called when the project name is empty.
-        The method will attempt to submit the already set details and
-        verify that an error is issued due to the missing name."""
+        """This method should be called when the details form has at
+        least one error. The method will attempt to submit the already
+        set details and verify that an error is issued."""
 
         assert self.is_on_subpage('details')
-        assert re.fullmatch('\s*', self.get_name()) is not None
 
         submit_button = self.BY_CLASS('btn-primary')
         error_wait = (By.CLASS_NAME, 'errorlist')
         self.test.click_through(submit_button, error_wait)
         assert self.is_on_subpage('details')
 
-        # Assert that the error message is for the project name field
+    def check_missing_name_error(self):
+        # Assert that there is a missing project name error message
         assert self.BY_XPATH(
             "//div[@class='form-group has-error']/" +
             "input[@id='id_details-name']/../" +
             "label[contains(@class, 'control-label')]/" +
-            "ul[@class='errorlist']").text == 'This field is required.'
+            "ul[@class='errorlist']").text == "This field is required."
+
+    def check_duplicate_name_error(self):
+        # Assert that there is a missing project name error message
+        assert self.BY_XPATH(
+            "//div[@class='form-group has-error']/" +
+            "input[@id='id_details-name']/../" +
+            "label[contains(@class, 'control-label')]/" +
+            "ul[@class='errorlist']").text == (
+                "Project with this name already exists in this organization.")
 
     def submit_details(self):
         assert self.is_on_subpage('details')

--- a/functional_tests/projects/test_project_add.py
+++ b/functional_tests/projects/test_project_add.py
@@ -159,6 +159,7 @@ class ProjectAddTest(FunctionalTest):
         proj_add_page.set_access(project['access'])
         proj_add_page.set_description(project['description'])
         proj_add_page.try_submit_details()
+        proj_add_page.check_missing_name_error()
         proj_add_page.check_details(project)
 
         # Check that an error occurs when the project name is only whitespace
@@ -170,6 +171,7 @@ class ProjectAddTest(FunctionalTest):
         proj_add_page.set_access(project['access'])
         proj_add_page.set_proj_url(project['url'])
         proj_add_page.try_submit_details()
+        proj_add_page.check_missing_name_error()
         proj_add_page.check_details(project)
 
         # Set project name, final access, and invalid URL

--- a/functional_tests/projects/test_project_add_duplicate.py
+++ b/functional_tests/projects/test_project_add_duplicate.py
@@ -23,7 +23,7 @@ class ProjectAddDuplicateTest(FunctionalTest):
             self.test_data['orgadmin'],
         )
 
-        # Define 1 org the OA is an admin of
+        # Define 2 orgs the OA is an admin of
         self.test_data['orgs'] = [
             {
                 'name': "UNESCO",
@@ -39,9 +39,18 @@ class ProjectAddDuplicateTest(FunctionalTest):
                 '_members': (0,),
                 '_admins': (0,),
             },
+            {
+                'name': "UNICEF",
+                'slug': 'unicef',
+                'description': (
+                    "United Nations Children's Emergency Fund"
+                ),
+                '_members': (),
+                '_admins': (),
+            },
         ]
 
-        # Define 1 project that will be duplicated
+        # Define 2 projects that will be duplicated in separate orgs
         self.test_data['projects'] = [
             {
                 'name': "Project Gutenberg",
@@ -52,19 +61,23 @@ class ProjectAddDuplicateTest(FunctionalTest):
                 '_org': 0,
                 '_managers': (0,),
             },
+            {
+                'name': "Wikipedia",
+                'slug': 'wikipedia',
+                'description': "Public project of UNICEF.",
+                'country': 'AU',
+                'access': 'public',
+                '_org': 1,
+                '_managers': (),
+            },
         ]
 
         self.load_test_data(self.test_data)
 
-    def test_add_duplicate_project(self):
-        """Verify that adding a project with the same name as an existing
-        project will be successful. This specifically tests the unique
-        project slug field constraint."""
+    def generic_test_add_duplicate_project(self, from_same_org=True):
 
         org = self.test_data['orgs'][0]
         project = {
-            'name': "Project Gutenberg",
-            'slug': 'project-gutenberg-1',
             'description': "",
             'country': '',
             'access': 'public',
@@ -72,6 +85,10 @@ class ProjectAddDuplicateTest(FunctionalTest):
             '_org_name': org['name'],
             '_org_logo': org['logo'] if 'logo' in org else '',
         }
+        duplicated_proj_idx = 0 if from_same_org else 1
+        duplicated_proj = self.test_data['projects'][duplicated_proj_idx]
+        project['name'] = duplicated_proj['name']
+        project['slug'] = duplicated_proj['slug'] + '-1'
 
         # Log in as org admin
         LoginPage(self).login(
@@ -79,28 +96,59 @@ class ProjectAddDuplicateTest(FunctionalTest):
             self.test_data['orgadmin']['password'],
         )
 
+        # Go to the add project wizard and
+        # proceed to step 2 and input the project name
         proj_add_page = ProjectAddPage(self)
         proj_add_page.go_to()
-
         proj_add_page.submit_geometry()
         proj_add_page.set_name(project['name'])
+
+        if from_same_org:
+            # If project name is duplicate from the same org, expect that
+            # submitting step 2 will result in an error
+            proj_add_page.try_submit_details()
+            proj_add_page.check_duplicate_name_error()
+
+            # Make the name unique
+            project['name'] = project['name'] + " 1"
+            proj_add_page.set_name(project['name'])
+
+        # successfully complete the add project wizard
         proj_add_page.submit_details()
         proj_add_page.submit_permissions()
 
-        # Check that we are now in the project page
-        # and that displayed project details are correct
+        # Check that we are now in the new project page
+        # and that the displayed project details are correct
         proj_page = ProjectPage(self, project['_org_slug'], project['slug'])
         assert proj_page.is_on_page()
         proj_page.check_page_contents(project)
 
-        old_project = self.test_data['projects'][0].copy()
-        old_project['_org_slug'] = org['slug']
-        old_project['_org_name'] = org['name']
-        old_project['_org_logo'] = org['logo'] if 'logo' in org else ''
+        # Construct final list of projects that should be in the DB
+        expected_projs = []
+        for proj in self.test_data['projects']:
+            proj_copy = proj.copy()
+            proj_org = self.test_data['orgs'][proj['_org']]
+            proj_copy['_org_slug'] = proj_org['slug']
+            proj_copy['_org_name'] = proj_org['name']
+            proj_copy['_org_logo'] = (
+                proj_org['logo'] if 'logo' in proj_org else '')
+            expected_projs.append(proj_copy)
+        expected_projs.append(project)
 
         # Go to project list and check that details are correct
         proj_list_page = ProjectListPage(self)
         proj_list_page.go_to_and_check_on_page()
-        proj_list_page.check_project_list([old_project, project])
+        proj_list_page.check_project_list(expected_projs)
 
         self.logout()
+
+    def test_add_duplicate_project(self):
+        """Verify that adding a project with the same name as an existing
+        project will not be successful until corrected."""
+        self.generic_test_add_duplicate_project(from_same_org=True)
+
+    def test_add_duplicate_project_in_another_org(self):
+        """Verify that adding a project with the same name as an existing
+        project in another org will be successful. This specifically
+        tests the unique project slug field constraint."""
+        self.generic_test_add_duplicate_project(from_same_org=False)


### PR DESCRIPTION
### Proposed changes in this pull request
- Resolve #324:
    - Add `unique=True` to the `name` field of the `Organization` model
    - Add a `unique_together` constraint for the `organization` and `name` fields of the `Project` model 
    - Generate the migration script for the above data model changes, and then modify the script to add two `RunPython` operations to deduplicate existing data, if any, in the database, one for organization names and the other for project names. The deduplication is based on the `SlugModel` algorithm. This migration script was manually tested by running it against the development environment database with the following test data:
        - Two organizations with the same name; expected change is that one of the organizations will have " 1" appended to its name
        - Two projects in the same organization with the same name; expected change is that one of the projects will have " 1" appended to its name
        - Two projects in different organizations with the same name; no change is expected
    - Add validation to check for unique project names in the `ProjectAddDetails` and `ProjectEditDetails` forms. This explicit validation is needed because the wizard nature of these forms prevents the `unique_together` validation from working resulting to `IntegrityError` exceptions
    - Add a similar validation to `ProjectSerializer` and suppress the automatic `unique_together` validation. This explicit validation is needed in place of the implicit validation because the implicit validation does not work due to the `organization` field being `read_only` in the serializer which conflicts with the requirement for implicit `unique_together` validation that the `unique_together` fields are `required=True`
    - Add unit tests for the following test cases:
        - `OrganizationForm` test for adding a new organization with a duplicate name
        - `ProjectAddDetails` test for adding a new project with a duplicate name from the same organization
        - `ProjectAddDetails` test for adding a new project with a duplicate name from a different organization
        - `ProjectEditDetails` test for updating a project with a duplicate name from the same organization
        - `OrganizationSerializer` test for adding a new organization with a duplicate name
        - `OrganizationSerializer` test for updating an organization with a duplicate name
        - `ProjectSerializer` test for adding a new project with a duplicate name from the same organization
        - `ProjectSerializer` test for adding a new project with a duplicate name from a different organization
        - `ProjectSerializer` test for updating a project with a duplicate name from the same organization
    - Disable the existing `OrganizationForm` unit test for testing that the organization `slug` becomes unique because organization names are now required to be unique which prevents the slug deduplication code from actually working
    - Update the existing add duplicate project name functional tests to test the case where the duplicate name is from the same organization and where the duplicate name is from a different organization
- Improve the restricted organization and project names ("Add" and "New") functionality:
    - The original idea with this restriction is to prevent "add" and "new" slug values. So the restriction was only applied during organization and project creation when the slug is assigned. So users can actually rename existing organizations and projects to "Add" or "New" even though we say to the user that these names are not allowed. This "hidden" feature I think is undesired.
    - Modify the existing `name` validations in `OrganizationForm`, `OrganizationSerializer`, and `ProjectSerializer` to also check during organization or project update
    - Add validation to `ProjectEditDetails`
    - Add unit tests for the following test cases:
        - `OrganizationForm` test for updating an organization with a restricted name
        - `ProjectEditDetails` test for updating a project with a restricted name
        - `OrganizationSerializer` test for updating an organization with a restricted name
        - `ProjectSerializer` test for updating a project with a restricted name

### When should this PR be merged
- I suggest that somebody confirm the data migration manual testing described above by doing it prior to merging because this manual testing cannot be automatically done (like in Travis)

### Risks
- Hopefully, there should be no production database corruption happening as a result of this update

### Follow up actions
- [ ] When Sprint 7 is deployed to production, the database migration procedure should be performed as a rehearsal of our procedures even though the production database does not contain any duplicate names as of now

- **Note to developers:** Django `migrate` action is needed when you update your local repository
