### PR TITLE
Fix #463: Make URL errors more meaningful

### DIFF
--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -110,7 +110,11 @@ class ContactsForm(forms.Form):
 
 
 class OrganizationForm(forms.ModelForm):
-    urls = pg_forms.SimpleArrayField(forms.URLField(), required=False)
+    urls = pg_forms.SimpleArrayField(
+        forms.URLField(required=False),
+        required=False,
+        error_messages={'item_invalid': ""},
+    )
     contacts = ContactsField(form=ContactsForm, required=False)
     access = PublicPrivateField()
 
@@ -121,15 +125,6 @@ class OrganizationForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user', None)
         super(OrganizationForm, self).__init__(*args, **kwargs)
-
-    def to_list(self, value):
-        if value:
-            return [value]
-        else:
-            return []
-
-    def clean_urls(self):
-        return self.to_list(self.data.get('urls'))
 
     def clean_name(self):
         name = self.cleaned_data['name']
@@ -287,7 +282,11 @@ class ProjectAddDetails(SuperUserCheck, forms.Form):
 
 
 class ProjectEditDetails(forms.ModelForm):
-    urls = pg_forms.SimpleArrayField(forms.URLField(), required=False)
+    urls = pg_forms.SimpleArrayField(
+        forms.URLField(required=False),
+        required=False,
+        error_messages={'item_invalid': ""},
+    )
     questionnaire = forms.CharField(
         required=False,
         widget=S3FileUploadWidget(upload_to='xls-forms',

--- a/functional_tests/organizations/test_organization_list.py
+++ b/functional_tests/organizations/test_organization_list.py
@@ -86,7 +86,7 @@ class OrganizationListTest(FunctionalTest):
         fields = page.get_fields()
         fields['name'].send_keys('Organization #2')
         fields['description'].send_keys('This is a test organization')
-        fields['urls'].send_keys('test.com')
+        fields['urls'].send_keys('invalid url')
         page.try_submit(err=['urls'], ok=['name', 'description'])
 
         fields = page.get_fields()


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #463: 
    - Fix the “Item 0 in the array did not validate: ” error message by overriding the default `item_invalid` error message of `SimpleArrayField` with an empty string.
    - Fix the erroneous error when entering a URL like “cadasta.org” by removing the unnecessary `to_list()` and `clean_urls()` methods in `OrganizationForm`. `URLField` can handle URLs like these and coerce them into valid HTTP URLs.
    - Add unit tests to check for the above bugs and to confirm that they are fixed
    - Add other unit tests related to URLs
    - Fix 1 functional test
    - Perform some DRYing of the affected unit tests

### When should this PR be merged
Anytime.

### Risks
No risks foreseen.

### Follow up actions
None.
