### PR TITLE
Fix #525: "Next" button is default in wizard steps

### DIFF
--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -3732,11 +3732,12 @@ table th[class*="col-"] {
     text-align: right;
     padding: 20px 30px; }
     #project-wizard .panel .panel-buttons .btn {
+      float: right;
       min-width: 160px !important;
-      margin-right: 20px;
+      margin-left: 20px;
       margin-bottom: 10px; }
-      #project-wizard .panel .panel-buttons .btn:last-child {
-        margin-right: 0; }
+      #project-wizard .panel .panel-buttons .btn:first-child {
+        margin-left: 0; }
     #project-wizard .panel .panel-buttons .btn-link {
       min-width: 60px !important; }
 

--- a/cadasta/core/static/css/wizard.scss
+++ b/cadasta/core/static/css/wizard.scss
@@ -119,7 +119,7 @@
   .col-md-8.map {
     padding-left: 0;
   }
-  h1 { 
+  h1 {
     color: $brand-darkblue;
     text-shadow: none;
     margin: 14px auto;
@@ -162,11 +162,12 @@
       text-align: right;
       padding: 20px 30px;
       .btn {
+        float: right;
         min-width: 160px !important;
-        margin-right: 20px;
+        margin-left: 20px;
         margin-bottom: 10px;
-        &:last-child {
-          margin-right: 0;
+        &:first-child {
+          margin-left: 0;
         }
       }
       .btn-link {

--- a/cadasta/templates/organization/project_add_details.html
+++ b/cadasta/templates/organization/project_add_details.html
@@ -128,13 +128,13 @@
 {% endblock %}
 
 {% block step_content_buttons %}
-<button class="btn btn-default btn-details-previous" type="submit" name="wizard_goto_step" value="{{ wizard.steps.prev }}">
-  <span class="glyphicon glyphicon-triangle-left"></span>
-  {% trans "Previous" %}
-</button>
 <button class="btn btn-primary" type="submit">
   {% trans 'Next' %}
   <span class="glyphicon glyphicon-triangle-right"></span>
+</button>
+<button class="btn btn-default btn-details-previous" type="submit" name="wizard_goto_step" value="{{ wizard.steps.prev }}">
+  <span class="glyphicon glyphicon-triangle-left"></span>
+  {% trans "Previous" %}
 </button>
 {% endblock %}
 

--- a/cadasta/templates/organization/project_add_permissions.html
+++ b/cadasta/templates/organization/project_add_permissions.html
@@ -53,13 +53,13 @@
 {% endblock %}
 
 {% block step_content_buttons %}
-<button class="btn btn-default" type="submit" name="wizard_goto_step" value="{{ wizard.steps.prev }}">
-  <span class="glyphicon glyphicon-triangle-left"></span>
-  {% trans "Previous" %}
-</button>
 <button class="btn btn-primary" type="submit">
   {% trans 'Next' %}
   <span class="glyphicon glyphicon-triangle-right"></span>
+</button>
+<button class="btn btn-default" type="submit" name="wizard_goto_step" value="{{ wizard.steps.prev }}">
+  <span class="glyphicon glyphicon-triangle-left"></span>
+  {% trans "Previous" %}
 </button>
 {% endblock %}
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Reorder "Previous" and "Next" buttons on project add wizard pages to make "Next" button be the default submit button for the forms.
- Add CSS to make the "Previous" button appear to the left of the "Next" button.

### When should this PR be merged

Any time.

### Risks

No risks.

### Follow up actions

None.