### PR TITLE
Resolve #612: Don’t show party picker if there are no parties

### DIFF
--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -5906,10 +5906,6 @@ div.add-btn-btm {
   border-bottom: 3px solid #e7e8ea;
   margin-bottom: 20px; }
 
-#new-item {
-  background: #f2f4f7;
-  padding: 20px 20px 0 20px; }
-
 .more-menu {
   float: left;
   font-size: 24px;
@@ -6071,9 +6067,6 @@ tr.contacts-error {
 
 /* =Party selection widget
 -------------------------------------------------------------- */
-#select-party label {
-  display: block; }
-
 #select-party #party-select {
   width: 100%; }
 

--- a/cadasta/core/static/css/main.scss
+++ b/cadasta/core/static/css/main.scss
@@ -1270,11 +1270,6 @@ div.add-btn-btm { // add party link at bottom of table
   margin-bottom: 20px;
 }
 
-#new-item {
-  background: $body-bg;
-  padding: 20px 20px 0 20px;
-}
-
 .more-menu {
   float: left;
   font-size: 24px;
@@ -1428,7 +1423,7 @@ div.add-btn-btm { // add party link at bottom of table
   background-color: $alert-warning-bg;
   padding: 10px;
 }
-  
+
 ul.errorlist {
   margin-bottom: 0;
   padding-left: 0;
@@ -1470,9 +1465,6 @@ tr.contacts-error {
 -------------------------------------------------------------- */
 
 #select-party {
-  label {
-    display: block;
-  }
   #party-select {
     width: 100%;
   }

--- a/cadasta/core/static/js/rel_new_item.js
+++ b/cadasta/core/static/js/rel_new_item.js
@@ -1,4 +1,3 @@
 $('button#add-party').click(function() {
-  var val = $('#new_entity_field').val();
-  $('#new_entity_field').val((val === 'on' ? '' : 'on'));
+  $('#new_entity_field').val('on');
 });

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -160,8 +160,12 @@ class TenureRelationshipAdd(LoginPermissionRequiredMixin,
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        prj = self.get_project()
 
+        kwargs['initial'] = {
+            'new_entity': not self.get_project().parties.exists(),
+        }
+
+        prj = self.get_project()
         kwargs['schema_selectors'] = ()
         if prj.current_questionnaire:
             kwargs['schema_selectors'] = (

--- a/cadasta/spatial/widgets.py
+++ b/cadasta/spatial/widgets.py
@@ -1,27 +1,31 @@
-from django.forms.widgets import HiddenInput
+from django.forms.widgets import Widget
 from django.utils.translation import ugettext as _
 from party.models import Party
 
 
-class SelectPartyWidget(HiddenInput):
+class SelectPartyWidget(Widget):
     def __init__(self, project, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.project = project
 
     def render(self, name, value, attrs={}):
         prj_parties = Party.objects.filter(project_id=self.project)
-        parties = ['<option value="' + p.id + '" data-type="' +
-                   p.get_type_display() + '">' + p.name + '</option>'
-                   for p in prj_parties]
+        parties = [
+            '<option value="' + p.id + '" data-type="' +
+            p.get_type_display() + '"' +
+            (' selected="selected"' if p.id == value else '') + '>' +
+            p.name + '</option>' for p in prj_parties
+        ]
 
         return (
             '<select id="party-select" name="{name}">'
+            '<option value="" data-type="">Please select a party</option>'
             '{parties}'
             '</select>'
         ).format(parties=''.join(parties), name=name)
 
 
-class NewEntityWidget(HiddenInput):
+class NewEntityWidget(Widget):
     class Media:
         js = ('/static/js/rel_new_item.js',)
 

--- a/cadasta/templates/spatial/relationship_add.html
+++ b/cadasta/templates/spatial/relationship_add.html
@@ -7,6 +7,7 @@
 {% block extra_head %}
 {{ block.super }}
 <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css" rel="stylesheet" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.9/select2-bootstrap.min.css" rel="stylesheet" />
 {% endblock %}
 
 {% block location_extra_script %}
@@ -28,6 +29,7 @@ $(document).ready(function() {
   $("#party-select").select2({
     minimumResultsForSearch: 6,
     templateResult: template,
+    theme: "bootstrap",
   });
 });
   </script>
@@ -48,13 +50,18 @@ $(document).ready(function() {
 
           <div class="modal-body">
             {% csrf_token %}
-
             <h4 class="step">{% trans "1. Connected party" %}</h4>
-            <div id="select-party" class="clearfix">
-              <label>{% trans "Choose an existing party to connect to this location" %}</label>
-              {% render_field form.id class+="form-control" %}
+            <div id="select-party" class="clearfix{% if form.new_entity.value %} hidden{% endif %}">
+              <div class="form-group{% if form.id.errors %} has-error{% endif %}">
+                <label for="{{ form.id.id_for_label }}">{% trans "Choose an existing party to connect to this location" %}</label>
+                <label class="pull-right control-label">{{ form.id.errors }}</label>
+                {{ form.id }}
+              </div>
+
               <label>{% trans "Or add a new party" %}</label>
-              {% render_field form.new_entity class+="form-control" %}
+              <div class="form-group">
+                {{ form.new_entity }}
+              </div>
             </div>
 
             <div id="new-item" class="clearfix{% if not form.new_entity.value %} hidden{% endif %}">


### PR DESCRIPTION
### Proposed changes in this pull request
- Resolve #612:
    - In the `TenureRelationshipAdd` view, provide initial `new_entity` `kwargs['initial']` data for the unbound `TenureRelationshipForm` based on whether the project has parties or not.
    - Add the conditional `hidden` class in the **spatial/relationship_add.html** template for the `select-party` sub-form based on this initial `new_entity` data. This hides the party picker and the “Add party” button if there are no parties yet.
- Improve `TenureRelationshipForm`:
    - Make `new_entity` the first field because the required-ness of the other fields depend on `new_entity`. This enables us to properly use `self.cleaned_data.get('new_entity', None)` instead of `self.data.get('new_entity', None)`.
    - To help resolve #445, add a blank first choice in the party picker widget, and wrap the widget in the template inside `<div class="form-group{% if form.id.errors %} has-error{% endif %}">` and add `<label class="pull-right control-label">{{ form.id.errors }}</label>` to catch the user not selecting a party.
    - Currently when the form has an error (ex., the relationship type was not selected), the selected party reverts back to the default choice. Fix this by adding the `selected="selected"` HTML attribute to the selected party.
    - To further help resolve #445, add a blank first choice in the `party_type` field, make it `required=False`, and add `clean_party_type()` to validate it.
- Do other miscellaneous improvements:
    - Load the Bootstrap 3 theme for the Select2 widget used for the party picker so that it is styled the same as our other form widgets.
    - Use the generic `Widget` instead of `HiddenInput` for the `SelectPartyWidget` and `NewEntityWidget` since `HiddenInput` does not provide any additional value for these two. Also don't use `render_field` in the template for these widgets.
    - Simplified the code in the **core/static/js/rel_new_item.js** file. Clicking the “Add party” button is a one-way street so the value toggling is unnecessary. (The user can cancel and start over if really needed.)
    - Improve some CSS and styling.
- Update and add unit tests as needed for the changes above.

### When should this PR be merged
Anytime.

### Risks
None foreseen.

### Follow up actions
None.