### PR TITLE
Add email notifications for unhandled exceptions and xform submission errors

### DIFF
--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -38,7 +38,7 @@ EMAIL_PORT = 465
 EMAIL_USE_SSL = True
 EMAIL_HOST_USER = os.environ['EMAIL_HOST_USER']
 EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
-SERVER_EMAIL = 'platform-errors@cadasta.org'
+SERVER_EMAIL = 'platform@cadasta.org'
 DEFAULT_FROM_EMAIL = 'platform@cadasta.org'
 ROOT_URLCONF = 'config.urls.production'
 
@@ -64,16 +64,21 @@ LOGGING = {
             'filename': '/var/log/django/debug.log',
             'formatter': 'simple'
         },
+        'email_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+        },
     },
     'loggers': {
         'django': {
-            'handlers': ['file'],
+            'handlers': ['file','email_admins'],
             'level': 'DEBUG',
             'propagate': True,
         },
         'xform.submissions': {
-            'handlers': ['file'],
-            'level': 'DEBUG'
+            'handlers': ['file','email_admins'],
+            'level': 'DEBUG',
+            'propagate': True,
         }
     },
 }

--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -71,12 +71,12 @@ LOGGING = {
     },
     'loggers': {
         'django': {
-            'handlers': ['file','email_admins'],
+            'handlers': ['file', 'email_admins'],
             'level': 'DEBUG',
             'propagate': True,
         },
         'xform.submissions': {
-            'handlers': ['file','email_admins'],
+            'handlers': ['file', 'email_admins'],
             'level': 'DEBUG',
             'propagate': True,
         }


### PR DESCRIPTION
### Proposed changes in this pull request

Updates settings template with configuration for email notifications. Emails to platform-admin@cadasta.org are triggered on unhandled exceptions and xform submission errors using Django's native AdminEmailHandler.

### When should this PR be merged

Anytime

### Risks

None; already in place on demo and prod environments. Provisioning template update only.

### Follow up actions

None