### PR TITLE
Refactor permissions checks (fixes #485)

### DIFF
--- a/cadasta/core/form_mixins.py
+++ b/cadasta/core/form_mixins.py
@@ -1,0 +1,14 @@
+from tutelary.models import Role
+
+
+class SuperUserCheck:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._su_role = None
+
+    def is_superuser(self, user):
+        if not hasattr(self, 'su_role'):
+            self.su_role = Role.objects.get(name='superuser')
+
+        return any([isinstance(pol, Role) and pol == self.su_role
+                    for pol in user.assigned_policies()])


### PR DESCRIPTION
### Proposed changes in this pull request

Refactor in-view permissions checking used for control of UI element visibility.

- Introduce permissions checking mixins for views to determine whether the requesting user is an administrator of a particular organization, or is allowed to create projects (either in a particular organization or in any organization).
- Introduce a superuser checking mixin for forms (in `core/form_mixins.py`).

Fixes #485

### When should this PR be merged

Any time.

### Risks

Low to no risk.

### Follow up actions

None.
