### PR TITLE
Resolve #441: Improve relationship party selection widget

### DIFF
--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -5820,8 +5820,7 @@ img.org-logo, img#org-logo {
   .top-btn .btn-rt {
     min-width: 20px; }
 
-button#add-contact,
-button#add-party {
+button#add-contact {
   padding: 0; }
 
 .btn-full {
@@ -5945,7 +5944,7 @@ div.add-btn-btm {
   .modal .modal-footer .btn {
     min-width: 100px; }
 
-.modal button#add-contact, .modal button#add-party {
+.modal button#add-contact {
   background: transparent;
   color: #2e51a3 !important;
   border: 0;
@@ -5989,5 +5988,32 @@ tr.contacts-error {
     border-top: none;
     padding-top: 0;
     background: #fcf8e3; }
+
+/* =Party selection widget
+-------------------------------------------------------------- */
+#select-party label {
+  display: block; }
+
+#select-party #party-select {
+  width: 100%; }
+
+#select-party .select2 {
+  display: block;
+  margin: 0.5em 0;
+  width: 100%; }
+
+#select-party #add-party {
+  padding: 6px 18px; }
+  #select-party #add-party .glyphicon {
+    opacity: 0.5;
+    padding-right: 8px; }
+
+.select2-container .party-name {
+  display: block; }
+
+.select2-container .party-type {
+  display: block;
+  font-size: 0.85em;
+  opacity: 0.75; }
 
 /*# sourceMappingURL=../../../../../static/css/main.css.map */

--- a/cadasta/core/static/css/main.scss
+++ b/cadasta/core/static/css/main.scss
@@ -1177,8 +1177,7 @@ img.org-logo, img#org-logo {
   }
 }
 
-button#add-contact,
-button#add-party { // below contacts table and party table
+button#add-contact { // below contacts table
   padding: 0;
 }
 
@@ -1324,7 +1323,7 @@ div.add-btn-btm { // add party link at bottom of table
       min-width: 100px;
     }
   }
-  button#add-contact, button#add-party {
+  button#add-contact {
     background: transparent;
     color: $link-color !important;
     border: 0;
@@ -1378,5 +1377,40 @@ tr.contacts-error {
     border-top: none;
     padding-top: 0;
     background: $alert-warning-bg;
+  }
+}
+
+/* =Party selection widget
+-------------------------------------------------------------- */
+
+#select-party {
+  label {
+    display: block;
+  }
+  #party-select {
+    width: 100%;
+  }
+  .select2 {
+    display: block;
+    margin: 0.5em 0;
+    width: 100%;
+  }
+  #add-party {
+    padding: 6px 18px;
+    .glyphicon {
+      opacity: 0.5;
+      padding-right: 8px;
+    }
+  }
+}
+
+.select2-container {
+  .party-name {
+    display: block;
+  }
+  .party-type {
+    display: block;
+    font-size: 0.85em;
+    opacity: 0.75;
   }
 }

--- a/cadasta/spatial/tests/test_widgets.py
+++ b/cadasta/spatial/tests/test_widgets.py
@@ -12,21 +12,22 @@ class SelectPartyWidgetTest(TestCase):
 
         widget = SelectPartyWidget(project=project)
         rendered = widget.render(name='name', value='value')
-        assert '<input type="hidden" name="name" value="value">' in rendered
-        assert ('<tr data-id="' + party_1.id + '"><td>' + party_1.name + ''
-                '</td><td>' + party_1.get_type_display() + '</td><tr>'
-                in rendered)
-        assert ('<tr data-id="' + party_2.id + '"><td>' + party_2.name + ''
-                '</td><td>' + party_2.get_type_display() + '</td><tr>'
-                in rendered)
+        assert ('<select id="party-select" name="name">' in rendered)
+        assert ('<option value="' + party_1.id + '" data-type="'
+                '' + party_1.get_type_display() + '">' + party_1.name + ''
+                '</option>' in rendered)
+        assert ('<option value="' + party_2.id + '" data-type="'
+                '' + party_2.get_type_display() + '">' + party_2.name + ''
+                '</option>' in rendered)
 
 
 class NewEntityWidgetTest(TestCase):
     def test_render_value(self):
         widget = NewEntityWidget()
         expected = (
-            '<button class="btn btn-link"'
-            '        id="add-party" type="button">Add party</button>'
+            '<button class="btn btn-default" id="add-party" type="button">'
+            '<span class="glyphicon glyphicon-plus" aria-hidden="true">'
+            '</span> Add party</button>'
             '<input id="new_entity_field" type="hidden"'
             '       name="name" value="value">'
         )
@@ -36,8 +37,9 @@ class NewEntityWidgetTest(TestCase):
     def test_render_no_value(self):
         widget = NewEntityWidget()
         expected = (
-            '<button class="btn btn-link"'
-            '        id="add-party" type="button">Add party</button>'
+            '<button class="btn btn-default" id="add-party" type="button">'
+            '<span class="glyphicon glyphicon-plus" aria-hidden="true">'
+            '</span> Add party</button>'
             '<input id="new_entity_field" type="hidden"'
             '       name="name" value="">'
         )

--- a/cadasta/spatial/widgets.py
+++ b/cadasta/spatial/widgets.py
@@ -1,4 +1,5 @@
 from django.forms.widgets import HiddenInput
+from django.utils.translation import ugettext as _
 from party.models import Party
 
 
@@ -9,26 +10,15 @@ class SelectPartyWidget(HiddenInput):
 
     def render(self, name, value, attrs={}):
         prj_parties = Party.objects.filter(project_id=self.project)
-        parties = ['<tr data-id="' + p.id + '"><td>' + p.name + '</td>'
-                   '<td>' + p.get_type_display() + '</td><tr>'
+        parties = ['<option value="' + p.id + '" data-type="' +
+                   p.get_type_display() + '">' + p.name + '</option>'
                    for p in prj_parties]
 
         return (
-            '<table class="table" id="select-list">'
-            '  <thead>'
-            '    <tr>'
-            '      <th>Party</th>'
-            '      <th>Type</th>'
-            '    </tr>'
-            '  </thead>'
-            '  <tbody>'
-            '    {parties}'
-            '  </tbody>'
-            '</table>'
-            '<input type="hidden" name="{name}" value="{value}">'
-        ).format(parties=''.join(parties),
-                 name=name,
-                 value=value or '')
+            '<select id="party-select" name="{name}">'
+            '{parties}'
+            '</select>'
+        ).format(parties=''.join(parties), name=name)
 
 
 class NewEntityWidget(HiddenInput):
@@ -37,10 +27,14 @@ class NewEntityWidget(HiddenInput):
 
     def render(self, name, value, attrs={}):
         html = (
-            '<button class="btn btn-link"'
-            '        id="add-party" type="button">Add party</button>'
+            '<button class="btn btn-default" id="add-party" type="button">'
+            '<span class="glyphicon glyphicon-plus" aria-hidden="true">'
+            '</span> {button_text}</button>'
             '<input id="new_entity_field" type="hidden"'
             '       name="{name}" value="{value}">'
         )
+        button_text = _("Add party")
 
-        return html.format(name=name, value=(value if value else ''))
+        return html.format(name=name,
+                           value=(value if value else ''),
+                           button_text=button_text)

--- a/cadasta/templates/spatial/relationship_add.html
+++ b/cadasta/templates/spatial/relationship_add.html
@@ -4,8 +4,33 @@
 
 {% block page_title %}Add new relationship | {% endblock %}
 
+{% block extra_head %}
+{{ block.super }}
+<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css" rel="stylesheet" />
+{% endblock %}
+
 {% block location_extra_script %}
   {{ form.media }}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
+  <script>
+$(document).ready(function() {
+  var template = function(party) {
+    if (!party.id) {
+      return party.text;
+    }
+    return $(
+      '<div class="party-option">' +
+      '<strong class="party-name">' + party.text + '</strong>' +
+      '<span class="party-type">' + party.element.dataset.type + '</span>' +
+      '</div>'
+    );
+  };
+  $("#party-select").select2({
+    minimumResultsForSearch: 6,
+    templateResult: template,
+  });
+});
+  </script>
 {% endblock %}
 
 {% block form_modal %}
@@ -26,11 +51,10 @@
 
             <h4 class="step">{% trans "1. Connected party" %}</h4>
             <div id="select-party" class="clearfix">
-              <label>Choose a party to connect to this location</label>
+              <label>{% trans "Choose an existing party to connect to this location" %}</label>
               {% render_field form.id class+="form-control" %}
-              <div class="add-btn-btm clearfix">
-                {% render_field form.new_entity class+="form-control" %}
-              </div>
+              <label>{% trans "Or add a new party" %}</label>
+              {% render_field form.new_entity class+="form-control" %}
             </div>
 
             <div id="new-item" class="clearfix{% if not form.new_entity.value %} hidden{% endif %}">


### PR DESCRIPTION
### Proposed changes in this pull request
- Resolve #441:
    - Use [Select2](https://select2.github.io/) to convert the table of selectable parties used in creating a new tenure relationship into a searchable select box. Select2 was used instead of [Selectize](https://selectize.github.io/selectize.js/) that was suggested by @clash99 because Select2 has its CSS and JS files hosted on a [CDN](https://cdnjs.com/about). Both support the features that we might want in a party selection widget and it's easy to switch to Selectize if that is desired.
    - Update the `SelectPartyWidget` widget to output `<select>` instead of `<table>`.
    - Update the `NewEntityWidget` widget to show the "Add party" button as a button instead of as a link, and to make the button text translatable.
    - Update the **relationship_add.html** template to load Select2 into the party `<select>` tag, and to make the widget `<label>`s translatable.
    - Update **main.scss** to style the updated widgets.
    - Update the widget unit tests.

### Screenshots
Default view of the "Add New Relationship" modal showing the Select2 in action.

![screen shot 2016-08-11 at 04 47 56](https://cloud.githubusercontent.com/assets/873653/17571295/400b5ed2-5f82-11e6-9e5e-835f4a6f2c95.png)

When the select box is clicked, we get a nice list of parties with their names and types shown. This can be easily updated in the future to include as many party attributes as needed.

![screen shot 2016-08-11 at 04 48 33](https://cloud.githubusercontent.com/assets/873653/17571306/4759d830-5f82-11e6-8ed2-53f53ddb914d.png)

Clicking on a party locks that selection in.

![screen shot 2016-08-11 at 04 48 45](https://cloud.githubusercontent.com/assets/873653/17571305/475800e6-5f82-11e6-8ac0-a61a3abc4f68.png)

Clicking on the "Add party" button allows us to create a new party instead. This is the same as the previous behavior.

![screen shot 2016-08-11 at 04 48 49](https://cloud.githubusercontent.com/assets/873653/17571301/47030622-5f82-11e6-991b-5b7626a7ce93.png)

When there are more than 5—this is customizable—parties in the project, the Select2 widget displays a search box that can filter the parties that can be selected.

![screen shot 2016-08-11 at 05 15 48](https://cloud.githubusercontent.com/assets/873653/17571439/c5448556-5f82-11e6-8019-a06055a85ffd.png)

### When should this PR be merged
It would be nice if @clash99 can take a look and see if the updated widget is up to the task. Alternatively, this can be merged now and then updated in the future.

### Risks
No risks foreseen

### Follow up actions
None.
