### PR TITLE
Fix organization users API issues

### DIFF
--- a/cadasta/organization/tests/test_serializers.py
+++ b/cadasta/organization/tests/test_serializers.py
@@ -334,7 +334,7 @@ class OrganizationUserSerializerTest(UserTestCase):
 
         assert serializer.data['username'] == user.username
         assert serializer.data['email'] == user.email
-        assert serializer.data['role'] == 'User'
+        assert serializer.data['admin'] is False
 
     def test_list_to_representation(self):
         users = UserFactory.create_batch(2)
@@ -349,16 +349,17 @@ class OrganizationUserSerializerTest(UserTestCase):
 
         assert len(serializer.data) == 3
 
+        print(serializer.data)
         for u in serializer.data:
-            if u['username'] is org_admin.username:
-                assert u['role'] == 'Admin'
+            if u['username'] == org_admin.username:
+                assert u['admin'] is True
             else:
-                assert u['role'] == 'User'
+                assert u['admin'] is False
 
     def test_set_roles_with_username(self):
         user = UserFactory.create()
         org = OrganizationFactory.create()
-        data = {'username': user.username, 'role': 'Admin'}
+        data = {'username': user.username, 'admin': True}
         serializer = serializers.OrganizationUserSerializer(
             data=data,
             context={
@@ -377,7 +378,7 @@ class OrganizationUserSerializerTest(UserTestCase):
     def test_set_roles_with_email(self):
         user = UserFactory.create()
         org = OrganizationFactory.create()
-        data = {'username': user.email, 'role': 'Admin'}
+        data = {'username': user.email, 'admin': True}
         serializer = serializers.OrganizationUserSerializer(
             data=data,
             context={
@@ -395,7 +396,7 @@ class OrganizationUserSerializerTest(UserTestCase):
 
     def test_set_roles_for_user_that_does_not_exist(self):
         org = OrganizationFactory.create()
-        data = {'username': 'some-user', 'role': 'Admin'}
+        data = {'username': 'some-user', 'admin': True}
         serializer = serializers.OrganizationUserSerializer(
             data=data, context={'organization': org}
         )
@@ -410,7 +411,7 @@ class OrganizationUserSerializerTest(UserTestCase):
         org = OrganizationFactory.create()
         user1 = UserFactory.create(email='some-user@some.com')
         UserFactory.create(email='some-user@some.com')
-        data = {'username': user1.email, 'role': 'Admin'}
+        data = {'username': user1.email, 'admin': 'true'}
         serializer = serializers.OrganizationUserSerializer(
             data=data, context={'organization': org}
         )
@@ -427,7 +428,7 @@ class OrganizationUserSerializerTest(UserTestCase):
         org = OrganizationFactory.create(add_users=[user])
         serializer = serializers.OrganizationUserSerializer(
             user,
-            data={'role': 'Admin'},
+            data={'admin': 'True'},
             partial=True,
             context={'organization': org}
         )
@@ -466,7 +467,7 @@ class ProjectUserSerializerTest(UserTestCase):
         assert len(serializer.data) == 3
 
         for u in serializer.data:
-            if u['username'] is prj_admin.username:
+            if u['username'] == prj_admin.username:
                 assert u['role'] == 'PM'
             else:
                 assert u['role'] == 'PU'

--- a/cadasta/organization/tests/test_views_api_projects.py
+++ b/cadasta/organization/tests/test_views_api_projects.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import PermissionDenied
 from tutelary.models import Policy, assign_user_policies
 
 from core.tests.base_test_case import UserTestCase
+from accounts.models import User
 from accounts.tests.factories import UserFactory
 from .factories import OrganizationFactory, ProjectFactory, clause
 from ..models import Project, ProjectRole, OrganizationRole
@@ -199,6 +200,7 @@ class ProjectUsersDetailAPITest(UserTestCase):
             assert response.status_code == status
         if count is not None:
             assert project.users.count() == count
+        assert User.objects.get(username=user) in User.objects.all()
 
     def test_get_user(self):
         user = UserFactory.create()

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -4,7 +4,7 @@ from tutelary.mixins import APIPermissionRequiredMixin
 
 from accounts.models import User
 
-from ..models import Organization
+from ..models import Organization, OrganizationRole, ProjectRole
 from .. import serializers
 from . import mixins
 
@@ -63,9 +63,9 @@ class OrganizationUsersDetail(APIPermissionRequiredMixin,
     permission_required = 'org.users.remove'
 
     def destroy(self, request, *args, **kwargs):
-        user = self.get_object()
-        role = self.org.users.get(id=user.id)
-        role.delete()
+        OrganizationRole.objects.get(
+            organization=self.org, user=self.get_object()
+        ).delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -195,8 +195,8 @@ class ProjectUsersDetail(APIPermissionRequiredMixin,
     }
 
     def destroy(self, request, *args, **kwargs):
-        user = self.get_object()
-        role = self.prj.users.get(id=user.id)
-        role.delete()
+        ProjectRole.objects.get(
+            project=self.prj, user=self.get_object()
+        ).delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix #603 (deleting a user from an organization also deleted the user): delete the relevant `OrganizationRole` object instead of the user object (also for `ProjectRole`).
- Fix #608 (all new organization users were set up as admins): correct the incompatibility in `EntityUserSerializer` caused by some models using roles that are strings (`ProjectRole`) and some using boolean roles (`OrganizationRole`) -- just convert string values of "`false`" or "`False`" to boolean `False`. 

### When should this PR be merged

Any time.

### Risks

None.

### Follow up actions

None.
