### PR TITLE
Fix #590: spatial unit visibility

### DIFF
--- a/cadasta/accounts/load.py
+++ b/cadasta/accounts/load.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from tutelary import models
 
 
-def run(verbose=True, force=False):
+def run(verbose=True, force=False, update=False):
     PERMISSIONS_DIR = settings.BASE_DIR + '/permissions/'
 
     if force:
@@ -16,6 +16,9 @@ def run(verbose=True, force=False):
                 'project-manager', 'data-collector', 'project-user']:
         try:
             pols[pol] = models.Policy.objects.get(name=pol)
+            if update:
+                pols[pol].body = open(PERMISSIONS_DIR + pol + '.json').read()
+                pols[pol].save()
         except:
             pols[pol] = models.Policy.objects.create(
                 name=pol,

--- a/cadasta/accounts/management/commands/loadpolicies.py
+++ b/cadasta/accounts/management/commands/loadpolicies.py
@@ -7,4 +7,4 @@ class Command(BaseCommand):
     help = """Loads policy data."""
 
     def handle(self, *args, **options):
-        load.run(force=options['force'])
+        load.run(force=options['force'], update=options['update'])

--- a/cadasta/config/permissions/default.json
+++ b/cadasta/config/permissions/default.json
@@ -26,6 +26,14 @@
       "effect": "allow",
       "action": ["project.view"],
       "object": ["project/*/*"]
+    },
+
+    {
+      // Any user is allowed to list the spatial units of public
+      // projects in an organization.
+      "effect": "allow",
+      "action": ["spatial.list"],
+      "object": ["project/*/*"]
     }
   ]
 }

--- a/cadasta/core/management/commands/loadstatic.py
+++ b/cadasta/core/management/commands/loadstatic.py
@@ -19,19 +19,30 @@ class Command(BaseCommand):
             default=False,
             help='Force object deletion and recreation'
         )
+        parser.add_argument(
+            '--update-policies',
+            action='store_true',
+            dest='update_policies',
+            default=False,
+            help='Force update of tutelary policies from JSON files'
+        )
 
     def handle(self, *args, **options):
-        # All of the following are idempotent unless "force" is used.
-        if options['force']:
-            print('FORCING STATIC DATA RELOAD!!!\n')
+        if options['update_policies']:
+            print('PERFORMING POLICY UPDATE FROM FILES!!!\n')
+            loadpolicies.Command().handle(force=False, update=True)
+        else:
+            # All of the following are idempotent unless "force" is used.
+            if options['force']:
+                print('FORCING STATIC DATA RELOAD!!!\n')
 
-        print('LOADING SITE\n')
-        loadsite.Command().handle(force=options['force'])
-        print('LOADING COUNTRIES\n')
-        loadcountries.Command().handle(force=options['force'])
-        print('LOADING POLICIES\n')
-        loadpolicies.Command().handle(force=options['force'])
-        print('LOADING ATTRIBUTE TYPES\n')
-        loadattrtypes.Command().handle(force=options['force'])
-        print('LOADING TENURE RELATIONSHIP TYPES\n')
-        loadtenurereltypes.Command().handle(force=options['force'])
+            print('LOADING SITE\n')
+            loadsite.Command().handle(force=options['force'])
+            print('LOADING COUNTRIES\n')
+            loadcountries.Command().handle(force=options['force'])
+            print('LOADING POLICIES\n')
+            loadpolicies.Command().handle(force=options['force'])
+            print('LOADING ATTRIBUTE TYPES\n')
+            loadattrtypes.Command().handle(force=options['force'])
+            print('LOADING TENURE RELATIONSHIP TYPES\n')
+            loadtenurereltypes.Command().handle(force=options['force'])

--- a/cadasta/core/tests/factories.py
+++ b/cadasta/core/tests/factories.py
@@ -28,8 +28,8 @@ class PolicyFactory(factory.django.DjangoModelFactory):
         kwargs['body'] = open(body_file).read()
         return kwargs
 
-    def load_policies():
-        load.run(force=True)
+    def load_policies(update=False):
+        load.run(force=not update, update=update)
 
 
 class RoleFactory(factory.django.DjangoModelFactory):

--- a/cadasta/core/tests/test_management_commands.py
+++ b/cadasta/core/tests/test_management_commands.py
@@ -20,6 +20,8 @@ class FixturesTest(TestCase):
         data.delete_test_projects()
         data.add_test_organizations()
         PolicyFactory.load_policies()
+        # Just for test coverage...
+        PolicyFactory.load_policies(update=True)
         create_attribute_types()
         load_tenure_relationship_types()
         data.add_test_users_and_roles()

--- a/cadasta/spatial/tests/test_views_api_spatial_units.py
+++ b/cadasta/spatial/tests/test_views_api_spatial_units.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import AnonymousUser
 from django.utils.translation import gettext as _
 from rest_framework import status as status_code
 
@@ -49,6 +50,13 @@ class SpatialUnitListAPITest(SpatialUnitListTestCase,
             status=status_code.HTTP_200_OK, length=self.num_records)
         assert extra_record.id not in (
             [u['properties']['id'] for u in content['features']])
+
+    def test_full_list_with_unauthorized_user(self):
+        org, prj = self._test_objs()
+        self._get(
+            org_slug=org.slug, prj_slug=prj.slug, user=AnonymousUser(),
+            status=status_code.HTTP_200_OK, length=self.num_records
+        )
 
     # def test_search_filter(self):
     #     org, prj = self._test_objs()

--- a/cadasta/spatial/tests/test_views_default.py
+++ b/cadasta/spatial/tests/test_views_default.py
@@ -93,8 +93,7 @@ class LocationsListTest(TestCase):
     def test_get_with_unauthorized_user(self):
         response, content = self.request(user=self.unauthorized_user)
         assert response.status_code == 200
-        assert content == self.expected_content(
-            geojson='{"type": "FeatureCollection", "features": []}')
+        assert content == self.expected_content()
 
     def test_get_with_unauthenticated_user(self):
         response = self.request()

--- a/cadasta/spatial/views/api.py
+++ b/cadasta/spatial/views/api.py
@@ -9,6 +9,11 @@ from . import mixins
 class SpatialUnitList(APIPermissionRequiredMixin,
                       mixins.SpatialQuerySetMixin,
                       generics.ListCreateAPIView):
+    def get_actions(self, request):
+        if self.get_project().public():
+            return ['project.view', 'spatial.list']
+        else:
+            return ['project.view_private', 'spatial.list']
 
     serializer_class = serializers.SpatialUnitSerializer
     filter_backends = (filters.DjangoFilterBackend,
@@ -17,7 +22,7 @@ class SpatialUnitList(APIPermissionRequiredMixin,
     filter_fields = ('type',)
 
     permission_required = {
-        'GET': 'spatial.list',
+        'GET': get_actions,
         'POST': 'spatial.create',
     }
 

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -23,7 +23,6 @@ class LocationsList(LoginPermissionRequiredMixin,
     template_name = 'spatial/location_map.html'
     permission_required = 'spatial.list'
     permission_denied_message = error_messages.SPATIAL_LIST
-    permission_filter_queryset = ('spatial.view',)
 
 
 class LocationsAdd(LoginPermissionRequiredMixin,

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,10 @@ envlist =
 
 [testenv]
 passenv = DJANGO_SETTINGS_MODULE
-setenv = PYTHONDONTWRITEBYTECODE=1
+setenv =
+  PYTHONDONTWRITEBYTECODE=1
+  CPLUS_INCLUDE_PATH=/usr/include/gdal
+  C_INCLUDE_PATH=/usr/include/gdal
 deps = -r{toxinidir}/requirements/dev.txt
 install_command = pip install --find-links https://s3.amazonaws.com:443/cadasta-wheelhouse/index.html {opts} {packages}
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix #590.
- Add the `spatial.list` permission for all public projects to the `default.json` policy file.
- Add the capabilty to force reloading of tutelary policies from JSON documents to the `loadstatic` command.  Running `./manage.py loadstatic --update-policies` will update the policies stored in the database from the JSON policy files.  (A server restart is needed after this to pick up the new policies from the database.)
- Update spatial unit list API to use correct permissions: the user must have the `spatial.list` permission on the project and must be able to view the project (so must have the `project.view` or `project.view_private` permission, depending on whether the project is public or private).
- Update tests to take account of the fact that anonymous users can now list spatial units.

### When should this PR be merged

Any time.

### Risks

None.

### Follow up actions

1. Run the management command `./manage.py loadstatic --update-policies` to load the new policy files into the database.
2. Restart the Django server to pick up the new policies from the database.
