### PR TITLE
Restore data task main.yml; loadstatic operations are still commented…

### DIFF
--- a/provision/roles/data/tasks/main.yml
+++ b/provision/roles/data/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Load static data
+  become: yes
+  become_user: "{{ app_user }}"
+  django_manage: command=loadstatic
+                 app_path="{{ application_path }}cadasta"
+                 virtualenv="{{ virtualenv_path }}"
+                 settings="{{ django_settings }}"


### PR DESCRIPTION
### Proposed changes in this pull request

Restores the data task to allow Ansible to run provisioning. The loadstatic command file still has actions commented out, so it does not reinstate the operations (just the framework, should we need it later).

### When should this PR be merged

Anytime. No impact to platform code; provisioning change only.

### Risks

None

### Follow up actions

Temporary fix; a more permanent solution is adding checks to see if the data exists before loading, so it will be skipped as part of a subsequent provisioning run.

… out in command file