### PR TITLE
Embedded player for demo site

### DIFF
--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -216,5 +216,6 @@
       $(".alert-success").fadeTo(500, 0).slideUp(500, function(){ $(this).hide(); });
     }, 5000);
     </script>
+    <script>!function(){var e=document.createElement("script"),t=document.getElementsByTagName("script")[0];e.async=1,e.src="https://inlinemanual.com/embed/player.b4b392a6f77d7d0d6e04cee62b835187.js",e.charset="UTF-8",t.parentNode.insertBefore(e,t)}();</script>
   </body>
 </html>


### PR DESCRIPTION
### Proposed changes in this pull request

This embeds player for inline manual that will only be effective on demo.cadasta.org

### When should this PR be merged

As soon as possible - we need it for this sprint release.

### Risks

I don't see any errors occurring on my host site so I don't think it should affect anything although there will be no benefits outside of the demo site.

### Follow up actions

- I will be creating tutorials in inlinemanual.com and once complete, should be able to publish from within there.  
- We should leverage people tracking and analytics options within inlinemanual.
- Consider using a standalone player download.  Spoke with @amplifi and with upbeat we will be able to track differences in page load times and focus on issues as they arise.

