### PR TITLE
Fix #530: add project wizard data preservation

### DIFF
--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -516,6 +516,18 @@ class ProjectAddTest(UserTestCase):
         assert Questionnaire.objects.filter(project=proj).exists() is True
         # assert proj.public
 
+    def test_wizard_previous(self):
+        self.client.force_login(self.users[0])
+        extents_response = self.client.post(
+            reverse('project:add'), self.EXTENTS_POST_DATA
+        )
+        assert extents_response.status_code == 200
+        self.DETAILS_POST_DATA['wizard_goto_step'] = 'extents'
+        details_response = self.client.post(
+            reverse('project:add'), self.DETAILS_POST_DATA
+        )
+        assert details_response.status_code == 200
+
     def test_full_flow_invalid_xlsform(self):
         self.client.force_login(self.users[0])
         extents_response = self.client.post(

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -411,6 +411,15 @@ class ProjectAddWizard(SuperUserCheckMixin,
 
         return result
 
+    def render_goto_step(self, goto_step, **kwargs):
+        form = self.get_form(data=self.request.POST, files=self.request.FILES)
+        if form.is_valid():
+            self.storage.set_step_data(self.steps.current,
+                                       self.process_step(form))
+            self.storage.set_step_files(self.steps.current,
+                                        self.process_step_files(form))
+        return super().render_goto_step(goto_step, **kwargs)
+
     def get_form_kwargs(self, step=None):
         if step == 'details':
             return {

--- a/cadasta/templates/organization/project_add_details.html
+++ b/cadasta/templates/organization/project_add_details.html
@@ -128,7 +128,7 @@
 {% endblock %}
 
 {% block step_content_buttons %}
-<button class="btn btn-default" type="submit" name="wizard_goto_step" value="{{ wizard.steps.prev }}">
+<button class="btn btn-default btn-details-previous" type="submit" name="wizard_goto_step" value="{{ wizard.steps.prev }}">
   <span class="glyphicon glyphicon-triangle-left"></span>
   {% trans "Previous" %}
 </button>

--- a/functional_tests/pages/ProjectAdd.py
+++ b/functional_tests/pages/ProjectAdd.py
@@ -256,6 +256,11 @@ class ProjectAddPage(Page):
         submit_button = self.BY_CLASS('btn-primary')
         submit_button.click()
 
+    def click_previous_details(self):
+        previous_button = self.BY_CLASS('btn-details-previous')
+        self.test.click_through(previous_button,
+                                (By.CLASS_NAME, 'project-extent-map'))
+
     def try_submit_details(self):
         """This method should be called when the details form has at
         least one error. The method will attempt to submit the already

--- a/functional_tests/projects/test_project_add.py
+++ b/functional_tests/projects/test_project_add.py
@@ -186,9 +186,15 @@ class ProjectAddTest(FunctionalTest):
         proj_add_page.click_submit_details()
         proj_add_page.check_details(project)
 
-        # Correct the URL and finally submit details
+        # Correct the URL, press "Previous" then "Next" and ensure
+        # that details settings are preserved.
         project['url'] = self.test_data['project_url']
         proj_add_page.set_proj_url(project['url'])
+        proj_add_page.click_previous_details()
+        proj_add_page.submit_geometry()
+        proj_add_page.check_details(project)
+
+        # Finally submit details
         proj_add_page.submit_details()
 
         # Set permissions


### PR DESCRIPTION
### Proposed changes in this pull request

- Add code to save form data when "Previous" button is pressed in add project wizard to ensure that field values are saved whatever steps the user takes through the wizard.  (By default, the form wizard that we are using only saves form data when transitioning between forms in the "normal" direction.  Special actions need to be taken if data is to be saved when switching back to a previous form.)

Fixes #530

### When should this PR be merged

Can be merged immediately.

### Risks

None.

### Follow up actions

None.
