### PR TITLE
Fix #543: Always show logged-in user's full name or username in page …

### DIFF
--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -709,7 +709,6 @@ class OrganizationMembersEditTest(UserTestCase):
         context['organization'] = self.org
         context['form'] = forms.EditOrganizationMemberForm(
             None, self.org, self.member)
-        context['user'] = self.member
 
         expected = render_to_string(
             'organization/organization_members_edit.html',

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -177,6 +177,11 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
     def get_queryset(self):
         return self.get_organization().users.all()
 
+    def get_context_object_name(self, obj):
+        # Dummy context so that the currently viewed user does not
+        # override the logged-in user
+        return 'org_member'
+
     def get_form(self):
         if self.request.method == 'POST':
             return self.form_class(self.request.POST,


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #543:
    - **Bug root cause:** the `OrganizationMembersEdit` view is a subclass of the generic `DetailView` and it views a single `User` object, namely the organization member whose permissions are being edited or to be removed from the organization. The default behavior of `DetailView` is to helpfully add a context variable whose name is the `model_name` of the object model ([documentation](https://docs.djangoproject.com/en/1.9/ref/class-based-views/mixins-single-object/#django.views.generic.detail.SingleObjectMixin.get_context_object_name)). Thus, the user currently being viewed gets placed into the `user` context, which overrides the logged-in user leading to the bug.
        - This issue trips up a lot of Django projects so the documentation was updated with a [special note describing the issue](https://docs.djangoproject.com/en/1.9/ref/class-based-views/mixins-single-object/#django.views.generic.detail.SingleObjectMixin.get_context_data).
    - Override `DetailView`'s `get_context_object_name()` method to avoid overwriting the logged-in user.
    - Modify an existing unit test to catch this bug and to confirm it has been fixed.

### When should this PR be merged
Anytime.

### Risks
None.

### Follow up actions
None.
