### PR TITLE
Removed loadstatic from provisioning. Attribute objects are no longer…

### DIFF
--- a/cadasta/core/management/commands/loadstatic.py
+++ b/cadasta/core/management/commands/loadstatic.py
@@ -1,24 +1,26 @@
 from django.core.management.base import BaseCommand
 
-from core.management.commands import loadsite
-from accounts.management.commands import loadpolicies
-from geography.management.commands import loadcountries
-from party.management.commands import loadtenurereltypes
-from jsonattrs.management.commands import loadattrtypes
+# from core.management.commands import loadsite
+# from accounts.management.commands import loadpolicies
+# from geography.management.commands import loadcountries
+# from party.management.commands import loadtenurereltypes
+# from jsonattrs.management.commands import loadattrtypes
 
 
 class Command(BaseCommand):
-    help = """Load in all site, country, policy and test data."""
+    help = """Load in all site, country, policy and test data.
+            Only run first time a database is set up."""
 
     def handle(self, *args, **options):
-        # All of the following are idempotent.
-        print('LOADING SITE\n')
-        loadsite.Command().handle()
-        print('LOADING COUNTRIES\n')
-        loadcountries.Command().handle()
-        print('LOADING POLICIES\n')
-        loadpolicies.Command().handle()
-        print('LOADING ATTRIBUTE TYPES\n')
-        loadattrtypes.Command().handle()
-        print('LOADING TENURE RELATIONSHIP TYPES\n')
-        loadtenurereltypes.Command().handle()
+        pass
+    #     # All of the following are idempotent.
+    #     print('LOADING SITE\n')
+    #     loadsite.Command().handle()
+    #     print('LOADING COUNTRIES\n')
+    #     loadcountries.Command().handle()
+    #     print('LOADING POLICIES\n')
+    #     loadpolicies.Command().handle()
+    #     print('LOADING ATTRIBUTE TYPES\n')
+    #     loadattrtypes.Command().handle()
+    #     print('LOADING TENURE RELATIONSHIP TYPES\n')
+    #     loadtenurereltypes.Command().handle()

--- a/provision/roles/data/tasks/main.yml
+++ b/provision/roles/data/tasks/main.yml
@@ -1,7 +1,0 @@
-- name: Load static data
-  become: yes
-  become_user: "{{ app_user }}"
-  django_manage: command=loadstatic
-                 app_path="{{ application_path }}cadasta"
-                 virtualenv="{{ virtualenv_path }}"
-                 settings="{{ django_settings }}"


### PR DESCRIPTION
### Proposed changes in this pull request
Deleted loadstatic from provision tasks. It's only purpose was to ensure all of the necessary data was pre-loaded, and is no longer needed for an established database.

Also fixes the project 500 error caused by provisioning.

### When should this PR be merged
ASAP

### Risks
None

### Follow up actions
For broken projects, go to `/organizations/<org-slug/projects/<proj-slug>/edit/details/`, click on the questionnaire link to download the questionnaire, then re-upload it.