### PR TITLE
Admin users can no longer delete/demote themselves

### DIFF
--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -151,6 +151,15 @@ class EntityUserSerializer(serializers.Serializer):
             if error:
                 raise serializers.ValidationError(error.format(value))
 
+    def validate_admin(self, role_value):
+        if 'request' in self.context:
+            if self.context['request'].user == self.instance:
+                if role_value != self.get_roles_object(self.instance).admin:
+                    raise serializers.ValidationError(
+                        _("Organization administrators cannot change their "
+                          "own permissions within the organization"))
+        return role_value
+
     def create(self, validated_data):
         obj = self.context[self.Meta.context_key]
 
@@ -171,7 +180,6 @@ class EntityUserSerializer(serializers.Serializer):
 
     def update(self, instance, validated_data):
         role = self.get_roles_object(instance)
-
         role_value = validated_data[self.Meta.role_key]
 
         if self.Meta.role_key in validated_data:

--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -697,6 +697,7 @@ class OrganizationMembersEditTest(UserTestCase):
         user = UserFactory.create()
         assign_user_policies(user, self.policy)
         setattr(self.request, 'user', user)
+        OrganizationRole.objects.create(organization=self.org, user=user)
 
         response = self.view(
             self.request,
@@ -708,7 +709,8 @@ class OrganizationMembersEditTest(UserTestCase):
         context['object'] = self.member
         context['organization'] = self.org
         context['form'] = forms.EditOrganizationMemberForm(
-            None, self.org, self.member)
+            None, self.org, self.member, user)
+        # context['current_user'] = user
 
         expected = render_to_string(
             'organization/organization_members_edit.html',
@@ -791,6 +793,7 @@ class OrganizationMembersEditTest(UserTestCase):
     def test_post_with_invalid_form(self):
         user = UserFactory.create()
         assign_user_policies(user, self.policy)
+        OrganizationRole.objects.create(organization=self.org, user=user)
         setattr(self.request, 'user', user)
         setattr(self.request, 'method', 'POST')
         setattr(self.request, 'POST', {'org_role': 'X'})

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -1,4 +1,5 @@
 from rest_framework.response import Response
+from rest_framework.exceptions import PermissionDenied
 from rest_framework import generics, filters, status
 from tutelary.mixins import APIPermissionRequiredMixin
 
@@ -63,8 +64,11 @@ class OrganizationUsersDetail(APIPermissionRequiredMixin,
     permission_required = 'org.users.remove'
 
     def destroy(self, request, *args, **kwargs):
+        user = self.get_object()
+        if user == request.user:
+            raise PermissionDenied
         OrganizationRole.objects.get(
-            organization=self.org, user=self.get_object()
+            organization=self.org, user=user
         ).delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -186,16 +186,25 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
         if self.request.method == 'POST':
             return self.form_class(self.request.POST,
                                    self.get_organization(),
-                                   self.get_object())
+                                   self.get_object(),
+                                   self.request.user)
         else:
             return self.form_class(None,
                                    self.get_organization(),
-                                   self.get_object())
+                                   self.get_object(),
+                                   self.request.user)
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context['organization'] = self.get_organization()
         context['form'] = self.get_form()
+
+        org_admin = OrganizationRole.objects.get(
+           user=self.request.user,
+           organization=context['organization']).admin
+        context['org_admin'] = (org_admin and
+                                not self.is_superuser and
+                                context['org_member'] == self.request.user)
         return context
 
     def post(self, request, *args, **kwargs):

--- a/cadasta/templates/organization/organization_members_edit.html
+++ b/cadasta/templates/organization/organization_members_edit.html
@@ -33,11 +33,21 @@
                 <div class="member-role form-group{% if form.org_role.errors %} has-error{% endif %}">
                   <label for="{{ form.org_role.id_for_label }}">Role</label>
                   <label class="pull-right control-label">{{ form.org_role.errors }}</label>
-                  {% render_field form.org_role class+="form-control" %}
+                  {% if org_admin %}
+                    {% render_field form.org_role class+="form-control" %}
+                  {% else %}
+                    {% render_field form.org_role class+="form-control" %}
+                  {% endif %}
                 </div>
                 <div class="btn-full">
-                  <button type="button" class="btn btn-danger" name="remove" data-toggle="modal" data-target="#remove_confirm">
+                  <button type="button" class="btn btn-danger" name="remove" data-toggle="modal" data-target="#remove_confirm"{% if org_admin %} disabled{% endif %}>
                     <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Remove member</button>
+                    {% if org_admin %}
+                      <div class="alert alert-full" role="alert">
+                        <div class="pull-left"><span class="glyphicon glyphicon-info-sign"></span></div>
+                        <div>An organization administrator cannot remove themself.</div>
+                      </div>
+                    {% endif %}
                 </div>
               </div>
             </div>
@@ -83,7 +93,7 @@
 {% endblock %}
 
 {% block modals %}
-
+{% if not org_admin  %}
 <div class="modal fade" id="remove_confirm" tabindex="-1" role="dialog">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -102,5 +112,6 @@
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
+{% endif %}
 
 {% endblock %}

--- a/functional_tests/organizations/test_organization_member.py
+++ b/functional_tests/organizations/test_organization_member.py
@@ -21,6 +21,7 @@ class OrganizationMemberTest(FunctionalTest):
                 organization=test_objs['organizations'][0],
                 user=UserFactory.create(
                         username='admin_user',
+                        full_name='Admin User',
                         password='password'),
                 admin=True)
 
@@ -64,6 +65,29 @@ class OrganizationMemberTest(FunctionalTest):
         roles = page.get_role_options()
         assert roles["admin"].text == roles["selected"].text
 
+    def test_changing_an_admins_organizational_role(self):
+        """An admin member can change a member's role in the organization."""
+
+        LoginPage(self).login('admin_user', 'password')
+        page = OrganizationMemberPage(self)
+        page.go_to()
+        OrganizationPage(self).go_to_organization_page()
+        OrganizationMemberListPage(self).go_to_member_list_page()
+        page.go_to_admin_member_page()
+
+        roles = page.get_role_options()
+        assert roles["admin"].text == roles["selected"].text
+
+        roles["member"].click()
+        page.click_submit_button()
+        self.get_screenshot()
+        # get error message
+        # assert you stayed on the same page.
+        roles = page.get_role_options()
+        errors = page.get_org_role_error()
+        assert errors.text == ("Organization administrators cannot change" +
+                               " their own role in the organization.")
+
     def test_removing_a_member_from_an_organization(self):
         """An admin member can remove a member from an organization."""
 
@@ -81,6 +105,21 @@ class OrganizationMemberTest(FunctionalTest):
 
         members = page.get_table_row().text
         assert "Test User" not in members
+
+    def test_removing_an_admin_member_from_an_organization(self):
+        """An admin member can remove a member from an organization."""
+
+        LoginPage(self).login('admin_user', 'password')
+        page = OrganizationMemberPage(self)
+        page.go_to()
+        OrganizationPage(self).go_to_organization_page()
+        OrganizationMemberListPage(self).go_to_member_list_page()
+        page.go_to_admin_member_page()
+
+        assert page.get_member_title() == "MEMBER: Admin User"
+
+        page.click_disabled_remove_button()
+        assert page.get_member_title() == "MEMBER: Admin User"
 
     def test_changing_member_project_permissions(self):
         """An admin user can change a member's permissions
@@ -121,4 +160,4 @@ class OrganizationMemberTest(FunctionalTest):
         page.go_to_testuser_member_page()
 
         roles = page.get_role_options()
-        assert roles["admin"].text == roles["selected"].text
+        assert roles['selected'].text == "Administrator"

--- a/functional_tests/pages/OrganizationMember.py
+++ b/functional_tests/pages/OrganizationMember.py
@@ -36,6 +36,14 @@ class OrganizationMemberPage(Page):
         testuser_title = self.get_member_title()
         return testuser_title
 
+    def go_to_admin_member_page(self):
+        testuser_page = self.get_table_row(
+            "[contains(@onclick, '/admin_user/')]"
+        )
+        self.click_through(testuser_page, (By.CLASS_NAME, 'page-title'))
+        testuser_title = self.get_member_title()
+        return testuser_title
+
     def get_form_field(self, xpath):
         return self.test.form_field(
                 'org-member-edit', xpath)
@@ -53,6 +61,10 @@ class OrganizationMemberPage(Page):
 
     def get_admin_role_option(self):
         return self.get_member_role_select("//option[contains(@value, 'A')]")
+
+    def get_org_role_error(self):
+        return self.get_form_field("div[contains(@class, 'member-role')]" +
+                                   "//ul[contains(@class, 'errorlist')]")
 
     def get_selected_role(self):
         return self.get_member_role_select(
@@ -72,6 +84,11 @@ class OrganizationMemberPage(Page):
 
     def click_remove_button(self):
         self.click_through(
+            self.test.button("remove"), (By.CSS_SELECTOR, "div.modal.fade.in")
+        )
+
+    def click_disabled_remove_button(self):
+        self.test.click_through_close(
             self.test.button("remove"), (By.CSS_SELECTOR, "div.modal.fade.in")
         )
 


### PR DESCRIPTION
### Proposed changes in this pull request
- Fixes #548
- Org admins can no longer delete themselves from their organization (UI or API)
- Org admins can no longer change their own permission in the organization (UI or API)
- Org admins will now have to be deleted/demoted by a superuser or another admin in the organization.

### When should this PR be merged
Whenever.

### Risks
- None

### Follow up actions
- Some changes to the API, so the documentation of errors needs to be updated, but not sure if it's worth it until the great API clean-up.