### PR TITLE
Force DRF Docs to provide Headers input

### DIFF
--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -90,6 +90,9 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.BasicAuthentication',
     ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
     'DEFAULT_VERSIONING_CLASS':
     'rest_framework.versioning.NamespaceVersioning',
     'DEFAULT_VERSION': 'v1',


### PR DESCRIPTION
### Proposed changes in this pull request

The live API endpoints provided by the DRF Docs tool that live at `/api/v1/docs` need to provide a way of setting up HTTP headers to provide an authentication token (by setting an `Authorization` header to say `Token <token-value>`).  This is because of some default settings in the DRF Docs setup.  This PR changes those settings to force DRF Docs to provide a way of setting headers for all the live API endpoints. 

### When should this PR be merged

I believe that this can be merged at any time, but I'd like for @linzjax and @oliverroick to take a look at it first.

### Risks

Low to none.

### Follow up actions

None.
