### PR TITLE
Try to make functional tests more reliable

### DIFF
--- a/functional_tests/pages/Login.py
+++ b/functional_tests/pages/Login.py
@@ -44,9 +44,8 @@ class LoginPage(Page):
         self.get_password_input().send_keys(password)
         return self.get_sign_in_button()
 
-    def login(self, username, password):
-        self.test.click_through(self.setup(username, password),
-                                self.test.BY_ALERT)
+    def login(self, username, password, wait=(By.CLASS_NAME, 'dashboard-map')):
+        self.test.click_through(self.setup(username, password), wait)
 
     def login_inactive(self, username, password):
         self.test.click_through(self.setup(username, password),

--- a/functional_tests/projects/test_project_add.py
+++ b/functional_tests/projects/test_project_add.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 import geography.load
 
 from base import FunctionalTest
@@ -110,6 +112,7 @@ class ProjectAddTest(FunctionalTest):
         LoginPage(self).login(
             self.test_data['superuser']['username'],
             self.test_data['superuser']['password'],
+            wait=(By.ID, 'project-wizard')
         )
         assert ProjectAddPage(self).is_on_page()
 

--- a/functional_tests/users/test_page_access.py
+++ b/functional_tests/users/test_page_access.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 from base import FunctionalTest
 from pages.Users import UsersPage
 from pages.Login import LoginPage
@@ -37,6 +39,7 @@ class PageAccessTest(FunctionalTest):
         LoginPage(self).login(
             self.test_data['superuser']['username'],
             self.test_data['superuser']['password'],
+            wait=(By.ID, 'users')
         )
         assert UsersPage(self).is_on_page()
 


### PR DESCRIPTION
### Proposed changes in this pull request

This is an attempt to make the functional tests on Travis a bit more reliable.  I believe that the reason things have been failing intermittently, almost exclusively on the login page, was because we were using the presence of an alert to indicate that the login was successful.  Since the "OK" alerts now disappear on a timer, it's possible for the login to work, and the alert to appear and disappear before Selenium gets around to checking it.  The test then times out.

I've changed the post-login check to look for permanent page features instead: for most pages, this is the `dashboard-map` DIV, but it's possible to override this in the `login` method of `LoginPage` (which is needed for cases with post-login redirections).

### When should this PR be merged

Immediately.

### Risks

None: it can't make anything worse!

### Follow up actions

Bask in the glow of working functional tests...
