### PR TITLE
Fixing #272

### DIFF
--- a/cadasta/config/permissions/org-admin.json
+++ b/cadasta/config/permissions/org-admin.json
@@ -12,7 +12,7 @@
     },
     {
       "effect": "allow",
-      "action": ["project.*", "project.users.*", "questionaire.*",
+      "action": ["project.*", "project.users.*", "questionnaire.*",
                  "resource.*", "spatial.*", "spatial_rel.*",
                  "party.*", "party_rel.*", "tenure_rel.*"],
       "object": ["project/$organization/*"]

--- a/cadasta/config/permissions/project-manager.json
+++ b/cadasta/config/permissions/project-manager.json
@@ -7,14 +7,14 @@
     // organization.
     {
       "effect": "allow",
-      "action": ["project.*", "project.users.*", "questionaire.*",
+      "action": ["project.*", "project.users.*", "questionnaire.*",
                  "resource.*", "spatial.*", "spatial_rel.*",
                  "party.*", "party_rel.*", "tenure_rel.*"],
       "object": ["project/$organization/$project"]
     },
     {
       "effect": "deny",
-      "action": ["project.archive", "project.unarchive", "questionaire.add"],
+      "action": ["project.archive", "project.unarchive", "questionnaire.add"],
       "object": ["project/$organization/$project"]
     },
 

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -1,27 +1,27 @@
 import time
 from zipfile import ZipFile
-from django import forms
-from django.conf import settings
-from django.contrib.postgres import forms as pg_forms
-from django.contrib.gis import forms as gisforms
-from core.util import slugify
-from django.utils.translation import ugettext as _
-from django.db import transaction
-from django.forms.utils import ErrorDict
-
-from leaflet.forms.widgets import LeafletWidget
-from tutelary.models import check_perms
-from buckets.widgets import S3FileUploadWidget
 
 from accounts.models import User
+from buckets.widgets import S3FileUploadWidget
 from core.form_mixins import SuperUserCheck
+from core.util import slugify
+from django import forms
+from django.conf import settings
+from django.contrib.gis import forms as gisforms
+from django.contrib.postgres import forms as pg_forms
+from django.db import transaction
+from django.forms.utils import ErrorDict
+from django.utils.translation import ugettext as _
+from leaflet.forms.widgets import LeafletWidget
 from questionnaires.models import Questionnaire
-from .models import Organization, Project, OrganizationRole, ProjectRole
+from tutelary.models import check_perms
+
 from .choices import ADMIN_CHOICES, ROLE_CHOICES
-from .fields import ProjectRoleField, PublicPrivateField, ContactsField
-from .download.xls import XLSExporter
 from .download.resources import ResourceExporter
 from .download.shape import ShapeExporter
+from .download.xls import XLSExporter
+from .fields import ContactsField, ProjectRoleField, PublicPrivateField
+from .models import Organization, OrganizationRole, Project, ProjectRole
 
 FORM_CHOICES = ROLE_CHOICES + (('Pb', _('Public User')),)
 QUESTIONNAIRE_TYPES = [
@@ -245,7 +245,7 @@ class ProjectAddDetails(SuperUserCheck, forms.Form):
     description = forms.CharField(required=False, widget=forms.Textarea)
     access = PublicPrivateField(initial='public')
     url = forms.URLField(required=False)
-    questionaire = forms.CharField(
+    questionnaire = forms.CharField(
         required=False,
         widget=S3FileUploadWidget(upload_to='xls-forms',
                                   accepted_types=QUESTIONNAIRE_TYPES))
@@ -348,6 +348,7 @@ class ProjectEditDetails(forms.ModelForm):
 
 
 class PermissionsForm(SuperUserCheck):
+
     def check_admin(self, user):
         if not hasattr(self, 'admins'):
             self.admins = [
@@ -379,6 +380,7 @@ class PermissionsForm(SuperUserCheck):
 
 
 class ProjectAddPermissions(PermissionsForm, forms.Form):
+
     def __init__(self, organization, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if organization is not None:
@@ -387,6 +389,7 @@ class ProjectAddPermissions(PermissionsForm, forms.Form):
 
 
 class ProjectEditPermissions(PermissionsForm, forms.Form):
+
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop('instance')
         super().__init__(*args, **kwargs)

--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -858,11 +858,11 @@ class ProjectEditDetailsTest(UserTestCase):
 
         form.add_error('questionnaire',
                        "Unknown question type 'interger'.")
-        form.add_error('questionnaire',
-                       "'interger' is not an accepted question type")
-        form.add_error('questionnaire',
-                       "'select multiple list' is not an accepted question "
-                       "type")
+        # form.add_error('questionnaire',
+        #                "'interger' is not an accepted question type")
+        # form.add_error('questionnaire',
+        #                "'select multiple list' is not an accepted question "
+        #                "type")
 
         expected = render_to_string(
             'organization/project_edit_details.html',

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -1,27 +1,25 @@
-import os
 import json
-from django.http import HttpResponse
-from django.db import transaction
-from django.shortcuts import redirect, get_object_or_404
-import django.views.generic as base_generic
-from django.core.urlresolvers import reverse
-from django.contrib import messages
-
-import formtools.wizard.views as wizard
+import os
+from collections import OrderedDict
 
 import core.views.generic as generic
-from core.views.mixins import SuperUserCheckMixin
-from core.mixins import PermissionRequiredMixin, LoginPermissionRequiredMixin
-from core.views.mixins import ArchiveMixin
+import django.views.generic as base_generic
+import formtools.wizard.views as wizard
 from accounts.models import User
-from questionnaires.models import Questionnaire
+from core.mixins import LoginPermissionRequiredMixin, PermissionRequiredMixin
+from core.views.mixins import ArchiveMixin, SuperUserCheckMixin
+from django.core.urlresolvers import reverse
+from django.db import transaction
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404, redirect
 from questionnaires.exceptions import InvalidXLSForm
+from questionnaires.models import Questionnaire
 from spatial.serializers import SpatialUnitGeoJsonSerializer
 
-from ..models import Organization, Project, OrganizationRole, ProjectRole
 from . import mixins
-from .. import forms
 from .. import messages as error_messages
+from .. import forms
+from ..models import Organization, OrganizationRole, Project, ProjectRole
 
 
 class OrganizationList(PermissionRequiredMixin, generic.ListView):
@@ -289,8 +287,8 @@ class ProjectList(PermissionRequiredMixin,
 
     def get(self, request, *args, **kwargs):
         if (hasattr(self.request.user, 'assigned_policies') and
-           self.is_superuser):
-                projects = Project.objects.all()
+                self.is_superuser):
+            projects = Project.objects.all()
         else:
             projects = []
             projects.extend(Project.objects.filter(access='public'))
@@ -309,6 +307,7 @@ class ProjectDashboard(PermissionRequiredMixin,
                        mixins.ProjectAdminCheckMixin,
                        mixins.ProjectMixin,
                        generic.DetailView):
+
     def get_actions(view, request):
         if view.get_object().public():
             return 'project.view'
@@ -367,6 +366,12 @@ class ProjectAddWizard(SuperUserCheckMixin,
                        wizard.SessionWizardView):
     permission_required = add_wizard_permission_required
     form_list = PROJECT_ADD_FORMS
+
+    class RevalidationError(Exception):
+        def __init__(self, step, form, **kwargs):
+            self.step = step
+            self.form = form
+            self.kwargs = kwargs
 
     def get_form_initial(self, step):
         initial = super().get_form_initial(step)
@@ -454,7 +459,7 @@ class ProjectAddWizard(SuperUserCheckMixin,
         description = form_data[1]['description']
         access = form_data[1].get('access')
         url = form_data[1]['url']
-        questionaire = form_data[1].get('questionaire')
+        questionnaire = form_data[1].get('questionnaire')
         contacts = form_data[1].get('contacts')
 
         org = Organization.objects.get(slug=organization)
@@ -464,31 +469,58 @@ class ProjectAddWizard(SuperUserCheckMixin,
             role = form_data[2].get(user.username, None)
             if role:
                 user_roles.append((user, role))
-
-        with transaction.atomic():
-            project = Project.objects.create(
-                name=name, organization=org,
-                description=description, urls=[url], extent=extent,
-                access=access, contacts=contacts
-            )
-            for username, role in user_roles:
-                user = User.objects.get(username=username)
-                ProjectRole.objects.create(
-                    project=project, user=user, role=role
+        try:
+            with transaction.atomic():
+                project = Project.objects.create(
+                    name=name, organization=org,
+                    description=description, urls=[url], extent=extent,
+                    access=access, contacts=contacts
                 )
-
-            if questionaire:
-                try:
+                for username, role in user_roles:
+                    user = User.objects.get(username=username)
+                    ProjectRole.objects.create(
+                        project=project, user=user, role=role
+                    )
+                if questionnaire:
                     Questionnaire.objects.create_from_form(
                         project=project,
-                        xls_form=questionaire
+                        xls_form=questionnaire
                     )
-                except InvalidXLSForm as e:
-                    messages.warning(self.request, e)
+        except InvalidXLSForm as e:
+            details_form = form_dict['details']
+            details_form.add_error('questionnaire', e)
+            raise self.RevalidationError('details', details_form, **kwargs)
 
         return redirect('organization:project-dashboard',
                         organization=organization,
                         project=project.slug)
+
+    def render_done(self, form, **kwargs):
+        final_forms = OrderedDict()
+        # walk through the form list and try to validate the data again.
+        for form_key in self.get_form_list():
+            form_obj = self.get_form(
+                step=form_key,
+                data=self.storage.get_step_data(form_key),
+                files=self.storage.get_step_files(form_key)
+            )
+            if not form_obj.is_valid():  # pragma:  no cover
+                return self.render_revalidation_failure(
+                    form_key, form_obj, **kwargs
+                )
+            final_forms[form_key] = form_obj
+
+        # catch bad xform here
+        try:
+            done_response = self.done(
+                final_forms.values(), form_dict=final_forms, **kwargs
+            )
+        except self.RevalidationError as e:
+            return self.render_revalidation_failure(
+                e.step, e.form, **e.kwargs
+            )
+        self.storage.reset()
+        return done_response
 
 
 class ProjectEdit(mixins.ProjectMixin,

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -198,8 +198,8 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
         context['form'] = self.get_form()
 
         org_admin = OrganizationRole.objects.get(
-           user=self.request.user,
-           organization=context['organization']).admin
+            user=self.request.user,
+            organization=context['organization']).admin
         context['org_admin'] = (org_admin and
                                 not self.is_superuser and
                                 context['org_member'] == self.request.user)
@@ -368,6 +368,7 @@ class ProjectAddWizard(SuperUserCheckMixin,
     form_list = PROJECT_ADD_FORMS
 
     class RevalidationError(Exception):
+
         def __init__(self, step, form, **kwargs):
             self.step = step
             self.form = form

--- a/cadasta/questionnaires/tests/test_managers.py
+++ b/cadasta/questionnaires/tests/test_managers.py
@@ -130,7 +130,7 @@ class QuestionnaireManagerTest(TestCase):
                 xls_form=form,
                 project=ProjectFactory.create()
             )
-        assert "'interger' is not an accepted question type" in e.value.errors
+        assert "Unknown question type 'interger'." in e.value.errors
 
         assert models.Questionnaire.objects.exists() is False
         assert models.QuestionGroup.objects.exists() is False

--- a/cadasta/questionnaires/tests/test_views_api.py
+++ b/cadasta/questionnaires/tests/test_views_api.py
@@ -124,6 +124,6 @@ class QuestionnaireDetailTest(UserTestCase):
         data = {'xls_form': form}
 
         content = self._put(data=data, status=400)
-        assert ("'interger' is not an accepted question type" in
+        assert ("Unknown question type 'interger'." in
                 content.get('xls_form'))
         assert Questionnaire.objects.filter(project=self.prj).count() == 0

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -50,7 +50,7 @@ class LocationsAdd(LoginPermissionRequiredMixin,
                 {'name': 'project',
                  'value': prj,
                  'selector': prj.id},
-                {'name': 'questionaire',
+                {'name': 'questionnaire',
                  'value': prj.current_questionnaire,
                  'selector': prj.current_questionnaire}
             )
@@ -176,7 +176,7 @@ class TenureRelationshipAdd(LoginPermissionRequiredMixin,
                 {'name': 'project',
                  'value': prj,
                  'selector': prj.id},
-                {'name': 'questionaire',
+                {'name': 'questionnaire',
                  'value': prj.current_questionnaire,
                  'selector': prj.current_questionnaire}
             )

--- a/cadasta/templates/organization/project_add_details.html
+++ b/cadasta/templates/organization/project_add_details.html
@@ -109,11 +109,11 @@
             <h3>2. Questionnaire</h3>
             <div class="row">
               <div class="col-md-9">
-                <div class="form-group{% if wizard.form.questionaire.errors %} has-error{% endif %}">
-                  <label for="{{ wizard.form.questionaire.id_for_label }}">{% trans "Select the questionnaire file to use for this project" %}</label>
-                  <label class="pull-right control-label">{{ wizard.form.questionaire.errors }}</label>
+                <div class="form-group{% if wizard.form.questionnaire.errors %} has-error{% endif %}">
+                  <label for="{{ wizard.form.questionnaire.id_for_label }}">{% trans "Select the questionnaire file to use for this project" %}</label>
+                  <label class="pull-right control-label">{{ wizard.form.questionnaire.errors }}</label>
                   <div class="well file-well">
-                    {% render_field wizard.form.questionaire class+="form-control" %}
+                    {% render_field wizard.form.questionnaire class+="form-control" %}
                     <p class="help-block">Accepted file types: xls, xlsx</p>
                   </div>
                   <div class="alert alert-info alert-full clearfix row" role="alert">


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes #272 

Errors in parsing XLSForms are now handled as validation errors in the project creation wizard. This PR also fixes inconsistencies in spelling of `questionnaire` throughout the platform.

### When should this PR be merged

Immediately

### Risks

None

### Follow up actions

Policies will need to be updated the next time the platform is deployed by running:

`./manage.py loadstatic --update-policies`