### PR TITLE
Changes for adding new project details questionnaire

### DIFF
--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -5622,8 +5622,7 @@ textarea.form-control {
   max-height: 80px; }
 
 .file-well {
-  padding: 10px 20px;
-  margin-bottom: 0; }
+  padding: 10px 20px; }
 
 .file-input {
   margin: 14px 0;

--- a/cadasta/core/static/css/main.scss
+++ b/cadasta/core/static/css/main.scss
@@ -893,7 +893,6 @@ textarea.form-control {
 
 .file-well {
   padding: 10px 20px;
-  margin-bottom: 0;
 }
 
 .file-input { // browse for file

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -111,7 +111,7 @@
       <!-- Page content -->
       <div id="page-content">
         {% block sub-nav %}{% endblock %}
-        <main class="container-fluid" role="main">
+        <main class="container-fluid{% block main-width %}{% endblock %}" role="main">
           {% if messages %}
           <div id="messages">
             {% for message in messages %}

--- a/cadasta/templates/organization/project_add_details.html
+++ b/cadasta/templates/organization/project_add_details.html
@@ -24,6 +24,8 @@
 </script>
 {% endblock %}
 
+{% block main-width %} container{% endblock %}
+
 {% block step_content_1 %}
 
   <!-- Main wizard  -->
@@ -110,8 +112,16 @@
                 <div class="form-group{% if wizard.form.questionaire.errors %} has-error{% endif %}">
                   <label for="{{ wizard.form.questionaire.id_for_label }}">{% trans "Select the questionnaire file to use for this project" %}</label>
                   <label class="pull-right control-label">{{ wizard.form.questionaire.errors }}</label>
-                  {% render_field wizard.form.questionaire class+="form-control" %}
-                  <p class="help-block">Accepted file type: xls</p>
+                  <div class="well file-well">
+                    {% render_field wizard.form.questionaire class+="form-control" %}
+                    <p class="help-block">Accepted file types: xls, xlsx</p>
+                  </div>
+                  <div class="alert alert-info alert-full clearfix row" role="alert">
+                    <div class="pull-left"><span class="glyphicon glyphicon-info-sign"></span></div>
+                    <div>
+                        For assistance with questionnaires view our <a href="http://docs.cadasta.org/en/08-XLSForms.html" class="alert-link" target="_blank">user guide</a>.  To help you get started two samples have been provided: <a href="https://s3-us-west-2.amazonaws.com/cadasta-resources/sample-forms/minimum_cadasta_questionnaire.xlsx" class="alert-link">a minimal</a> and <a href="https://s3-us-west-2.amazonaws.com/cadasta-resources/sample-forms/standard_cadasta_questionnaire.xlsx" class="alert-link">a standard questionnaire</a>.
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/cadasta/templates/organization/project_add_permissions.html
+++ b/cadasta/templates/organization/project_add_permissions.html
@@ -5,6 +5,8 @@
 
 {% block page_title %}| Assign team{% endblock %}
 
+{% block main-width %} container{% endblock %}
+
 {% block step_content_1 %}
 
   <!-- Main wizard  -->

--- a/cadasta/templates/organization/project_edit_details.html
+++ b/cadasta/templates/organization/project_edit_details.html
@@ -62,8 +62,16 @@
                 <div class="form-group{% if form.questionnaire.errors %} has-error{% endif %}">
                   <label for="{{ form.questionnaire.id_for_label }}">{% trans "Select the questionnaire file to use for this project" %}</label>
                   <label class="pull-right control-label">{{ form.questionnaire.errors }}</label>
-                  {{ form.questionnaire }}
-                  <p class="help-block">Accepted file type: xls</p>
+                  <div class="well file-well">
+                    {{ form.questionnaire }}
+                    <p class="help-block">Accepted file types: xls, xlsx</p>
+                  </div>
+                  <div class="alert alert-info alert-full clearfix row" role="alert">
+                    <div class="pull-left"><span class="glyphicon glyphicon-info-sign"></span></div>
+                    <div>
+                        For assistance with questionnaires view our <a href="http://docs.cadasta.org/en/08-XLSForms.html" class="alert-link" target="_blank">user guide</a>.  To help you get started two samples have been provided: <a href="https://s3-us-west-2.amazonaws.com/cadasta-resources/sample-forms/minimum_cadasta_questionnaire.xlsx" class="alert-link">a minimal</a> and <a href="https://s3-us-west-2.amazonaws.com/cadasta-resources/sample-forms/standard_cadasta_questionnaire.xlsx" class="alert-link">a standard questionnaire</a>.
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Proposed changes in this pull request

- Add instruction text and links to sample forms for questionnaire section of project add and edit forms.


### When should this PR be merged

- Whenever convenient, for sprint 8.


### Risks

- None foreseen.


### Follow up actions

- As sample forms are updated, upload to cadasta-resources s3 bucket and make name generic to replace current form.

----------------------------------------------------------------------------------------------------------

Questionnaire text added

Edit page, also contained width for wizard to not be fluid

Updated links

Updated label

Removed link target