### PR TITLE
Firefox for testing from S3 bucket

### DIFF
--- a/provision/roles/testing/tasks/main.yml
+++ b/provision/roles/testing/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download Firefox 46 install bundle
   become: yes
   become_user: root
-  get_url: url=https://ftp.mozilla.org/pub/firefox/releases/46.0.1/linux-x86_64/en-US/firefox-46.0.1.tar.bz2
+  get_url: url=https://cadasta-miscellaneous.s3.amazonaws.com/firefox-46.0.1.tar.bz2
            dest=/opt/firefox-46.0.1.tar.bz2
 
 - name: Unpack Firefox 46 install bundle


### PR DESCRIPTION
### Proposed changes in this pull request

We need to install Firefox in the development VM for functional testing.  I've been having problems with the main Firefox FTP site this morning, so I uploaded a copy of the relevant install bundle to our `cadasta-miscellaneous` S3 bucket and updated the provisioning scripts to get the bundle from there.

### When should this PR be merged

Any time.

### Risks

No risks.

### Follow up actions

None.