### PR TITLE
Bump django-jsonattr version

### DIFF
--- a/cadasta/spatial/forms.py
+++ b/cadasta/spatial/forms.py
@@ -101,8 +101,8 @@ class TenureRelationshipForm(forms.Form):
                 'initial': initial
             }
             field = form_field_from_name(atype.form_field)
-            if atype.form_field == 'CharField':
-                args['max_length'] = 32
+            # if atype.form_field == 'CharField':
+            #     args['max_length'] = 32
             if (atype.form_field == 'ChoiceField' or
                atype.form_field == 'MultipleChoiceField'):
                 args['choices'] = list(map(lambda c: (c, c), attr.choices))

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -23,7 +23,7 @@ django-buckets==0.1.15
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.2.0
-django-jsonattrs==0.1.8
+django-jsonattrs==0.1.9
 openpyxl==2.3.5
 pytz==2016.4
 shapely==1.5.16


### PR DESCRIPTION
### Proposed changes in this pull request

Bump the version of django-jsonattr to 0.1.9, which removes the length restriction of attribute character fields in forms.  This fixes #557.

### When should this PR be merged

Right away.

### Risks

Shouldn't be any, though it's not particularly well tested, obviously.

### Follow up actions

Make sure everything still works.
