### PR TITLE
Fix #528: Include contacts when adding a project

### DIFF
--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -459,8 +459,8 @@ class ProjectAddTest(UserTestCase):
         'details-url': 'http://www.test.org',
         'details-contacts-TOTAL_FORMS': 1,
         'details-contacts-INITIAL_FORMS': 0,
-        'details-contacts-0-name': '',
-        'details-contacts-0-email': '',
+        'details-contacts-0-name': "John Lennon",
+        'details-contacts-0-email': 'john@beatles.co.uk',
         'details-contacts-0-tel': ''
     }
     PERMISSIONS_POST_DATA = {
@@ -499,6 +499,9 @@ class ProjectAddTest(UserTestCase):
         proj = Project.objects.get(organization=self.org, name='Test Project')
         assert proj.slug == 'test-project'
         assert proj.description == 'This is a test project'
+        assert len(proj.contacts) == 1
+        assert proj.contacts[0]['name'] == "John Lennon"
+        assert proj.contacts[0]['email'] == 'john@beatles.co.uk'
         assert ProjectRole.objects.filter(project=proj).count() == 3
         for r in ProjectRole.objects.filter(project=proj):
             if r.user.username == 'org_member_1':
@@ -535,6 +538,9 @@ class ProjectAddTest(UserTestCase):
         proj = Project.objects.get(organization=self.org, name='Test Project')
         assert proj.slug == 'test-project'
         assert proj.description == 'This is a test project'
+        assert len(proj.contacts) == 1
+        assert proj.contacts[0]['name'] == "John Lennon"
+        assert proj.contacts[0]['email'] == 'john@beatles.co.uk'
         for r in ProjectRole.objects.filter(project=proj):
             if r.user.username == 'org_member_1':
                 assert r.role == 'PM'
@@ -576,6 +582,9 @@ class ProjectAddTest(UserTestCase):
         proj = Project.objects.get(organization=self.org, slug=expected_slug)
         assert proj.slug == expected_slug
         assert proj.description == 'This is a test project'
+        assert len(proj.contacts) == 1
+        assert proj.contacts[0]['name'] == "John Lennon"
+        assert proj.contacts[0]['email'] == 'john@beatles.co.uk'
         assert ProjectRole.objects.filter(project=proj).count() == 3
         for r in ProjectRole.objects.filter(project=proj):
             if r.user.username == 'org_member_1':

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -426,12 +426,14 @@ class ProjectAddWizard(SuperUserCheckMixin,
     def done(self, form_list, form_dict, **kwargs):
         form_data = [form.cleaned_data for form in form_list]
         extent = form_data[0]['extent']
+        organization = form_data[1]['organization']
         name = form_data[1]['name']
         description = form_data[1]['description']
-        organization = form_data[1]['organization']
+        access = form_data[1].get('access')
         url = form_data[1]['url']
         questionaire = form_data[1].get('questionaire')
-        access = form_data[1].get('access')
+        contacts = form_data[1].get('contacts')
+
         org = Organization.objects.get(slug=organization)
 
         user_roles = []
@@ -444,7 +446,7 @@ class ProjectAddWizard(SuperUserCheckMixin,
             project = Project.objects.create(
                 name=name, organization=org,
                 description=description, urls=[url], extent=extent,
-                access=access
+                access=access, contacts=contacts
             )
             for username, role in user_roles:
                 user = User.objects.get(username=username)


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #528:
    - Include missing `contacts` argument in the `Project.objects.create()` call in `ProjectAddWizard.done()`
    - Modify 3 unit tests to catch this bug and confirm that it has been fixed

### When should this PR be merged
Anytime.

### Risks
No risks foreseen.

### Follow up actions
None.