### PR TITLE
Update django-jsonattrs to version 0.1.8

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -23,7 +23,7 @@ django-buckets==0.1.15
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.2.0
-django-jsonattrs==0.1.5
+django-jsonattrs==0.1.8
 openpyxl==2.3.5
 pytz==2016.4
 shapely==1.5.16


### PR DESCRIPTION
### Proposed changes in this pull request

Update `django-jsonattrs` version to 0.1.8.  (May help to fix a couple of attributes problems, like https://github.com/Cadasta/cadasta-platform/issues/592).

### When should this PR be merged

Any time.

### Risks

Low to none.

### Follow up actions

Retest outstanding attribute-related issues.
