### PR TITLE
Tidy up provisioning and loadstatic thing

### DIFF
--- a/cadasta/accounts/load.py
+++ b/cadasta/accounts/load.py
@@ -3,8 +3,13 @@ from django.conf import settings
 from tutelary import models
 
 
-def run(verbose=True):
+def run(verbose=True, force=False):
     PERMISSIONS_DIR = settings.BASE_DIR + '/permissions/'
+
+    if force:
+        models.PermissionSet.objects.all().delete()
+        models.Role.objects.all().delete()
+        models.Policy.objects.all().delete()
 
     pols = {}
     for pol in ['default', 'superuser', 'org-admin', 'org-member',

--- a/cadasta/accounts/management/commands/loadpolicies.py
+++ b/cadasta/accounts/management/commands/loadpolicies.py
@@ -7,4 +7,4 @@ class Command(BaseCommand):
     help = """Loads policy data."""
 
     def handle(self, *args, **options):
-        load.run()
+        load.run(force=options['force'])

--- a/cadasta/core/management/commands/loadstatic.py
+++ b/cadasta/core/management/commands/loadstatic.py
@@ -1,26 +1,37 @@
 from django.core.management.base import BaseCommand
 
-# from core.management.commands import loadsite
-# from accounts.management.commands import loadpolicies
-# from geography.management.commands import loadcountries
-# from party.management.commands import loadtenurereltypes
-# from jsonattrs.management.commands import loadattrtypes
+from core.management.commands import loadsite
+from accounts.management.commands import loadpolicies
+from geography.management.commands import loadcountries
+from party.management.commands import loadtenurereltypes
+from jsonattrs.management.commands import loadattrtypes
 
 
 class Command(BaseCommand):
     help = """Load in all site, country, policy and test data.
             Only run first time a database is set up."""
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--force',
+            action='store_true',
+            dest='force',
+            default=False,
+            help='Force object deletion and recreation'
+        )
+
     def handle(self, *args, **options):
-        pass
-    #     # All of the following are idempotent.
-    #     print('LOADING SITE\n')
-    #     loadsite.Command().handle()
-    #     print('LOADING COUNTRIES\n')
-    #     loadcountries.Command().handle()
-    #     print('LOADING POLICIES\n')
-    #     loadpolicies.Command().handle()
-    #     print('LOADING ATTRIBUTE TYPES\n')
-    #     loadattrtypes.Command().handle()
-    #     print('LOADING TENURE RELATIONSHIP TYPES\n')
-    #     loadtenurereltypes.Command().handle()
+        # All of the following are idempotent unless "force" is used.
+        if options['force']:
+            print('FORCING STATIC DATA RELOAD!!!\n')
+
+        print('LOADING SITE\n')
+        loadsite.Command().handle(force=options['force'])
+        print('LOADING COUNTRIES\n')
+        loadcountries.Command().handle(force=options['force'])
+        print('LOADING POLICIES\n')
+        loadpolicies.Command().handle(force=options['force'])
+        print('LOADING ATTRIBUTE TYPES\n')
+        loadattrtypes.Command().handle(force=options['force'])
+        print('LOADING TENURE RELATIONSHIP TYPES\n')
+        loadtenurereltypes.Command().handle(force=options['force'])

--- a/cadasta/core/tests/factories.py
+++ b/cadasta/core/tests/factories.py
@@ -29,7 +29,7 @@ class PolicyFactory(factory.django.DjangoModelFactory):
         return kwargs
 
     def load_policies():
-        load.run()
+        load.run(force=True)
 
 
 class RoleFactory(factory.django.DjangoModelFactory):

--- a/cadasta/core/tests/util.py
+++ b/cadasta/core/tests/util.py
@@ -30,7 +30,7 @@ class TestCase(DjangoTestCase):
     def setUp(self):
         PolicyFactory.load_policies()
         create_attribute_types()
-        load_tenure_relationship_types()
+        load_tenure_relationship_types(force=True)
         self.authorized_user = UserFactory.create()
         self.unauthorized_user = UserFactory.create()
 

--- a/cadasta/geography/management/commands/loadcountries.py
+++ b/cadasta/geography/management/commands/loadcountries.py
@@ -1,10 +1,12 @@
 from django.core.management.base import BaseCommand
 
 from ... import load
+from ...models import WorldBorder
 
 
 class Command(BaseCommand):
     help = """Loads country boundary data."""
 
     def handle(self, *args, **options):
-        load.run()
+        if options['force'] or not WorldBorder.objects.exists():
+            load.run()

--- a/cadasta/party/management/commands/loadtenurereltypes.py
+++ b/cadasta/party/management/commands/loadtenurereltypes.py
@@ -7,4 +7,4 @@ class Command(BaseCommand):
     help = "Load tenure relationship types."
 
     def handle(self, *args, **options):
-        load_tenure_relationship_types()
+        load_tenure_relationship_types(force=options['force'])

--- a/cadasta/party/models.py
+++ b/cadasta/party/models.py
@@ -308,7 +308,9 @@ TENURE_RELATIONSHIP_TYPES = (
 )
 
 
-def load_tenure_relationship_types():
+def load_tenure_relationship_types(force=False):
+    if force:
+        TenureRelationshipType.objects.all().delete()
     for tr_type in TENURE_RELATIONSHIP_TYPES:
         if not TenureRelationshipType.objects.filter(
                 id=tr_type[0], label=tr_type[1]

--- a/provision/aws-deploy.yml
+++ b/provision/aws-deploy.yml
@@ -19,4 +19,3 @@
     - cadasta/install
     - cadasta/application
     - webserver/production
-    - data

--- a/provision/roles/data/tasks/main.yml
+++ b/provision/roles/data/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Load static data
+  become: yes
+  become_user: "{{ app_user }}"
+  django_manage: command=loadstatic
+                 app_path="{{ application_path }}cadasta"
+                 virtualenv="{{ virtualenv_path }}"
+                 settings="{{ django_settings }}"

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -23,7 +23,7 @@ django-buckets==0.1.15
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.2.0
-django-jsonattrs==0.1.9
+django-jsonattrs==0.1.10
 openpyxl==2.3.5
 pytz==2016.4
 shapely==1.5.16


### PR DESCRIPTION
### Proposed changes in this pull request

- Reinstate commented code in `loadstatic` management command.
- Add a `--force` flag to the `loadstatic` management command.  If static data database entities already exist, `loadstatic` will not make any changes unless this flag is supplied.
- Bump `django-jsonattrs` version to 0.1.10 to pick up version with `force` flag in attribute type loading.
- Reinstate `data` provisioning role for development only to ensure that newly created development VMs have the appropriate static data loaded.

### When should this PR be merged

Any time.

### Risks

Low to none, but reviewer (@amplifi) should check that the Ansible provisioning steps that will run during deployment and redeployment will produce the expected results.  In particular, the `loadstatic` command is now *not* run from the `aws-deploy.yml` Ansible playbook, so static data loading will need to be performed as an additional step during deployments.

### Follow up actions

None.