### PR TITLE
Safari fix for header menu in small screens

### DIFF
--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -5017,7 +5017,7 @@ header {
     .reg-links .btn-user .thumbnail {
       margin-right: 4px; }
   .reg-links .btn-reg {
-    min-width: auto;
+    min-width: 50px;
     margin-top: 24px;
     margin-left: 0;
     font-size: 12px;

--- a/cadasta/core/static/css/main.scss
+++ b/cadasta/core/static/css/main.scss
@@ -351,7 +351,7 @@ header {
       }
     }
     .btn-reg { // login and register links
-      min-width: auto;
+      min-width: 50px;
       margin-top: 24px;
       margin-left: 0;
       font-size: 12px;

--- a/cadasta/party/forms.py
+++ b/cadasta/party/forms.py
@@ -29,7 +29,9 @@ class TenureRelationshipEditForm(AttributeModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        tenuretypes = TenureRelationshipType.objects.values_list('id', 'label')
+        tenuretypes = sorted(
+            TenureRelationshipType.objects.values_list('id', 'label')
+        )
         self.fields['tenure_type'].choices = tenuretypes
 
     def save(self):

--- a/cadasta/party/tests/test_forms.py
+++ b/cadasta/party/tests/test_forms.py
@@ -65,6 +65,8 @@ class PartyFormTest(UserTestCase):
 class TenureRelationshipEditFormTest(UserTestCase):
     def test_init(self):
         form = forms.TenureRelationshipEditForm(schema_selectors=())
-        tenuretypes = TenureRelationshipType.objects.values_list('id', 'label')
+        tenuretypes = sorted(
+            TenureRelationshipType.objects.values_list('id', 'label')
+        )
         assert len(tenuretypes) > 0
         assert list(form.fields['tenure_type'].choices) == list(tenuretypes)

--- a/cadasta/spatial/forms.py
+++ b/cadasta/spatial/forms.py
@@ -65,7 +65,7 @@ class TenureRelationshipForm(forms.Form):
             list(Party.TYPE_CHOICES))
         self.fields['tenure_type'].choices = (
             [('', _("Please select a relationship type"))] +
-            list(TenureRelationshipType.objects.values_list('id', 'label')))
+            sorted(TenureRelationshipType.objects.values_list('id', 'label')))
         self.project = project
         self.spatial_unit = spatial_unit
         self.add_attribute_fields(schema_selectors)

--- a/cadasta/spatial/tests/test_forms.py
+++ b/cadasta/spatial/tests/test_forms.py
@@ -143,7 +143,7 @@ class TenureRelationshipFormTest(UserTestCase):
         assert isinstance(form.fields['tenure_type'], ChoiceField)
         assert form.fields['tenure_type'].choices == (
             [('', _('Please select a relationship type'))] +
-            list(TENURE_RELATIONSHIP_TYPES)
+            sorted(list(TENURE_RELATIONSHIP_TYPES))
         )
         assert ("All Types" not in
                 dict(form.fields['tenure_type'].choices).values())


### PR DESCRIPTION
### Proposed changes in this pull request

- Adjust min-width size css for reg buttons in header


### When should this PR be merged

- When convenient, for sprint 8


### Risks

- None foreseen

### Follow up actions

- Once released to staging, qa in mobile safari browser
