### PR TITLE
Resolve #596: Use "boundary" instead of "location"

### DIFF
--- a/cadasta/templates/organization/project_edit_geometry.html
+++ b/cadasta/templates/organization/project_edit_geometry.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load leaflet_tags %}
 
-{% block page_title %}Edit project location | {% endblock %}
+{% block page_title %}Edit project boundary | {% endblock %}
 {% block body-class %} map{% endblock %}
 
 
@@ -34,18 +34,18 @@
 {% csrf_token %}
   <div class="col-md-12 content-single">
     <div class="row">
-      <!-- Location map  -->
+      <!-- Boundary map  -->
       <div class="col-md-8 map">
         {{ form.extent }}
       </div>
-      <!-- / location map -->
-      <!-- Location detail  -->
+      <!-- / Boundary map -->
+      <!-- Boundary detail  -->
       <div class="col-md-4 detail detail-edit">
-        <h2>{% trans "Edit project location" %}</h2>
+        <h2>{% trans "Edit project boundary" %}</h2>
         <div class="panel panel-default">
           <div class="panel-body">
             <p>
-              {% blocktrans %}Use the tools provided on the left side of the map to outline your project boundary. Once complete, select the save button below.{% endblocktrans %}
+              {% blocktrans %}Use the tools provided on the left side of the map to update your project boundary. Once complete, select the save button below.{% endblocktrans %}
             </p>
             <div class="alert alert-info alert-full clearfix row" role="alert">
               <div class="pull-left"><span class="glyphicon glyphicon-info-sign"></span></div>
@@ -60,7 +60,7 @@
           </div>
         </div>
       </div>
-      <!-- / location detail -->
+      <!-- / Boundary detail -->
     </div>
   </div>
 </form>

--- a/cadasta/templates/organization/project_wrapper.html
+++ b/cadasta/templates/organization/project_wrapper.html
@@ -29,7 +29,7 @@
           <span class="more-menu glyphicon glyphicon-option-vertical"></span>
         </a>
         <ul class="dropdown-menu" aria-labelledby="dLabel">
-          <li><a class="edit" href="{% url 'organization:project-edit-geometry' object.organization.slug object.slug %}">{% trans "Edit project location" %}</a></li>
+          <li><a class="edit" href="{% url 'organization:project-edit-geometry' object.organization.slug object.slug %}">{% trans "Edit project boundary" %}</a></li>
           <li><a class="edit" href="{% url 'organization:project-edit-details' object.organization.slug object.slug %}">{% trans "Edit project details" %}</a></li>
           <li><a class="edit" href="{% url 'organization:project-edit-permissions' object.organization.slug object.slug %}">{% trans "Edit member permissions" %}</a></li>
           <li role="separator" class="divider"></li>
@@ -54,7 +54,7 @@
         </a>
         <button type="button" class="btn btn-primary btn-rt dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <span class="caret"></span>
-          <span class="sr-only">Toggle Add</span>
+          <span class="sr-only">{%trans "Toggle add" %}</span>
         </button>
         <ul class="dropdown-menu">
           <!--<li><a href="#">{% trans "Add party" %}</a></li>


### PR DESCRIPTION
### Proposed changes in this pull request
- Resolve #596:
    - Replace user-facing "location" text with "boundary" when referring to the project boundary.
    - (I've checked and there are no user-facing texts that use "extent" to refer to the project boundary.)
- Make one user-facing text translatable

### When should this PR be merged
During Sprint 7 code freeze.

### Risks
No risks foreseen.

### Follow up actions
None.