### PR TITLE
Resolve #510: Improve messaging on orgs with no projects

### DIFF
--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -14,7 +14,7 @@
       <div class="col-md-8 main-text col-height hidden-xs hidden-sm">
         <h2>{% trans "Organization Overview" %}</h2>
         <div class="panel panel-default">
-          <div class="panel-heading"><h3>Projects</h3></div>
+          <div class="panel-heading"><h3>{% trans "Projects" %}</h3></div>
           <div class="panel-body">
             {% if projects  %}
             <table class="table table-hover datatable" data-paging-type="simple">
@@ -50,6 +50,10 @@
                 <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add new members" %}
               </a>
             </div>
+            {% else %}
+            <p>
+              {% trans "This organization does not have any public projects." %}
+            </p>
             {% endif %}
             {% endif %}
           </div>


### PR DESCRIPTION
### Proposed changes in this pull request
- Resolve #510 by adding some overview text for an organization which has no public projects yet to a user who is not an org admin.
- Made all text on the **organization_dashboard.html** template translatable. (Well, it was just one text.)

### When should this PR be merged
Anytime.

### Risks
None.

### Follow up actions
No actions needed.
