### PR TITLE
Update template to force SSL for all platform and API URLs

### DIFF
--- a/provision/roles/webserver/production/templates/nginx-production
+++ b/provision/roles/webserver/production/templates/nginx-production
@@ -3,7 +3,18 @@ upstream django {
 }
 
 server {
-    listen      80;
+    listen      80; #force redirect to https for API URLs
+    server_name {{ api_url }};
+    return      301         https://{{ api_url }}$request_uri;
+}
+
+server {
+    listen      80; #force redirect to https for platform URLs
+    server_name {{ main_url }};
+    return      301         https://{{ main_url }}$request_uri;
+}
+
+server {
     listen      443 ssl;
     server_name {{ api_url }};
     ssl_certificate     /etc/ssl/private/domain.crt;
@@ -47,7 +58,6 @@ server {
 }
 
 server {
-    listen      80;
     listen      443 ssl;
     server_name {{ main_url }};
     ssl_certificate     /etc/ssl/private/domain.crt;


### PR DESCRIPTION
### Proposed changes in this pull request

Forces redirect from http to https for all platform and API URLs, as per #551 

-

### When should this PR be merged

Anytime -- provisioning template update only; no impact to current platform code

-

### Risks

None

-

### Follow up actions

None; change has already been deployed to staging, demo, & production envs

-
