### PR TITLE
Fix #594: Correct edit resource cancel button URL

### DIFF
--- a/cadasta/resources/tests/test_views_default.py
+++ b/cadasta/resources/tests/test_views_default.py
@@ -466,9 +466,24 @@ class ProjectResourcesEditTest(UserTestCase):
         if response.status_code == 200:
             content = response.render().content.decode('utf-8')
             form = ResourceForm(instance=self.resource)
+            cancel_url = self.request.GET.get('next', None)
+            if cancel_url:
+                cancel_url += '#resources'
+            else:
+                cancel_url = reverse(
+                    'resources:project_list',
+                    kwargs={
+                        'organization': self.project.organization.slug,
+                        'project': self.project.slug
+                    }
+                )
             expected = render_to_string(
                 'resources/edit.html',
-                {'object': self.project, 'form': form},
+                {
+                    'object': self.project,
+                    'form': form,
+                    'cancel_url': cancel_url,
+                },
                 request=self.request
             )
             assert expected == content
@@ -510,6 +525,17 @@ class ProjectResourcesEditTest(UserTestCase):
         return response
 
     def test_get_form(self):
+        self._get(status=200)
+
+    def test_get_form_with_next_query_parameter(self):
+        self.request.GET['next'] = '/organizations/'
+        self._get(status=200)
+
+    def test_get_form_with_location_next_query_parameter(self):
+        url = ('https://example.com/organizations/sample-org/'
+               'projects/sample-proj/records/'
+               'locations/jvzsiszjzrbpecm69549u2z5/')
+        self.request.GET['next'] = url
         self._get(status=200)
 
     def test_get_non_existent_project(self):

--- a/cadasta/resources/views/default.py
+++ b/cadasta/resources/views/default.py
@@ -77,6 +77,11 @@ class ProjectResourcesEdit(LoginPermissionRequiredMixin,
     permission_required = 'resource.edit'
     permission_denied_message = error_messages.RESOURCE_EDIT
 
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context['cancel_url'] = self.get_success_url()
+        return context
+
 
 class ResourceArchive(LoginPermissionRequiredMixin,
                       ArchiveMixin,

--- a/cadasta/templates/resources/edit.html
+++ b/cadasta/templates/resources/edit.html
@@ -22,12 +22,11 @@
       {% csrf_token %}
         <div class="panel panel-default">
           <div class="panel-body">
-            {{ form.errors }}
             {% include "resources/form.html" %}
           </div>
           <div class="panel-footer panel-buttons">
             <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
-            <a href="{{ request.META.HTTP_REFERER }}" class="btn btn-default cancel">{% trans "Cancel" %}</a>
+            <a href="{{ cancel_url }}" class="btn btn-default cancel">{% trans "Cancel" %}</a>
           </div>
         </div>
       </form>


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #594:
    - Change the edit resource form's cancel button URL to use the `get_success_url()` URL of the same view.
    - Add 2 unit tests and update the unit test framework.
- Remove the unnecessary extra error messages that appear. (I don't think the edit resource form has any non-field-specific errors.)

### When should this PR be merged
Before Sprint 7 release.

### Risks
No risks foreseen.

### Follow up actions
None.
