### PR TITLE
Archived organizations and projects are now frozen.

### DIFF
--- a/cadasta/core/mixins.py
+++ b/cadasta/core/mixins.py
@@ -46,3 +46,16 @@ class PermissionRequiredMixin(mixins.PermissionRequiredMixin):
 class LoginPermissionRequiredMixin(PermissionRequiredMixin,
                                    mixins.LoginPermissionRequiredMixin):
     pass
+
+
+def update_permissions(permission, obj=None):
+    def set_permissions(self, request, view=None):
+        if (hasattr(self, 'get_organization') and
+                self.get_organization().archived):
+                    return False
+        if (hasattr(self, 'get_project') and self.get_project().archived):
+            return False
+        if obj and self.get_object().archived:
+            return False
+        return permission
+    return set_permissions

--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -5664,8 +5664,10 @@ textarea.form-control {
 -------------------------------------------------------------- */
 .dataTables_wrapper {
   clear: both; }
-  .dataTables_wrapper .table-search div.dataTables_filter {
-    text-align: left; }
+  .dataTables_wrapper .table-search label {
+    float: left;
+    text-align: left;
+    margin-right: 10px; }
   .dataTables_wrapper .table-search input {
     margin-left: 0 !important; }
   .dataTables_wrapper .table-entries {
@@ -5763,6 +5765,10 @@ textarea.form-control {
     min-width: 60px !important; }
   .table div.org-logo {
     padding: 4px 0; }
+  .table td.archived, .table td.unarchived {
+    display: none !important; }
+  .table th.archived, .table th.unarchived {
+    display: none !important; }
 
 table.table-location {
   border-top: none; }
@@ -5988,16 +5994,23 @@ div.add-btn-btm {
     color: #843534; }
 
 .label {
+  display: inline-block;
+  margin-left: 6px;
+  margin-right: 6px;
   font-size: 11px;
   font-weight: 500;
   vertical-align: middle; }
 
-h1.label {
-  font-size: 14px; }
+h1 .label {
+  font-size: 16px; }
 
 @media (max-width: 991px) {
   .alert {
     max-width: none; } }
+
+@media (max-width: 767px) {
+  h1 .label {
+    font-size: 12px; } }
 
 /* =Modals
 -------------------------------------------------------------- */

--- a/cadasta/core/static/css/main.scss
+++ b/cadasta/core/static/css/main.scss
@@ -929,8 +929,10 @@ textarea.form-control {
 .dataTables_wrapper {
   clear: both;
   .table-search { // search 
-    div.dataTables_filter {
+    label {
+      float: left;
       text-align: left;
+      margin-right: 10px;
     }
     input {
       margin-left: 0 !important;
@@ -1065,6 +1067,12 @@ textarea.form-control {
   }
   div.org-logo {
     padding: 4px 0;
+  }
+  td.archived, td.unarchived {
+    display: none !important
+  }
+  th.archived, th.unarchived {
+    display: none !important
   }
 }
 
@@ -1350,20 +1358,28 @@ div.add-btn-btm { // add party link at bottom of table
 }
 
 .label {
-  font-size: 11px;
-  font-weight: 500;
+  display: inline-block;
+  margin-left: 6px;
+  margin-right: 6px;
+  font-size: 11px; 
+  font-weight: 500; 
   vertical-align: middle;
 }
 
-h1.label {
-  font-size: 14px;
+h1 .label {
+  font-size: 16px;
 }
-
 
 @media (max-width: $screen-sm-max) {
   .alert {
     max-width: none;
   }
+}
+
+@media (max-width: $screen-xs-max) {
+  h1 .label {
+    font-size: 12px;
+  } 
 }
 
 /* =Modals

--- a/cadasta/core/static/js/dataTables.selectFiltering.js
+++ b/cadasta/core/static/js/dataTables.selectFiltering.js
@@ -1,0 +1,40 @@
+(function(window, document, $) {
+    $(document).on('init.dt', function(e, dtSettings) {
+        if ( e.namespace !== 'dt' ) {
+            return;
+        }
+        addSelectOptions = function(){
+            aData = ['Active', 'Archived', 'All']
+            var r='<label><select class="form-control input-sm" id="archive-filter">', i, iLen=aData.length;
+            for ( i=0 ; i<iLen ; i++ )
+            {
+                r += '<option value="'+aData[i]+'">'+aData[i]+'</option>';
+            }
+            return r+'</select></label>';
+        }
+
+        var table = $('#DataTables_Table_0').DataTable();
+        table.order([1, 'asc']).draw()
+
+        if ($(".archived").length ){
+            dtSettings.nTableWrapper.childNodes[0].childNodes[0].innerHTML += addSelectOptions()
+            table.columns(0).search('False').draw();
+
+            $('input').on( 'keyup', function () {
+                table.search( this.value ).draw();
+            });
+
+            $('#archive-filter').change(function () {
+                var value = ''
+                table.search(value).draw();
+                var selection = $('#archive-filter').val()
+                if (selection === 'Active') {
+                    value = 'False'
+                } else if (selection === 'Archived') {
+                    value = 'True';
+                }
+                table.columns(0).search(value).draw();
+            });
+        }
+    });
+})(window, document, jQuery);

--- a/cadasta/core/static/js/dataTables.selectFiltering.js
+++ b/cadasta/core/static/js/dataTables.selectFiltering.js
@@ -14,7 +14,9 @@
         }
 
         var table = $('#DataTables_Table_0').DataTable();
-        table.order([1, 'asc']).draw()
+        if ($(".unarchived").length ){
+            table.order([1, 'asc']).draw()
+        }
 
         if ($(".archived").length ){
             dtSettings.nTableWrapper.childNodes[0].childNodes[0].innerHTML += addSelectOptions()

--- a/cadasta/core/tests/test_views_default.py
+++ b/cadasta/core/tests/test_views_default.py
@@ -61,14 +61,13 @@ class DashboardTest(ViewTestCase, UserTestCase, TestCase):
         user = UserFactory.create()
         response = self.request(user=user)
         assert response.status_code == 200
-        self._test_projects_rendered(response)
 
     def test_private_projects_rendered_when_org_member_is_signed_in(self):
         user = UserFactory.create()
         OrganizationRole.objects.create(organization=self.org, user=user)
         response = self.request(user=user)
 
-        gj = self._render_geojson(Project.objects.all())
+        gj = self._render_geojson(Project.objects.filter(archived=False))
         expected_content = self.render_content(is_superuser=False, geojson=gj)
         assert response.status_code == 200
         assert response.content == expected_content
@@ -77,7 +76,8 @@ class DashboardTest(ViewTestCase, UserTestCase, TestCase):
         user = UserFactory.create()
         response = self.request(user=user)
 
-        gj = self._render_geojson(Project.objects.filter(access='public'))
+        gj = self._render_geojson(Project.objects.filter(access='public',
+                                                         archived=False))
         expected_content = self.render_content(is_superuser=False, geojson=gj)
         assert response.status_code == 200
         assert response.content == expected_content

--- a/cadasta/core/tests/test_views_default.py
+++ b/cadasta/core/tests/test_views_default.py
@@ -46,6 +46,9 @@ class DashboardTest(ViewTestCase, UserTestCase, TestCase):
         ProjectFactory.create(
             name='Private Project',
             access='private', organization=self.org, extent=extent)
+        ProjectFactory.create(
+            name='Archived Project', archived=True,
+            organization=self.org, extent=extent)
 
     def _render_geojson(self, projects):
         return json.dumps(ProjectGeometrySerializer(projects, many=True).data)
@@ -58,6 +61,7 @@ class DashboardTest(ViewTestCase, UserTestCase, TestCase):
         user = UserFactory.create()
         response = self.request(user=user)
         assert response.status_code == 200
+        self._test_projects_rendered(response)
 
     def test_private_projects_rendered_when_org_member_is_signed_in(self):
         user = UserFactory.create()

--- a/cadasta/core/views/default.py
+++ b/cadasta/core/views/default.py
@@ -38,10 +38,12 @@ class Dashboard(TemplateView):
                         if org in user_orgs:
                             projects.extend(org.projects.filter(
                                 access='private',
-                                extent__isnull=False))
+                                extent__isnull=False,
+                                archived=False))
             projects.extend(Project.objects.filter(
                 access='public',
-                extent__isnull=False))
+                extent__isnull=False,
+                archived=False))
         context = self.get_context_data(projects=projects)
         return super(TemplateView, self).render_to_response(context)
 

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -266,7 +266,7 @@ class ProjectAddDetails(SuperUserCheck, forms.Form):
                 (o.slug, o.name) for o in Organization.objects.order_by('name')
             ]
         else:
-            qs = self.user.organizations.all()
+            qs = self.user.organizations.all().filter(archived=False)
             self.fields['organization'].choices = [
                 (o.slug, o.name) for o in qs.order_by('name')
                 if check_perms(self.user, ('project.create',), (o,))

--- a/cadasta/organization/models.py
+++ b/cadasta/organization/models.py
@@ -67,6 +67,9 @@ class Organization(SlugModel, RandomIDModel):
             ('org.view',
              {'description': _("View existing organizations"),
               'error_message': messages.ORG_VIEW}),
+            ('org.view_archived',
+             {'description': _("View archived organization"),
+              'error_message': messages.ORG_VIEW}),
             ('org.update',
              {'description': _("Update an existing organization"),
               'error_message': messages.ORG_EDIT}),
@@ -97,7 +100,7 @@ class Organization(SlugModel, RandomIDModel):
         return str(self)
 
     def public_projects(self):
-        return self.projects.filter(access='public')
+        return self.projects.filter(access='public', archived=False)
 
     def all_projects(self):
         return self.projects.all()
@@ -193,6 +196,9 @@ class Project(ResourceModelMixin, SlugModel, RandomIDModel):
               'error_message': messages.PROJ_VIEW}),
             ('project.view_private',
              {'description': _("View private projects"),
+              'error_message': messages.PROJ_VIEW}),
+            ('project.view_archived',
+             {'description': _("View archived projects"),
               'error_message': messages.PROJ_VIEW}),
             ('project.update',
              {'description': _("Update an existing project"),

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -45,6 +45,16 @@ class OrganizationSerializer(DetailSerializer, FieldSelectorSerializer,
 
         return org
 
+    def update(self, *args, **kwargs):
+        org = super(OrganizationSerializer, self).update(*args, **kwargs)
+        data = args[1]
+        if 'archived' in data.keys():
+            for project in org.projects.all():
+                project.archived = data['archived']
+                project.save()
+
+        return org
+
 
 class ProjectSerializer(DetailSerializer, serializers.ModelSerializer):
     users = UserSerializer(many=True, read_only=True)

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -36,7 +36,6 @@ class OrganizationList(PermissionsFilterMixin,
 
 
 class OrganizationDetail(APIPermissionRequiredMixin,
-                         mixins.OrganizationMixin,
                          generics.RetrieveUpdateAPIView):
     def view_actions(self, request):
         if self.get_object().archived:
@@ -122,7 +121,6 @@ class UserAdminDetail(APIPermissionRequiredMixin,
 
 class OrganizationProjectList(PermissionsFilterMixin,
                               APIPermissionRequiredMixin,
-                              mixins.OrganizationMixin,
                               mixins.OrgAdminCheckMixin,
                               mixins.ProjectQuerySetMixin,
                               generics.ListCreateAPIView):
@@ -173,12 +171,12 @@ class ProjectList(PermissionsFilterMixin,
                   mixins.ProjectQuerySetMixin,
                   generics.ListAPIView):
     def permission_filter(self, view, p):
-        if p.access == 'public' and p.archived is False:
-            return ('project.view',)
-        elif p.archived is True:
+        if p.archived is True:
             return ('project.view_archived',)
-        else:
+        elif p.access == 'private':
             return ('project.view_private',)
+        else:
+            return ('project.view',)
 
     serializer_class = serializers.ProjectSerializer
     filter_backends = (filters.DjangoFilterBackend,

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from rest_framework.exceptions import PermissionDenied
 from rest_framework import generics, filters, status
 from tutelary.mixins import APIPermissionRequiredMixin, PermissionsFilterMixin
+from core.mixins import update_permissions
 
 from accounts.models import User
 
@@ -29,11 +30,19 @@ class OrganizationList(PermissionsFilterMixin,
         'GET': 'org.list',
         'POST': 'org.create',
     }
-    permission_filter_queryset = ('org.view',)
+    permission_filter_queryset = (lambda self, view, o: ('org.view',)
+                                  if o.archived is False
+                                  else ('org.view_archived',))
 
 
 class OrganizationDetail(APIPermissionRequiredMixin,
+                         mixins.OrganizationMixin,
                          generics.RetrieveUpdateAPIView):
+    def view_actions(self, request):
+        if self.get_object().archived:
+            return 'org.view_archived'
+        return 'org.view'
+
     def patch_actions(self, request):
         if hasattr(request, 'data'):
             is_archived = self.get_object().archived
@@ -42,6 +51,8 @@ class OrganizationDetail(APIPermissionRequiredMixin,
                 return ('org.update', 'org.archive')
             elif is_archived and (is_archived != new_archived):
                 return ('org.update', 'org.unarchive')
+            elif is_archived and (is_archived == new_archived):
+                return False
         return 'org.update'
 
     lookup_url_kwarg = 'organization'
@@ -50,7 +61,7 @@ class OrganizationDetail(APIPermissionRequiredMixin,
     serializer_class = serializers.OrganizationSerializer
     lookup_field = 'slug'
     permission_required = {
-        'GET': 'org.view',
+        'GET': view_actions,
         'PATCH': patch_actions,
     }
 
@@ -64,7 +75,7 @@ class OrganizationUsers(APIPermissionRequiredMixin,
     serializer_class = serializers.OrganizationUserSerializer
     permission_required = {
         'GET': 'org.users.list',
-        'POST': 'org.users.add',
+        'POST': update_permissions('org.users.add'),
     }
 
 
@@ -73,7 +84,7 @@ class OrganizationUsersDetail(APIPermissionRequiredMixin,
                               generics.RetrieveUpdateDestroyAPIView):
 
     serializer_class = serializers.OrganizationUserSerializer
-    permission_required = 'org.users.remove'
+    permission_required = update_permissions('org.users.remove')
 
     def destroy(self, request, *args, **kwargs):
         user = self.get_object()
@@ -111,6 +122,8 @@ class UserAdminDetail(APIPermissionRequiredMixin,
 
 class OrganizationProjectList(PermissionsFilterMixin,
                               APIPermissionRequiredMixin,
+                              mixins.OrganizationMixin,
+                              mixins.OrgAdminCheckMixin,
                               mixins.ProjectQuerySetMixin,
                               generics.ListCreateAPIView):
     org_lookup = 'organization'
@@ -123,7 +136,7 @@ class OrganizationProjectList(PermissionsFilterMixin,
     ordering_fields = ('name', 'organization', 'country', 'description',)
     permission_required = {
         'GET': 'project.list',
-        'POST': 'project.create'
+        'POST': update_permissions('project.create')
     }
 
     def get_organization(self):
@@ -144,15 +157,29 @@ class OrganizationProjectList(PermissionsFilterMixin,
         if self.request.method == 'POST':
             return [self.get_organization()]
 
-        return super().get_queryset().filter(
-            organization__slug=self.kwargs['organization']
-        )
+        if self.is_administrator:
+            return super().get_queryset().filter(
+                organization__slug=self.kwargs['organization']
+            )
+        else:
+            return super().get_queryset().filter(
+                organization__slug=self.kwargs['organization'],
+                archived=False, access='public'
+            )
 
 
 class ProjectList(PermissionsFilterMixin,
                   APIPermissionRequiredMixin,
                   mixins.ProjectQuerySetMixin,
                   generics.ListAPIView):
+    def permission_filter(self, view, p):
+        if p.access == 'public' and p.archived is False:
+            return ('project.view',)
+        elif p.archived is True:
+            return ('project.view_archived',)
+        else:
+            return ('project.view_private',)
+
     serializer_class = serializers.ProjectSerializer
     filter_backends = (filters.DjangoFilterBackend,
                        filters.SearchFilter,
@@ -160,13 +187,16 @@ class ProjectList(PermissionsFilterMixin,
     filter_fields = ('archived',)
     search_fields = ('name', 'organization__name', 'country', 'description',)
     ordering_fields = ('name', 'organization', 'country', 'description',)
-    permission_required = 'project.list'
+    permission_required = {'GET': 'project.list'}
+    permission_filter_queryset = permission_filter
 
 
 class ProjectDetail(APIPermissionRequiredMixin,
                     mixins.OrganizationMixin,
                     generics.RetrieveUpdateDestroyAPIView):
     def get_actions(self, request):
+        if self.get_object().archived:
+            return 'project.view_archived'
         if self.get_object().public():
             return 'project.view'
         else:
@@ -180,6 +210,8 @@ class ProjectDetail(APIPermissionRequiredMixin,
                 return ('project.update', 'project.archive')
             elif is_archived and (is_archived != new_archived):
                 return ('project.update', 'project.unarchive')
+            elif is_archived and (is_archived == new_archived):
+                return False
         return 'project.update'
 
     serializer_class = serializers.ProjectSerializer
@@ -204,10 +236,11 @@ class ProjectDetail(APIPermissionRequiredMixin,
 class ProjectUsers(APIPermissionRequiredMixin,
                    mixins.ProjectRoles,
                    generics.ListCreateAPIView):
+
     serializer_class = serializers.ProjectUserSerializer
     permission_required = {
         'GET': 'project.users.list',
-        'POST': 'project.users.add'
+        'POST': update_permissions('project.users.add')
     }
 
 
@@ -218,8 +251,8 @@ class ProjectUsersDetail(APIPermissionRequiredMixin,
 
     permission_required = {
         'GET': 'project.users.list',
-        'PATCH': 'project.users.edit',
-        'DELETE': 'project.users.delete'
+        'PATCH': update_permissions('project.users.update'),
+        'DELETE': update_permissions('project.users.delete'),
     }
 
     def destroy(self, request, *args, **kwargs):

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -2,11 +2,13 @@ import json
 import os
 from collections import OrderedDict
 
+
 import core.views.generic as generic
 import django.views.generic as base_generic
 import formtools.wizard.views as wizard
 from accounts.models import User
-from core.mixins import LoginPermissionRequiredMixin, PermissionRequiredMixin
+from core.mixins import (LoginPermissionRequiredMixin, PermissionRequiredMixin,
+                         update_permissions)
 from core.views.mixins import ArchiveMixin, SuperUserCheckMixin
 from django.core.urlresolvers import reverse
 from django.db import transaction
@@ -26,7 +28,28 @@ class OrganizationList(PermissionRequiredMixin, generic.ListView):
     model = Organization
     template_name = 'organization/organization_list.html'
     permission_required = 'org.list'
-    permission_filter_queryset = ('org.view',)
+    permission_filter_queryset = (lambda self, view, o: ('org.view',)
+                                  if o.archived == 'False'
+                                  else ('org.view_archived',))
+
+    def get(self, request, *args, **kwargs):
+        if (hasattr(self.request.user, 'assigned_policies') and
+           self.is_superuser):
+                organizations = Organization.objects.all()
+        else:
+            organizations = []
+            organizations.extend(Organization.objects.filter(archived=False))
+            if hasattr(self.request.user, 'organizations'):
+                for org in Organization.objects.filter(archived=True):
+                    if org in self.request.user.organizations.all():
+                        if OrganizationRole.objects.get(organization=org,
+                                                        user=self.request.user
+                                                        ).admin is True:
+                                organizations.append(org)
+        self.object_list = sorted(
+            organizations, key=lambda o: o.slug)
+        context = self.get_context_data()
+        return super(generic.ListView, self).render_to_response(context)
 
 
 class OrganizationAdd(LoginPermissionRequiredMixin, generic.CreateView):
@@ -54,9 +77,15 @@ class OrganizationDashboard(PermissionRequiredMixin,
                             mixins.OrgAdminCheckMixin,
                             mixins.ProjectCreateCheckMixin,
                             generic.DetailView):
+    def get_actions(self, view, request):
+        if self.get_object().archived:
+            return 'org.view_archived'
+        return 'org.view'
+
     model = Organization
     template_name = 'organization/organization_dashboard.html'
-    permission_required = 'org.view'
+    permission_required = get_actions
+    permission_denied_message = error_messages.ORG_VIEW
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
@@ -69,7 +98,11 @@ class OrganizationDashboard(PermissionRequiredMixin,
                 orgs = self.request.user.organizations.all()
                 for org in orgs:
                     if org.slug == self.kwargs['slug']:
-                        projects = self.object.all_projects()
+                        if self.is_administrator:
+                            projects = self.object.all_projects()
+                        else:
+                            projects = self.object.all_projects().filter(
+                                archived=False)
         context['projects'] = projects
         return super(generic.DetailView, self).render_to_response(context)
 
@@ -79,7 +112,7 @@ class OrganizationEdit(LoginPermissionRequiredMixin,
     model = Organization
     form_class = forms.OrganizationForm
     template_name = 'organization/organization_edit.html'
-    permission_required = 'org.update'
+    permission_required = update_permissions('org.update', True)
     permission_denied_message = error_messages.ORG_EDIT
 
     def get_success_url(self):
@@ -99,6 +132,16 @@ class OrgArchiveView(LoginPermissionRequiredMixin,
             'organization:dashboard',
             kwargs={'slug': self.object.slug}
         )
+
+    def archive(self):
+        assert hasattr(self, 'do_archive'), "Please set do_archive attribute"
+        self.object = self.get_object()
+        self.object.archived = self.do_archive
+        self.object.save()
+        for project in self.object.projects.all():
+            project.archived = self.do_archive
+            project.save()
+        return redirect(self.get_success_url())
 
 
 class OrganizationArchive(OrgArchiveView):
@@ -129,7 +172,7 @@ class OrganizationMembersAdd(mixins.OrganizationMixin,
     model = OrganizationRole
     form_class = forms.AddOrganizationMemberForm
     template_name = 'organization/organization_members_add.html'
-    permission_required = 'org.users.add'
+    permission_required = update_permissions('org.users.add')
     permission_denied_message = error_messages.ORG_USERS_ADD
 
     def get_context_data(self, *args, **kwargs):
@@ -163,7 +206,7 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
     slug_url_kwarg = 'username'
     template_name = 'organization/organization_members_edit.html'
     form_class = forms.EditOrganizationMemberForm
-    permission_required = 'org.users.edit'
+    permission_required = update_permissions('org.users.edit')
     permission_denied_message = error_messages.ORG_USERS_EDIT
 
     def get_success_url(self):
@@ -221,7 +264,7 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
 class OrganizationMembersRemove(mixins.OrganizationMixin,
                                 LoginPermissionRequiredMixin,
                                 generic.DeleteView):
-    permission_required = 'org.users.remove'
+    permission_required = update_permissions('org.users.remove')
     permission_denied_message = error_messages.ORG_USERS_REMOVE
 
     def get_object(self):
@@ -277,26 +320,39 @@ class ProjectList(PermissionRequiredMixin,
                   mixins.ProjectQuerySetMixin,
                   mixins.ProjectCreateCheckMixin,
                   generic.ListView):
+    def permission_filter(self, view, p):
+        if p.access == 'public' and p.archived is False:
+            return ('project.view',)
+        elif p.archived is True:
+            return ('project.view_archived',)
+        else:
+            return ('project.view_private',)
+
     model = Project
     template_name = 'organization/project_list.html'
     permission_required = 'project.list'
-    permission_filter_queryset = (lambda self, view, p: ('project.view',)
-                                  if p.access == 'public'
-                                  else ('project.view_private',))
+    permission_filter_queryset = permission_filter
     project_create_check_multiple = True
 
     def get(self, request, *args, **kwargs):
-        if (hasattr(self.request.user, 'assigned_policies') and
-                self.is_superuser):
-            projects = Project.objects.all()
+        user = self.request.user
+        if (hasattr(user, 'assigned_policies') and
+           self.is_superuser):
+                projects = Project.objects.all()
         else:
             projects = []
-            projects.extend(Project.objects.filter(access='public'))
-            if hasattr(self.request.user, 'organizations'):
-                user_orgs = self.request.user.organizations.all()
+            projects.extend(Project.objects.filter(access='public',
+                                                   archived=False))
+            if hasattr(user, 'organizations'):
                 for org in Organization.objects.all():
-                    if org in user_orgs:
+                    if org in user.organizations.all():
                         projects.extend(org.projects.filter(access='private'))
+                        if OrganizationRole.objects.get(organization=org,
+                                                        user=user
+                                                        ).admin is True:
+                            projects.extend(
+                                org.projects.filter(archived=True,
+                                                    access='public'))
         self.object_list = sorted(
             projects, key=lambda p: p.organization.slug + ':' + p.slug)
         context = self.get_context_data()
@@ -307,9 +363,10 @@ class ProjectDashboard(PermissionRequiredMixin,
                        mixins.ProjectAdminCheckMixin,
                        mixins.ProjectMixin,
                        generic.DetailView):
-
-    def get_actions(view, request):
-        if view.get_object().public():
+    def get_actions(self, view):
+        if self.prj.archived:
+            return "project.view_archived"
+        if self.prj.public():
             return 'project.view'
         else:
             return 'project.view_private'
@@ -352,11 +409,19 @@ PROJECT_ADD_TEMPLATES = {
 
 
 def add_wizard_permission_required(self, view, request):
+    if 'organization' in self.kwargs:
+        if Organization.objects.get(
+                slug=self.kwargs.get('organization')).archived:
+            return False
     if request.method != 'POST':
         return ()
     session = request.session.get('wizard_project_add_wizard', None)
     if session is None or 'details' not in session['step_data']:
         return ()
+    elif 'details' in session['step_data'] and Organization.objects.get(
+                slug=session['step_data']['details']['details-organization'][0]
+                ).archived:
+            return False
     else:
         return 'project.create'
 
@@ -530,7 +595,7 @@ class ProjectEdit(mixins.ProjectMixin,
                   mixins.ProjectAdminCheckMixin,
                   LoginPermissionRequiredMixin):
     model = Project
-    permission_required = 'project.update'
+    permission_required = update_permissions('project.update', True)
 
     def get_object(self):
         return self.get_project()
@@ -592,7 +657,11 @@ class ProjectArchive(ProjectEdit, ArchiveMixin, generic.DetailView):
 
 
 class ProjectUnarchive(ProjectEdit, ArchiveMixin, generic.DetailView):
-    permission_required = 'project.unarchive'
+    def patch_actions(self, request, view=None):
+        if self.get_organization().archived:
+            return False
+        return 'project.unarchive'
+    permission_required = patch_actions
     permission_denied_message = error_messages.PROJ_UNARCHIVE
     do_archive = False
 

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -50,6 +50,9 @@ class ProjectMixin:
             )
         return self.prj
 
+    def get_organization(self):
+        return self.get_project().organization
+
 
 class ProjectRoles(ProjectMixin):
     lookup_field = 'username'

--- a/cadasta/party/tests/test_views_api_party_relationships.py
+++ b/cadasta/party/tests/test_views_api_party_relationships.py
@@ -182,15 +182,13 @@ class PartyRelationshipCreateAPITest(APITestCase, UserTestCase, TestCase):
             err_msg.format(self.prj.slug, other_party.project.slug))
 
     def test_create_valid_record_with_archived_project(self):
-        assert False
-        org, prj = self._test_objs()
-        prj.archived = True
-        prj.save()
-        prj.refresh_from_db()
-        self._post(
-            org_slug=org.slug, prj_slug=prj.slug,
-            data=self.default_create_data,
-            status=status_code.HTTP_403_FORBIDDEN)
+        self.prj.archived = True
+        self.prj.save()
+
+        response = self.request(method='POST', user=self.user)
+        assert response.status_code == 403
+        assert PartyRelationship.objects.count() == 0
+        assert response.content['detail'] == PermissionDenied.default_detail
 
 
 class PartyRelationshipDetailAPITest(APITestCase, UserTestCase, TestCase):
@@ -456,15 +454,16 @@ class PartyRelationshipUpdateAPITest(APITestCase, UserTestCase, TestCase):
             err_msg.format(self.party1.project.slug, other_party.project.slug))
 
     def test_update_valid_record_with_archived_project(self):
-        assert False
-        rel, org = self._test_objs()
-        rel.project.archived = True
-        rel.project.save()
-        rel.project.refresh_from_db()
+        self.prj.archived = True
+        self.prj.save()
 
-        self._test_patch_public_record(
-            self.get_valid_updated_data, status_code.HTTP_403_FORBIDDEN,
-            org_slug=org.slug, prj_slug=rel.project.slug, record=rel)
+        response = self.request(method='PATCH', user=self.user)
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.party1 == self.party1
+        assert self.rel.party2 == self.party2
 
 
 class PartyRelationshipDeleteAPITest(APITestCase, UserTestCase, TestCase):
@@ -582,3 +581,12 @@ class PartyRelationshipDeleteAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(method='DELETE', user=user)
         assert response.status_code == 204
         assert PartyRelationship.objects.count() == 0
+
+    def test_delete_record_with_archived_project(self):
+        self.prj.archived = True
+        self.prj.save()
+
+        response = self.request(method='DELETE', user=self.user)
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+        assert PartyRelationship.objects.count() == 1

--- a/cadasta/party/tests/test_views_api_party_relationships.py
+++ b/cadasta/party/tests/test_views_api_party_relationships.py
@@ -181,6 +181,17 @@ class PartyRelationshipCreateAPITest(APITestCase, UserTestCase, TestCase):
         assert response.content['non_field_errors'][0] == (
             err_msg.format(self.prj.slug, other_party.project.slug))
 
+    def test_create_valid_record_with_archived_project(self):
+        assert False
+        org, prj = self._test_objs()
+        prj.archived = True
+        prj.save()
+        prj.refresh_from_db()
+        self._post(
+            org_slug=org.slug, prj_slug=prj.slug,
+            data=self.default_create_data,
+            status=status_code.HTTP_403_FORBIDDEN)
+
 
 class PartyRelationshipDetailAPITest(APITestCase, UserTestCase, TestCase):
     view_class = api.PartyRelationshipDetail
@@ -443,6 +454,17 @@ class PartyRelationshipUpdateAPITest(APITestCase, UserTestCase, TestCase):
             "'party1' project ({}) should be equal to 'party2' project ({})")
         assert response.content['non_field_errors'][0] == (
             err_msg.format(self.party1.project.slug, other_party.project.slug))
+
+    def test_update_valid_record_with_archived_project(self):
+        assert False
+        rel, org = self._test_objs()
+        rel.project.archived = True
+        rel.project.save()
+        rel.project.refresh_from_db()
+
+        self._test_patch_public_record(
+            self.get_valid_updated_data, status_code.HTTP_403_FORBIDDEN,
+            org_slug=org.slug, prj_slug=rel.project.slug, record=rel)
 
 
 class PartyRelationshipDeleteAPITest(APITestCase, UserTestCase, TestCase):

--- a/cadasta/party/tests/test_views_api_tenure_relationships.py
+++ b/cadasta/party/tests/test_views_api_tenure_relationships.py
@@ -165,15 +165,13 @@ class TenureRelationshipCreateTestCase(APITestCase, UserTestCase, TestCase):
             err_msg.format(other_party.project.slug, self.prj.slug))
 
     def test_create_valid_record_with_archived_project(self):
-        assert False
-        org, prj = self._test_objs()
-        prj.archived = True
-        prj.save()
-        prj.refresh_from_db()
-        self._post(
-            org_slug=org.slug, prj_slug=prj.slug,
-            data=self.default_create_data,
-            status=status_code.HTTP_403_FORBIDDEN)
+        self.prj.archived = True
+        self.prj.save()
+
+        response = self.request(user=self.user, method='POST')
+        assert response.status_code == 403
+        assert TenureRelationship.objects.count() == 0
+        assert response.content['detail'] == PermissionDenied.default_detail
 
 
 class TenureRelationshipDetailAPITest(APITestCase, UserTestCase, TestCase):
@@ -436,6 +434,18 @@ class TenureRelationshipUpdateAPITest(APITestCase, UserTestCase, TestCase):
         assert self.rel.party == self.party
         assert self.rel.spatial_unit == self.spatial_unit
 
+    def test_update_with_archived_project(self):
+        self.prj.archived = True
+        self.prj.save()
+
+        response = self.request(user=self.user, method='PATCH')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.party == self.party
+        assert self.rel.spatial_unit == self.spatial_unit
+
 
 class TenureRelationshipDeleteAPITest(APITestCase, UserTestCase, TestCase):
     view_class = api.TenureRelationshipDetail
@@ -553,13 +563,11 @@ class TenureRelationshipDeleteAPITest(APITestCase, UserTestCase, TestCase):
         assert response.status_code == 204
         assert TenureRelationship.objects.count() == 0
 
-    def test_update_valid_record_with_archived_project(self):
-        assert False
-        rel, org = self._test_objs()
-        rel.project.archived = True
-        rel.project.save()
-        rel.project.refresh_from_db()
+    def test_delete_record_with_archived_project(self):
+        self.prj.archived = True
+        self.prj.save()
 
-        self._test_patch_public_record(
-            self.get_valid_updated_data, status_code.HTTP_403_FORBIDDEN,
-            org_slug=org.slug, prj_slug=rel.project.slug, record=rel)
+        response = self.request(method='DELETE', user=self.user)
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+        assert TenureRelationship.objects.count() == 1

--- a/cadasta/party/tests/test_views_api_tenure_relationships.py
+++ b/cadasta/party/tests/test_views_api_tenure_relationships.py
@@ -164,6 +164,17 @@ class TenureRelationshipCreateTestCase(APITestCase, UserTestCase, TestCase):
         assert response.content['non_field_errors'][0] == (
             err_msg.format(other_party.project.slug, self.prj.slug))
 
+    def test_create_valid_record_with_archived_project(self):
+        assert False
+        org, prj = self._test_objs()
+        prj.archived = True
+        prj.save()
+        prj.refresh_from_db()
+        self._post(
+            org_slug=org.slug, prj_slug=prj.slug,
+            data=self.default_create_data,
+            status=status_code.HTTP_403_FORBIDDEN)
+
 
 class TenureRelationshipDetailAPITest(APITestCase, UserTestCase, TestCase):
     view_class = api.TenureRelationshipDetail
@@ -538,7 +549,17 @@ class TenureRelationshipDeleteAPITest(APITestCase, UserTestCase, TestCase):
         OrganizationRole.objects.create(organization=self.prj.organization,
                                         user=user,
                                         admin=True)
-
         response = self.request(method='DELETE', user=user)
         assert response.status_code == 204
         assert TenureRelationship.objects.count() == 0
+
+    def test_update_valid_record_with_archived_project(self):
+        assert False
+        rel, org = self._test_objs()
+        rel.project.archived = True
+        rel.project.save()
+        rel.project.refresh_from_db()
+
+        self._test_patch_public_record(
+            self.get_valid_updated_data, status_code.HTTP_403_FORBIDDEN,
+            org_slug=org.slug, prj_slug=rel.project.slug, record=rel)

--- a/cadasta/party/tests/test_views_default.py
+++ b/cadasta/party/tests/test_views_default.py
@@ -155,11 +155,13 @@ class PartiesAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add parties to this project."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -187,12 +189,14 @@ class PartiesAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert Party.objects.count() == 0
         assert response.status_code == 302
         assert ("You don't have permission to add parties to this project."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
 
 class PartyDetailTest(ViewTestCase, UserTestCase, TestCase):
@@ -342,11 +346,13 @@ class PartiesEditTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to update this party."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -383,10 +389,13 @@ class PartiesEditTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
-        assert response['location'] != self.expected_success_url
+        assert ("You don't have permission to update this party."
+                in response.messages)
 
         self.party.refresh_from_db()
         assert self.party.name != self.post_data['name']
@@ -455,11 +464,13 @@ class PartiesDeleteTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to remove this party."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -492,11 +503,13 @@ class PartiesDeleteTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to remove this party."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
 
 @pytest.mark.usefixtures('make_dirs')
@@ -569,11 +582,13 @@ class PartyResourcesAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add resources to this party"
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -608,11 +623,13 @@ class PartyResourcesAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add resources to this party"
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
 
 @pytest.mark.usefixtures('make_dirs')
@@ -691,11 +708,13 @@ class PartyResourcesNewTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add resources to this party"
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -725,11 +744,13 @@ class PartyResourcesNewTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add resources to this party"
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
         assert self.party.resources.count() == 0
 
@@ -879,11 +900,13 @@ class PartyRelationshipEditTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to update this tenure relationship."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -918,11 +941,13 @@ class PartyRelationshipEditTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to update this tenure relationship."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
         self.relationship.refresh_from_db()
         assert self.relationship.tenure_type_id != 'LH'
@@ -992,11 +1017,13 @@ class PartyRelationshipDeleteTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to remove this tenure relationship."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -1028,11 +1055,13 @@ class PartyRelationshipDeleteTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.unauthorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to remove this tenure relationship."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
         assert TenureRelationship.objects.count() == 1
 
@@ -1111,12 +1140,14 @@ class PartyRelationshipResourceAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add resources to this tenure "
                 "relationship."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -1152,12 +1183,14 @@ class PartyRelationshipResourceAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add resources to this tenure "
                 "relationship."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
         assert self.relationship.resources.count() == 1
         assert self.relationship.resources.first() == self.attached
@@ -1239,12 +1272,14 @@ class PartyRelationshipResourceNewTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add resources to this tenure "
                 "relationship."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -1275,9 +1310,11 @@ class PartyRelationshipResourceNewTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add resources to this tenure "
                 "relationship."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)

--- a/cadasta/party/tests/test_views_default.py
+++ b/cadasta/party/tests/test_views_default.py
@@ -152,6 +152,15 @@ class PartiesAddTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add parties to this project."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -174,6 +183,16 @@ class PartiesAddTest(ViewTestCase, UserTestCase, TestCase):
         assert Party.objects.count() == 0
         assert response.status_code == 302
         assert '/account/login/' in response.location
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert Party.objects.count() == 0
+        assert response.status_code == 302
+        assert ("You don't have permission to add parties to this project."
+                in [str(m) for m in get_messages(self.request)])
 
 
 class PartyDetailTest(ViewTestCase, UserTestCase, TestCase):
@@ -320,6 +339,15 @@ class PartiesEditTest(ViewTestCase, UserTestCase, TestCase):
         with pytest.raises(Http404):
             self.request(user=user, url_kwargs={'party': 'abc123'})
 
+    def test_get_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to update this party."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -347,6 +375,18 @@ class PartiesEditTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(method='POST')
         assert response.status_code == 302
         assert '/account/login/' in response.location
+
+        self.party.refresh_from_db()
+        assert self.party.name != self.post_data['name']
+        assert self.party.type != self.post_data['type']
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert response['location'] != self.expected_success_url
 
         self.party.refresh_from_db()
         assert self.party.name != self.post_data['name']
@@ -412,6 +452,15 @@ class PartiesDeleteTest(ViewTestCase, UserTestCase, TestCase):
         with pytest.raises(Http404):
             self.request(user=user, url_kwargs={'party': 'abc123'})
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to remove this party."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -439,6 +488,15 @@ class PartiesDeleteTest(ViewTestCase, UserTestCase, TestCase):
 
         assert Party.objects.count() == 1
         assert TenureRelationship.objects.count() == 1
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to remove this party."
+                in [str(m) for m in get_messages(self.request)])
 
 
 @pytest.mark.usefixtures('make_dirs')
@@ -508,6 +566,15 @@ class PartyResourcesAddTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add resources to this party"
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -537,6 +604,15 @@ class PartyResourcesAddTest(ViewTestCase, UserTestCase, TestCase):
 
         assert self.party.resources.count() == 1
         assert self.party.resources.first() == self.attached
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add resources to this party"
+                in [str(m) for m in get_messages(self.request)])
 
 
 @pytest.mark.usefixtures('make_dirs')
@@ -612,6 +688,15 @@ class PartyResourcesNewTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add resources to this party"
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -634,6 +719,17 @@ class PartyResourcesNewTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(method='POST')
         assert response.status_code == 302
         assert '/account/login/' in response.location
+
+        assert self.party.resources.count() == 0
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add resources to this party"
+                in [str(m) for m in get_messages(self.request)])
 
         assert self.party.resources.count() == 0
 
@@ -780,6 +876,15 @@ class PartyRelationshipEditTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to update this tenure relationship."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -807,6 +912,18 @@ class PartyRelationshipEditTest(ViewTestCase, UserTestCase, TestCase):
         assert '/account/login/' in response.location
 
         print(self.relationship.tenure_type_id)
+        self.relationship.refresh_from_db()
+        assert self.relationship.tenure_type_id != 'LH'
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to update this tenure relationship."
+                in [str(m) for m in get_messages(self.request)])
+
         self.relationship.refresh_from_db()
         assert self.relationship.tenure_type_id != 'LH'
 
@@ -872,6 +989,15 @@ class PartyRelationshipDeleteTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to remove this tenure relationship."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -897,6 +1023,17 @@ class PartyRelationshipDeleteTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
         self.relationship.refresh_from_db()
+        assert TenureRelationship.objects.count() == 1
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.unauthorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to remove this tenure relationship."
+                in [str(m) for m in get_messages(self.request)])
+
         assert TenureRelationship.objects.count() == 1
 
 
@@ -971,6 +1108,16 @@ class PartyRelationshipResourceAddTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add resources to this tenure "
+                "relationship."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -998,6 +1145,19 @@ class PartyRelationshipResourceAddTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(method='POST')
         assert response.status_code == 302
         assert '/account/login/' in response.location
+
+        assert self.relationship.resources.count() == 1
+        assert self.relationship.resources.first() == self.attached
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add resources to this tenure "
+                "relationship."
+                in [str(m) for m in get_messages(self.request)])
 
         assert self.relationship.resources.count() == 1
         assert self.relationship.resources.first() == self.attached
@@ -1076,6 +1236,16 @@ class PartyRelationshipResourceNewTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add resources to this tenure "
+                "relationship."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -1101,3 +1271,13 @@ class PartyRelationshipResourceNewTest(ViewTestCase, UserTestCase, TestCase):
         assert '/account/login/' in response.location
 
         assert self.relationship.resources.count() == 0
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add resources to this tenure "
+                "relationship."
+                in [str(m) for m in get_messages(self.request)])

--- a/cadasta/party/views/api.py
+++ b/cadasta/party/views/api.py
@@ -6,6 +6,7 @@ from rest_framework import generics, filters, status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from tutelary.mixins import APIPermissionRequiredMixin
+from core.mixins import update_permissions
 
 from party.models import (PartyRelationship,
                           TenureRelationship)
@@ -28,7 +29,7 @@ class PartyList(APIPermissionRequiredMixin,
     ordering_fields = ('name',)
     permission_required = {
         'GET': 'party.list',
-        'POST': 'party.create'
+        'POST': update_permissions('party.create')
     }
     # permission_filter_queryset = ('project.',)
 
@@ -46,8 +47,8 @@ class PartyDetail(APIPermissionRequiredMixin,
     lookup_field = 'id'
     permission_required = {
         'GET': 'party.view',
-        'PATCH': 'party.update',
-        'DELETE': 'party.delete',
+        'PATCH': update_permissions('party.update'),
+        'DELETE': update_permissions('party.delete'),
     }
 
 
@@ -124,7 +125,7 @@ class PartyRelationshipCreate(APIPermissionRequiredMixin,
                               mixins.PartyRelationshipQuerySetMixin,
                               generics.CreateAPIView):
 
-    permission_required = 'party_rel.create'
+    permission_required = update_permissions('party_rel.create')
     serializer_class = serializers.PartyRelationshipWriteSerializer
 
     def get_perms_objects(self):
@@ -139,8 +140,8 @@ class PartyRelationshipDetail(APIPermissionRequiredMixin,
     lookup_field = 'id'
     permission_required = {
         'GET': 'party_rel.view',
-        'PATCH': 'party_rel.update',
-        'DELETE': 'party_rel.delete'
+        'PATCH': update_permissions('party_rel.update'),
+        'DELETE': update_permissions('party_rel.delete')
     }
 
     def get_serializer_class(self):
@@ -158,7 +159,7 @@ class TenureRelationshipCreate(APIPermissionRequiredMixin,
                                mixins.TenureRelationshipQuerySetMixin,
                                generics.CreateAPIView):
 
-    permission_required = 'tenure_rel.create'
+    permission_required = update_permissions('tenure_rel.create')
     serializer_class = serializers.TenureRelationshipWriteSerializer
 
     def get_perms_objects(self):
@@ -173,8 +174,8 @@ class TenureRelationshipDetail(APIPermissionRequiredMixin,
     lookup_field = 'id'
     permission_required = {
         'GET': 'tenure_rel.view',
-        'PATCH': 'tenure_rel.update',
-        'DELETE': 'tenure_rel.delete'
+        'PATCH': update_permissions('tenure_rel.update'),
+        'DELETE': update_permissions('tenure_rel.delete')
     }
 
     def get_serializer_class(self):

--- a/cadasta/party/views/default.py
+++ b/cadasta/party/views/default.py
@@ -2,7 +2,7 @@ from core.views import generic
 import django.views.generic as base_generic
 from django.core.urlresolvers import reverse
 from jsonattrs.mixins import JsonAttrsMixin
-from core.mixins import LoginPermissionRequiredMixin
+from core.mixins import LoginPermissionRequiredMixin, update_permissions
 
 from organization.views import mixins as organization_mixins
 from resources.forms import AddResourceFromLibraryForm
@@ -26,7 +26,7 @@ class PartiesAdd(LoginPermissionRequiredMixin,
                  generic.CreateView):
     form_class = forms.PartyForm
     template_name = 'party/party_add.html'
-    permission_required = 'party.create'
+    permission_required = update_permissions('party.create')
     permission_denied_message = error_messages.PARTY_CREATE
 
     def get_perms_objects(self):
@@ -57,7 +57,7 @@ class PartiesEdit(LoginPermissionRequiredMixin,
                   generic.UpdateView):
     template_name = 'party/party_edit.html'
     form_class = forms.PartyForm
-    permission_required = 'party.update'
+    permission_required = update_permissions('party.update')
     permission_denied_message = error_messages.PARTY_UPDATE
 
 
@@ -66,7 +66,7 @@ class PartiesDelete(LoginPermissionRequiredMixin,
                     organization_mixins.ProjectAdminCheckMixin,
                     generic.DeleteView):
     template_name = 'party/party_delete.html'
-    permission_required = 'party.delete'
+    permission_required = update_permissions('party.delete')
     permission_denied_message = error_messages.PARTY_DELETE
 
     def get_success_url(self):
@@ -82,7 +82,7 @@ class PartyResourcesAdd(LoginPermissionRequiredMixin,
                         generic.DetailView):
     template_name = 'party/resources_add.html'
     form_class = AddResourceFromLibraryForm
-    permission_required = 'party.resources.add'
+    permission_required = update_permissions('party.resources.add')
     permission_denied_message = error_messages.PARTY_RESOURCES_ADD
 
     def post(self, request, *args, **kwargs):
@@ -99,7 +99,7 @@ class PartyResourcesNew(LoginPermissionRequiredMixin,
                         resource_mixins.HasUnattachedResourcesMixin,
                         generic.CreateView):
     template_name = 'party/resources_new.html'
-    permission_required = 'party.resources.add'
+    permission_required = update_permissions('party.resources.add')
     permission_denied_message = error_messages.PARTY_RESOURCES_ADD
 
 
@@ -122,7 +122,7 @@ class PartyRelationshipEdit(LoginPermissionRequiredMixin,
                             generic.UpdateView):
     template_name = 'party/relationship_edit.html'
     form_class = forms.TenureRelationshipEditForm
-    permission_required = 'tenure_rel.update'
+    permission_required = update_permissions('tenure_rel.update')
     permission_denied_message = error_messages.TENURE_REL_UPDATE
 
     def get_success_url(self):
@@ -134,7 +134,7 @@ class PartyRelationshipDelete(LoginPermissionRequiredMixin,
                               organization_mixins.ProjectAdminCheckMixin,
                               generic.DeleteView):
     template_name = 'party/relationship_delete.html'
-    permission_required = 'tenure_rel.delete'
+    permission_required = update_permissions('tenure_rel.delete')
     permission_denied_message = error_messages.TENURE_REL_DELETE
 
     def get_success_url(self):
@@ -149,7 +149,7 @@ class PartyRelationshipResourceNew(LoginPermissionRequiredMixin,
                                    resource_mixins.HasUnattachedResourcesMixin,
                                    generic.CreateView):
     template_name = 'party/relationship_resources_new.html'
-    permission_required = 'tenure_rel.resources.add'
+    permission_required = update_permissions('tenure_rel.resources.add')
     permission_denied_message = error_messages.TENURE_REL_RESOURCES_ADD
 
 
@@ -160,7 +160,7 @@ class PartyRelationshipResourceAdd(LoginPermissionRequiredMixin,
                                    generic.DetailView):
     template_name = 'party/relationship_resources_add.html'
     form_class = AddResourceFromLibraryForm
-    permission_required = 'tenure_rel.resources.add'
+    permission_required = update_permissions('tenure_rel.resources.add')
     permission_denied_message = error_messages.TENURE_REL_RESOURCES_ADD
 
     def post(self, request, *args, **kwargs):

--- a/cadasta/resources/tests/test_views_default.py
+++ b/cadasta/resources/tests/test_views_default.py
@@ -214,6 +214,14 @@ class ProjectResourcesAddTest(ViewTestCase, UserTestCase, TestCase):
                          url_kwargs={'organization': 'some-org',
                                      'project': 'some-project'})
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        self._get(status=302)
+        assert ("You don't have permission to add resources."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_update(self):
         project_resources = self.project.resources.all()
         response = self.request(method='POST', user=self.user)
@@ -244,6 +252,16 @@ class ProjectResourcesAddTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(method='POST')
         assert response.status_code == 302
         assert '/account/login/' in response.location
+        assert self.project.resources.count() == 1
+        assert self.project.resources.first() == self.attached
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        self._post(status=302)
+        assert ("You don't have permission to add resources."
+                in [str(m) for m in get_messages(self.request)])
         assert self.project.resources.count() == 1
         assert self.project.resources.first() == self.attached
 
@@ -305,6 +323,14 @@ class ProjectResourcesNewTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        self._get(status=302)
+        assert ("You don't have permission to add resources."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_create(self):
         response = self.request(method='POST', user=self.user)
         assert response.status_code == 302
@@ -348,6 +374,14 @@ class ProjectResourcesNewTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
         assert self.project.resources.count() == 0
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        self._post(status=302)
+        assert ("You don't have permission to add resources."
+                in [str(m) for m in get_messages(self.request)])
 
 
 @pytest.mark.usefixtures('make_dirs')
@@ -532,6 +566,14 @@ class ProjectResourcesEditTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        self._get(status=302)
+        assert ("You don't have permission to edit this resource."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_update(self):
         response = self.request(method='POST', user=self.user)
         assert response.status_code == 302
@@ -561,6 +603,16 @@ class ProjectResourcesEditTest(ViewTestCase, UserTestCase, TestCase):
         assert '/account/login/' in response.location
         assert self.project.resources.count() == 1
         assert self.project.resources.first().name != 'Some name'
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        self._post(status=302)
+        assert ("You don't have permission to edit this resource."
+                in [str(m) for m in get_messages(self.request)])
+        assert self.project.resources.count() == 1
+        assert self.project.resources.first().name != self.data['name']
 
 
 @pytest.mark.usefixtures('make_dirs')

--- a/cadasta/resources/views/api.py
+++ b/cadasta/resources/views/api.py
@@ -1,5 +1,6 @@
 from rest_framework import filters, generics
 from tutelary.mixins import APIPermissionRequiredMixin
+from core.mixins import update_permissions
 from . import mixins
 
 
@@ -14,7 +15,7 @@ class ProjectResources(APIPermissionRequiredMixin,
     ordering_fields = ('name', 'description', 'file',)
     permission_required = {
         'GET': 'resource.list',
-        'POST': 'resource.add'
+        'POST': update_permissions('resource.add')
     }
 
     def filter_archived_resources(self, view, obj):
@@ -33,6 +34,8 @@ class ProjectResourcesDetail(APIPermissionRequiredMixin,
 
     def patch_actions(self, request):
         if hasattr(request, 'data'):
+            if self.get_object().project.archived:
+                return False
             is_archived = self.get_object().archived
             new_archived = request.data.get('archived', is_archived)
             if not is_archived and (is_archived != new_archived):

--- a/cadasta/resources/views/default.py
+++ b/cadasta/resources/views/default.py
@@ -1,5 +1,5 @@
 import django.views.generic as base_generic
-from core.mixins import LoginPermissionRequiredMixin
+from core.mixins import LoginPermissionRequiredMixin, update_permissions
 from core.views import generic
 from core.views.mixins import ArchiveMixin
 from django.core.urlresolvers import reverse
@@ -44,7 +44,7 @@ class ProjectResourcesAdd(LoginPermissionRequiredMixin,
                           generic.DetailView):
     template_name = 'resources/project_add_existing.html'
     form_class = AddResourceFromLibraryForm
-    permission_required = 'resource.add'
+    permission_required = update_permissions('resource.add')
     permission_denied_message = error_messages.RESOURCE_ADD
 
     def get_object(self):
@@ -64,7 +64,7 @@ class ProjectResourcesNew(LoginPermissionRequiredMixin,
                           organization_mixins.ProjectAdminCheckMixin,
                           generic.CreateView):
     template_name = 'resources/project_add_new.html'
-    permission_required = 'resource.add'
+    permission_required = update_permissions('resource.add')
     permission_denied_message = error_messages.RESOURCE_ADD
 
     def get_perms_objects(self):
@@ -110,7 +110,7 @@ class ProjectResourcesEdit(LoginPermissionRequiredMixin,
                            organization_mixins.ProjectAdminCheckMixin,
                            generic.UpdateView):
     template_name = 'resources/edit.html'
-    permission_required = 'resource.edit'
+    permission_required = update_permissions('resource.edit')
     permission_denied_message = error_messages.RESOURCE_EDIT
 
     def get_context_data(self, *args, **kwargs):

--- a/cadasta/resources/views/default.py
+++ b/cadasta/resources/views/default.py
@@ -124,7 +124,7 @@ class ResourceArchive(LoginPermissionRequiredMixin,
                       mixins.ResourceObjectMixin,
                       generic.UpdateView):
     do_archive = True
-    permission_required = 'resource.archive'
+    permission_required = update_permissions('resource.archive')
     permission_denied_message = error_messages.RESOURCE_ARCHIVE
 
     def get_success_url(self):
@@ -158,7 +158,7 @@ class ResourceUnarchive(LoginPermissionRequiredMixin,
                         mixins.ResourceObjectMixin,
                         generic.UpdateView):
     do_archive = False
-    permission_required = 'resource.unarchive'
+    permission_required = update_permissions('resource.unarchive')
     permission_denied_message = error_messages.RESOURCE_UNARCHIVE
 
 
@@ -168,7 +168,7 @@ class ResourceDetach(LoginPermissionRequiredMixin,
     http_method_names = ('post',)
     model = ContentObject
     pk_url_kwarg = 'attachment'
-    permission_required = 'resource.edit'
+    permission_required = update_permissions('resource.edit')
     permission_denied_message = error_messages.RESOURCE_EDIT
 
     def get_object(self):

--- a/cadasta/spatial/tests/base_classes.py
+++ b/cadasta/spatial/tests/base_classes.py
@@ -1,0 +1,710 @@
+import json
+
+from django.utils.translation import gettext as _
+from django.contrib.auth.models import AnonymousUser
+from rest_framework import status as status_code
+from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework.exceptions import PermissionDenied
+
+from core.tests.base_test_case import UserTestCase
+from organization.models import OrganizationRole
+from accounts.tests.factories import UserFactory
+from organization.tests.factories import (OrganizationFactory,
+                                          clause)
+from tutelary.models import Policy
+
+
+class RecordBaseTestCase(UserTestCase):
+
+    def setUp(self):
+        """Set up some policies and users having those policies."""
+
+        super().setUp()
+
+        clauses = {
+            'clause': [
+                {
+                    'effect': 'allow',
+                    'object': ['project/*/*',
+                               'spatial/*/*/*',
+                               'spatial_rel/*/*/*',
+                               'party/*/*/*',
+                               'party_rel/*/*/*',
+                               'tenure_rel/*/*/*'],
+                    'action': ['project.*',
+                               'project.*.*',
+                               'spatial.*',
+                               'spatial_rel.*',
+                               'party.*',
+                               'party_rel.*',
+                               'tenure_rel.*']
+                }
+            ]
+        }
+        policy = Policy.objects.create(
+            name='basic-test',
+            body=json.dumps(clauses))
+        self.user = UserFactory.create()
+        self.user.assign_policies(policy)
+
+        restricted_clauses = {
+            'clause': [
+                clause('allow', ['project.list'], ['organization/*']),
+                clause('allow', ['project.view'], ['project/*/*'])
+            ]
+        }
+        restricted_policy = Policy.objects.create(
+            name='restricted',
+            body=json.dumps(restricted_clauses))
+        self.restricted_user = UserFactory.create()
+        self.restricted_user.assign_policies(restricted_policy)
+
+
+class RecordListBaseTestCase(RecordBaseTestCase):
+
+    def _get(
+        self, org_slug, prj_slug, user=None, query=None,
+        status=None, length=None
+    ):
+        if user is None:
+            user = self.user
+        url = self.url.format(org=org_slug, prj=prj_slug)
+        if query is not None:
+            url += '?' + query
+        request = APIRequestFactory().get(url)
+        force_authenticate(request, user=user)
+        response = self.view(
+            request, organization=org_slug, project=prj_slug).render()
+        content = json.loads(response.content.decode('utf-8'))
+        if status is not None:
+            print(response.status_code, status)
+            assert response.status_code == status
+        if status == status_code.HTTP_200_OK:
+            assert length is not None
+        if length is not None:
+            assert len(content['features']) == length
+        return content
+
+
+class RecordListAPITest:
+
+    # Hooks that need to be defined in the child class:
+    # self._test_objs()
+    # self.num_records
+
+    def _test_list_private_record(
+        self,
+        status=None,              # Optional expected HTTP status status_code
+        user=None,                # Optional user that does the update
+        length=None,              # Expected number of records returned
+        make_org_member=False,       # Flag to make the user an org member
+        make_other_org_member=False  # Flag to make the user a member
+                                     # of another org
+    ):
+        if user is None:
+            user = self.user
+        org, prj = self._test_objs(access='private')
+        if make_org_member:
+            OrganizationRole.objects.create(organization=org, user=user)
+        if make_other_org_member:
+            other_org = OrganizationFactory.create()
+            OrganizationRole.objects.create(organization=other_org, user=user)
+        if status == status_code.HTTP_200_OK and length is None:
+            length = self.num_records
+        content = self._get(
+            org_slug=org.slug, prj_slug=prj.slug, user=user,
+            status=status, length=length)
+        if status == status_code.HTTP_403_FORBIDDEN:
+            assert content['detail'] == PermissionDenied.default_detail
+
+    def test_full_list_with_nonexistent_org(self):
+        org, prj = self._test_objs()
+        content = self._get(
+            org_slug='evil-corp', prj_slug=prj.slug,
+            status=status_code.HTTP_404_NOT_FOUND)
+        assert content['detail'] == "Project not found."
+
+    def test_full_list_with_nonexistent_project(self):
+        org, prj = self._test_objs()
+        content = self._get(
+            org_slug=org.slug, prj_slug='world-domination',
+            status=status_code.HTTP_404_NOT_FOUND)
+        assert content['detail'] == "Project not found."
+
+    def test_full_list_with_unauthorized_user(self):
+        org, prj = self._test_objs()
+        content = self._get(
+            org_slug=org.slug, prj_slug=prj.slug, user=AnonymousUser(),
+            status=status_code.HTTP_403_FORBIDDEN)
+        assert content['detail'] == PermissionDenied.default_detail
+
+    def test_list_private_record(self):
+        self._test_list_private_record(status=status_code.HTTP_200_OK)
+
+    def test_list_private_record_with_unauthorized_user(self):
+        self._test_list_private_record(
+            user=AnonymousUser(), status=status_code.HTTP_403_FORBIDDEN)
+
+    def test_list_private_records_without_permission(self):
+        self._test_list_private_record(
+            user=self.restricted_user, status=status_code.HTTP_403_FORBIDDEN)
+
+    def test_list_private_records_based_on_org_membership(self):
+        self._test_list_private_record(
+            user=UserFactory.create(), status=status_code.HTTP_200_OK,
+            make_org_member=True)
+
+    def test_list_private_records_with_other_org_membership(self):
+        self._test_list_private_record(
+            user=UserFactory.create(), status=status_code.HTTP_403_FORBIDDEN,
+            make_other_org_member=True)
+
+
+class RecordCreateBaseTestCase(RecordBaseTestCase):
+
+    # Hooks that need to be defined in the child class:
+    # self.record_model
+    # self.num_records
+
+    def _post(self, org_slug, prj_slug, data, status, user=None):
+        if user is None:
+            user = self.user
+        url = self.url.format(org=org_slug, prj=prj_slug)
+        request = APIRequestFactory().post(url, data=data, format='json')
+        force_authenticate(request, user=user)
+        response = self.view(
+            request, organization=org_slug, project=prj_slug).render()
+        content = json.loads(response.content.decode('utf-8'))
+        print(response.status_code, status)
+        assert response.status_code == status
+        assert self.record_model.objects.count() == (
+            self.num_records +
+            (1 if status == status_code.HTTP_201_CREATED else 0))
+        return content
+
+
+class RecordCreateAPITest:
+
+    # Hooks that need to be defined in the child class:
+    # self.default_create_data
+    # self._test_objs()
+
+    def _test_create_private_record(
+        self,
+        status,                   # Expected HTTP status status_code
+        user=None,                # Optional user that does the update
+        count=None,               # Expected number of records in DB
+        make_org_member=False,       # Flag to make the user an org member
+        make_other_org_member=False  # Flag to make the user a member
+                                     # of another org
+    ):
+        if user is None:
+            user = self.user
+        org, prj = self._test_objs(access='private')
+        if make_org_member:
+            OrganizationRole.objects.create(organization=org, user=user)
+        if make_other_org_member:
+            other_org = OrganizationFactory.create()
+            OrganizationRole.objects.create(organization=other_org, user=user)
+        content = self._post(
+            org_slug=org.slug, prj_slug=prj.slug, user=user,
+            status=status, data=self.default_create_data)
+        if status == status_code.HTTP_403_FORBIDDEN:
+            assert content['detail'] == PermissionDenied.default_detail
+
+    def test_create_valid_record(self):
+        org, prj = self._test_objs()
+        self._post(
+            org_slug=org.slug, prj_slug=prj.slug,
+            data=self.default_create_data, status=status_code.HTTP_201_CREATED)
+
+    def test_create_record_with_nonexistent_org(self):
+        org, prj = self._test_objs()
+        content = self._post(
+            org_slug='evil-corp', prj_slug=prj.slug,
+            data=self.default_create_data,
+            status=status_code.HTTP_404_NOT_FOUND)
+        assert content['detail'] == "Project not found."
+
+    def test_create_record_with_nonexistent_project(self):
+        org, prj = self._test_objs()
+        content = self._post(
+            org_slug=org.slug, prj_slug='world-domination',
+            data=self.default_create_data,
+            status=status_code.HTTP_404_NOT_FOUND)
+        assert content['detail'] == "Project not found."
+
+    def test_create_record_with_unauthorized_user(self):
+        org, prj = self._test_objs()
+        content = self._post(
+            org_slug=org.slug, prj_slug=prj.slug, user=AnonymousUser(),
+            data=self.default_create_data,
+            status=status_code.HTTP_403_FORBIDDEN)
+        assert content['detail'] == PermissionDenied.default_detail
+
+    def test_create_private_record(self):
+        self._test_create_private_record(status=status_code.HTTP_201_CREATED)
+
+    def test_create_private_record_with_unauthorized_user(self):
+        self._test_create_private_record(
+            user=AnonymousUser(), status=status_code.HTTP_403_FORBIDDEN)
+
+    def test_create_private_record_without_permission(self):
+        self._test_create_private_record(
+            user=self.restricted_user, status=status_code.HTTP_403_FORBIDDEN)
+
+    def test_create_private_record_based_on_org_membership(self):
+        self._test_create_private_record(
+            user=UserFactory.create(), status=status_code.HTTP_403_FORBIDDEN,
+            make_org_member=True)
+
+    def test_create_private_record_with_other_org_membership(self):
+        self._test_create_private_record(
+            user=UserFactory.create(), status=status_code.HTTP_403_FORBIDDEN,
+            make_other_org_member=True)
+
+
+class RecordDetailBaseTestCase(RecordBaseTestCase):
+
+    # Hooks that need to be defined in the child class:
+    # self.record_id_url_var_name
+
+    def _get(self, org_slug, prj_slug, record_id, user, status):
+        url = self.url.format(org=org_slug, prj=prj_slug, record=record_id)
+        request = APIRequestFactory().get(url)
+        force_authenticate(request, user=user)
+        kwargs = {self.record_id_url_var_name: record_id}
+        response = self.view(
+            request, organization=org_slug, project=prj_slug, **kwargs
+        ).render()
+        content = json.loads(response.content.decode('utf-8'))
+        print(response.status_code, status)
+        assert response.status_code == status
+        return content
+
+    def _patch(self, org_slug, prj_slug, record, data, user, status):
+        url = self.url.format(org=org_slug, prj=prj_slug, record=record.id)
+        request = APIRequestFactory().patch(url, data, format='json')
+        force_authenticate(request, user=user)
+        kwargs = {self.record_id_url_var_name: record.id}
+        response = self.view(
+            request, organization=org_slug, project=prj_slug, **kwargs
+        ).render()
+        content = json.loads(response.content.decode('utf-8'))
+        print(response.status_code, status)
+        assert response.status_code == status
+        record.refresh_from_db()
+        return content
+
+    def _delete(self, org_slug, prj_slug, record_id, user, status):
+        url = self.url.format(org=org_slug, prj=prj_slug, record=record_id)
+        request = APIRequestFactory().delete(url)
+        force_authenticate(request, user=user)
+        kwargs = {self.record_id_url_var_name: record_id}
+        response = self.view(
+            request, organization=org_slug, project=prj_slug, **kwargs
+        ).render()
+        print(response.status_code, status)
+        assert response.status_code == status
+        if response.content:
+            content = json.loads(response.content.decode('utf-8'))
+            return content
+
+
+class RecordDetailAPITest:
+
+    # Hooks that need to be defined in the child class:
+    # self.model_name
+    # self._test_objs()
+    # self.is_id_in_content()
+
+    def _test_get_public_record(
+        self,
+        status,         # Expected HTTP status status_code
+        user=None,      # Optional user that does the update
+        org_slug=None,  # Optional org slug of record
+        prj_slug=None   # Optional project slug of record
+    ):
+        # Set up request
+        record = self._test_objs()[0]
+        record_id = record.id
+        if user is None:
+            user = self.user
+        if (
+            status == status_code.HTTP_404_NOT_FOUND and
+            prj_slug is None and org_slug is None
+        ):
+            record_id = 'notanid'
+        if org_slug is None:
+            org_slug = record.project.organization.slug
+        if prj_slug is None:
+            prj_slug = record.project.slug
+
+        # Perform request
+        content = self._get(
+            org_slug=org_slug, prj_slug=prj_slug, record_id=record_id,
+            user=user, status=status)
+
+        # Perform post-checks
+        if status == status_code.HTTP_200_OK:
+            assert self.is_id_in_content(content, record.id)
+        if status == status_code.HTTP_403_FORBIDDEN:
+            assert content['detail'] == PermissionDenied.default_detail
+        if status == status_code.HTTP_404_NOT_FOUND:
+            if record_id == 'notanid':
+                err_msg = _("{} not found.".format(self.model_name))
+                assert content['detail'] == err_msg
+            else:
+                assert content['detail'] == _("Project not found.")
+
+    def _test_get_private_record(
+        self,
+        status,                      # Expected HTTP status status_code
+        user=None,                   # Optional user that does the update
+        make_org_member=False,       # Flag to make the user an org member
+        make_other_org_member=False  # Flag to make the user a member
+                                     # of another org
+    ):
+        # Set up request
+        record, org = self._test_objs(access='private')
+        if user is None:
+            user = self.user
+        if make_org_member:
+            OrganizationRole.objects.create(organization=org, user=user)
+        if make_other_org_member:
+            other_org = OrganizationFactory.create()
+            OrganizationRole.objects.create(organization=other_org, user=user)
+
+        # Perform request
+        content = self._get(
+            org_slug=org.slug, prj_slug=record.project.slug,
+            record_id=record.id, user=user, status=status)
+
+        # Perform post-checks
+        if status == status_code.HTTP_200_OK:
+            assert self.is_id_in_content(content, record.id)
+        if status == status_code.HTTP_403_FORBIDDEN:
+            assert content['detail'] == PermissionDenied.default_detail
+
+    def test_get_public_record_with_valid_user(self):
+        self._test_get_public_record(status_code.HTTP_200_OK)
+
+    def test_get_public_nonexistent_record(self):
+        self._test_get_public_record(status_code.HTTP_404_NOT_FOUND)
+
+    def test_get_public_record_with_nonexistent_org(self):
+        self._test_get_public_record(
+            status_code.HTTP_404_NOT_FOUND, org_slug='evil-corp')
+
+    def test_get_public_record_with_nonexistent_project(self):
+        self._test_get_public_record(
+            status_code.HTTP_404_NOT_FOUND, prj_slug='world-domination')
+
+    def test_get_public_record_with_unauthorized_user(self):
+        self._test_get_public_record(
+            status_code.HTTP_403_FORBIDDEN, user=AnonymousUser())
+
+    def test_get_private_record(self):
+        self._test_get_private_record(status_code.HTTP_200_OK)
+
+    def test_get_private_record_with_unauthorized_user(self):
+        self._test_get_private_record(
+            status_code.HTTP_403_FORBIDDEN, user=AnonymousUser())
+
+    def test_get_private_record_without_permission(self):
+        self._test_get_private_record(
+            status_code.HTTP_403_FORBIDDEN, user=self.restricted_user)
+
+    def test_get_private_record_based_on_org_membership(self):
+        self._test_get_private_record(
+            status_code.HTTP_200_OK, user=UserFactory.create(),
+            make_org_member=True)
+
+    def test_get_private_record_with_other_org_membership(self):
+        self._test_get_private_record(
+            status_code.HTTP_403_FORBIDDEN, user=UserFactory.create(),
+            make_other_org_member=True)
+
+
+class RecordUpdateAPITest:
+
+    # Hooks that need to be defined in the child class:
+    # self.model_name
+    # self.record_factory
+    # self._test_objs()
+    # self.get_valid_updated_data()
+    # self.check_for_unchanged()
+
+    def _test_patch_public_record(
+        self,
+        get_new_data,       # Callback to return partially updated record
+        status,             # Expected HTTP status status_code
+        user=None,          # Optional user that does the update
+        org_slug=None,      # Optional org slug of record
+        prj_slug=None,      # Optional project slug of record
+        record=None         # Optional existing record
+    ):
+        # Set up request
+        existing_record, org = self._test_objs()
+        record = record or existing_record
+        if user is None:
+            user = self.user
+        if org_slug is None:
+            org_slug = existing_record.project.organization.slug
+        if prj_slug is None:
+            prj_slug = existing_record.project.slug
+
+        print(org_slug, prj_slug)
+        # Perform request
+        content = self._patch(
+            org_slug=org_slug, prj_slug=prj_slug, record=record, user=user,
+            status=status, data=get_new_data())
+
+        # Perform post-checks
+        if status == status_code.HTTP_403_FORBIDDEN:
+            assert content['detail'] == PermissionDenied.default_detail
+        if status == status_code.HTTP_404_NOT_FOUND:
+            if record != existing_record:
+                err_msg = _("{} not found.".format(self.model_name))
+                assert content['detail'] == err_msg
+            else:
+                assert content['detail'] == _("Project not found.")
+        if status != status_code.HTTP_200_OK:
+            existing_content = self._get(
+                org_slug=org.slug, prj_slug=existing_record.project.slug,
+                record_id=existing_record.id, user=self.user,
+                status=status_code.HTTP_200_OK)
+            self.check_for_unchanged(existing_content)
+        return content
+
+    def _test_patch_private_record(
+        self,
+        get_new_data,           # Callback to return partially updated record
+        status,                 # Expected HTTP status status_code
+        user=None,              # Optional user that does the update
+        make_org_member=False,       # Flag to make the user an org member
+        make_org_admin=False,        # Flag to make the user an org admin
+        make_other_org_member=False  # Flag to make the user a member
+                                     # of another org
+    ):
+        # Set up request
+        existing_record, org = self._test_objs(access='private')
+        if user is None:
+            user = self.user
+        if make_org_member:
+            OrganizationRole.objects.create(organization=org, user=user)
+        if make_org_admin:
+            OrganizationRole.objects.create(
+                organization=org, user=user, admin=True)
+        if make_other_org_member:
+            other_org = OrganizationFactory.create()
+            OrganizationRole.objects.create(organization=other_org, user=user)
+
+        # Perform request
+        content = self._patch(
+            org_slug=org.slug, prj_slug=existing_record.project.slug,
+            record=existing_record, user=user, data=get_new_data(),
+            status=status)
+
+        # Perform post-checks
+        if status == status_code.HTTP_403_FORBIDDEN:
+            assert content['detail'] == PermissionDenied.default_detail
+        if status != status_code.HTTP_200_OK:
+            existing_content = self._get(
+                org_slug=org.slug, prj_slug=existing_record.project.slug,
+                record_id=existing_record.id, user=self.user,
+                status=status_code.HTTP_200_OK)
+            self.check_for_unchanged(existing_content)
+        return content
+
+    def test_update_with_valid_data(self):
+        content = self._test_patch_public_record(
+            self.get_valid_updated_data, status_code.HTTP_200_OK)
+        self.check_for_updated(content)
+
+    def test_update_with_nonexistent_org(self):
+        self._test_patch_public_record(
+            self.get_valid_updated_data, status_code.HTTP_404_NOT_FOUND,
+            org_slug='evil-corp')
+
+    def test_update_with_nonexistent_project(self):
+        self._test_patch_public_record(
+            self.get_valid_updated_data, status_code.HTTP_404_NOT_FOUND,
+            prj_slug='world-domination')
+
+    def test_update_with_nonexistent_record(self):
+        self._test_patch_public_record(
+            self.get_valid_updated_data, status_code.HTTP_404_NOT_FOUND,
+            record=self.record_factory.create())
+
+    def test_update_with_unauthorized_user(self):
+        self._test_patch_public_record(
+            self.get_valid_updated_data, status_code.HTTP_403_FORBIDDEN,
+            user=AnonymousUser())
+
+    def test_update_private_record(self):
+        content = self._test_patch_private_record(
+            self.get_valid_updated_data, status_code.HTTP_200_OK)
+        self.check_for_updated(content)
+
+    def test_update_private_record_with_unauthorized_user(self):
+        self._test_patch_private_record(
+            self.get_valid_updated_data, status_code.HTTP_403_FORBIDDEN,
+            user=AnonymousUser())
+
+    def test_update_private_record_without_permission(self):
+        self._test_patch_private_record(
+            self.get_valid_updated_data, status_code.HTTP_403_FORBIDDEN,
+            user=self.restricted_user)
+
+    def test_update_private_record_based_on_org_membership(self):
+        self._test_patch_private_record(
+            self.get_valid_updated_data, status_code.HTTP_403_FORBIDDEN,
+            user=UserFactory.create(), make_org_member=True)
+
+    def test_update_private_record_based_on_org_admin(self):
+        content = self._test_patch_private_record(
+            self.get_valid_updated_data, status_code.HTTP_200_OK,
+            user=UserFactory.create(), make_org_admin=True)
+        self.check_for_updated(content)
+
+    def test_update_private_record_with_other_org_membership(self):
+        self._test_patch_private_record(
+            self.get_valid_updated_data, status_code.HTTP_403_FORBIDDEN,
+            user=UserFactory.create(), make_other_org_member=True)
+
+
+class RecordDeleteAPITest:
+
+    # Hooks that need to be defined in the child class:
+    # self.model_name
+    # self.record_factory
+    # self._test_objs()
+
+    def _test_delete_public_record(
+        self,
+        status,         # Expected HTTP status status_code
+        user=None,      # Optional user that does the update
+        org_slug=None,  # Optional org slug of record
+        prj_slug=None,  # Optional project slug of record
+        record=None     # Optional existing record
+    ):
+        # Set up request
+        existing_record = self._test_objs()[0]
+        record = record or existing_record
+        if user is None:
+            user = self.user
+        if org_slug is None:
+            org_slug = existing_record.project.organization.slug
+        if prj_slug is None:
+            prj_slug = existing_record.project.slug
+        kwargs = {
+            'org_slug': org_slug,
+            'prj_slug': prj_slug,
+            'record_id': record.id,
+            'user': user,
+        }
+
+        # Perform request
+        content = self._delete(status=status, **kwargs)
+
+        # Perform post-checks
+        kwargs['user'] = self.user
+        kwargs['record_id'] = existing_record.id
+        if status == status_code.HTTP_204_NO_CONTENT:
+            self._get(status=status_code.HTTP_404_NOT_FOUND, **kwargs)
+        if status == status_code.HTTP_403_FORBIDDEN:
+            assert content['detail'] == PermissionDenied.default_detail
+            self._get(status=status_code.HTTP_200_OK, **kwargs)
+        if status == status_code.HTTP_404_NOT_FOUND:
+            if record != existing_record:
+                err_msg = _("{} not found.".format(self.model_name))
+                assert content['detail'] == err_msg
+            else:
+                assert content['detail'] == _("Project not found.")
+
+    def _test_delete_private_record(
+        self,
+        status,                      # Expected HTTP status status_code
+        user=None,                   # Optional user that does the update
+        make_org_member=False,       # Flag to make the user an org member
+        make_org_admin=False,        # Flag to make the user an org admin
+        make_other_org_member=False  # Flag to make the user a member
+                                     # of another org
+    ):
+        # Set up request
+        existing_record, org = self._test_objs(access='private')
+        if user is None:
+            user = self.user
+        if make_org_member:
+            OrganizationRole.objects.create(organization=org, user=user)
+        if make_org_admin:
+            OrganizationRole.objects.create(
+                organization=org, user=user, admin=True)
+        if make_other_org_member:
+            other_org = OrganizationFactory.create()
+            OrganizationRole.objects.create(organization=other_org, user=user)
+
+        kwargs = {
+            'org_slug': org.slug,
+            'prj_slug': existing_record.project.slug,
+            'record_id': existing_record.id,
+            'user': user,
+        }
+
+        # Perform request
+        content = self._delete(status=status, **kwargs)
+
+        # Perform post-checks
+        kwargs['user'] = self.user
+        if status == status_code.HTTP_204_NO_CONTENT:
+            self._get(status=status_code.HTTP_404_NOT_FOUND, **kwargs)
+        if status == status_code.HTTP_403_FORBIDDEN:
+            assert content['detail'] == PermissionDenied.default_detail
+            self._get(status=status_code.HTTP_200_OK, **kwargs)
+
+    def test_delete_record(self):
+        self._test_delete_public_record(status_code.HTTP_204_NO_CONTENT)
+
+    def test_delete_with_nonexistent_org(self):
+        self._test_delete_public_record(
+            status_code.HTTP_404_NOT_FOUND, org_slug='evil-corp')
+
+    def test_delete_with_nonexistent_project(self):
+        self._test_delete_public_record(
+            status_code.HTTP_404_NOT_FOUND, prj_slug='world-domination')
+
+    def test_delete_with_nonexistent_record(self):
+        self._test_delete_public_record(
+            status_code.HTTP_404_NOT_FOUND,
+            record=self.record_factory.create())
+
+    def test_delete_with_unauthorized_user(self):
+        self._test_delete_public_record(
+            status_code.HTTP_403_FORBIDDEN, user=AnonymousUser())
+
+    def test_delete_private_record(self):
+        self._test_delete_private_record(status_code.HTTP_204_NO_CONTENT)
+
+    def test_delete_private_record_with_unauthorized_user(self):
+        self._test_delete_private_record(
+            status_code.HTTP_403_FORBIDDEN, user=AnonymousUser())
+
+    def test_delete_private_record_without_permission(self):
+        self._test_delete_private_record(
+            status_code.HTTP_403_FORBIDDEN, user=self.restricted_user)
+
+    def test_delete_private_record_based_on_org_membership(self):
+        self._test_delete_private_record(
+            status_code.HTTP_403_FORBIDDEN, user=UserFactory.create(),
+            make_org_member=True)
+
+    def test_delete_private_record_based_on_org_admin(self):
+        self._test_delete_private_record(
+            status_code.HTTP_204_NO_CONTENT, user=UserFactory.create(),
+            make_org_admin=True)
+
+    def test_delete_private_record_with_other_org_membership(self):
+        self._test_delete_private_record(
+            status_code.HTTP_403_FORBIDDEN, user=UserFactory.create(),
+            make_other_org_member=True)

--- a/cadasta/spatial/tests/test_views_api_spatial_relationships.py
+++ b/cadasta/spatial/tests/test_views_api_spatial_relationships.py
@@ -172,6 +172,16 @@ class SpatialRelationshipCreateAPITest(APITestCase, UserTestCase, TestCase):
         assert response.content['non_field_errors'][0] == (
             err_msg.format(self.prj.slug, other_su.project.slug))
 
+    def test_create_valid_record_with_archived_project(self):
+        org, prj = self._test_objs()
+        prj.archived = True
+        prj.save()
+        prj.refresh_from_db()
+        self._post(
+            org_slug=org.slug, prj_slug=prj.slug,
+            data=self.default_create_data,
+            status=status_code.HTTP_403_FORBIDDEN)
+
 
 class SpatialRelationshipDetailAPITest(APITestCase, UserTestCase, TestCase):
     view_class = api.SpatialRelationshipDetail
@@ -425,6 +435,16 @@ class SpatialRelationshipUpdateAPITest(APITestCase, UserTestCase, TestCase):
         assert self.rel.su1 == self.su1
         assert self.rel.su2 == self.su2
 
+    def test_update_valid_record_with_archived_project(self):
+        su, org = self._test_objs()
+        su.project.archived = True
+        su.project.save()
+        su.project.refresh_from_db()
+
+        self._test_patch_public_record(
+            self.get_valid_updated_data, status_code.HTTP_403_FORBIDDEN,
+            org_slug=org.slug, prj_slug=su.project.slug, record=su)
+
     def test_update_invalid_record_with_different_project(self):
         other_su = SpatialUnitFactory.create()
         response = self.request(user=self.user,
@@ -551,3 +571,6 @@ class SpatialRelationshipDeleteAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(method='DELETE', user=user)
         assert response.status_code == 204
         assert SpatialRelationship.objects.count() == 0
+
+    def test_delete_record_from_archived_org(self):
+        assert False

--- a/cadasta/spatial/tests/test_views_default.py
+++ b/cadasta/spatial/tests/test_views_default.py
@@ -190,6 +190,16 @@ class LocationAddTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add "
+                "locations to this project."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -214,6 +224,16 @@ class LocationAddTest(ViewTestCase, UserTestCase, TestCase):
         assert SpatialUnit.objects.count() == 0
         assert response.status_code == 302
         assert '/account/login/' in response.location
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add "
+                "locations to this project."
+                in [str(m) for m in get_messages(self.request)])
 
 
 class LocationDetailTest(ViewTestCase, UserTestCase, TestCase):
@@ -359,6 +379,15 @@ class LocationEditTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to update this location."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -385,6 +414,15 @@ class LocationEditTest(ViewTestCase, UserTestCase, TestCase):
         assert '/account/login/' in response.location
         self.location.refresh_from_db()
         assert self.location.type != self.post_data['type']
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to update this location."
+                in [str(m) for m in get_messages(self.request)])
 
 
 class LocationDelete(ViewTestCase, UserTestCase, TestCase):
@@ -447,6 +485,15 @@ class LocationDelete(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to remove this location."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -470,6 +517,17 @@ class LocationDelete(ViewTestCase, UserTestCase, TestCase):
         response = self.request(method='POST')
         assert response.status_code == 302
         assert '/account/login/' in response.location
+        assert SpatialUnit.objects.count() == 1
+        assert TenureRelationship.objects.count() == 1
+
+    def test_POST_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to remove this location."
+                in [str(m) for m in get_messages(self.request)])
         assert SpatialUnit.objects.count() == 1
         assert TenureRelationship.objects.count() == 1
 
@@ -539,6 +597,16 @@ class LocationResourceAddTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to "
+                "add resources to this location."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -564,6 +632,18 @@ class LocationResourceAddTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(method='POST')
         assert response.status_code == 302
         assert '/account/login/' in response.location
+        assert self.location.resources.count() == 1
+        assert self.location.resources.first() == self.attached
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to "
+                "add resources to this location."
+                in [str(m) for m in get_messages(self.request)])
         assert self.location.resources.count() == 1
         assert self.location.resources.first() == self.attached
 
@@ -639,6 +719,16 @@ class LocationResourceNewTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to "
+                "add resources to this location."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -660,6 +750,17 @@ class LocationResourceNewTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(method='POST')
         assert response.status_code == 302
         assert '/account/login/' in response.location
+        assert self.location.resources.count() == 0
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to "
+                "add resources to this location."
+                in [str(m) for m in get_messages(self.request)])
         assert self.location.resources.count() == 0
 
 
@@ -790,6 +891,16 @@ class TenureRelationshipAddTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add tenure relationships to "
+                "this project."
+                in [str(m) for m in get_messages(self.request)])
+
     def test_post_new_party_with_authorized(self):
         user = UserFactory.create()
         assign_policies(user)
@@ -898,5 +1009,17 @@ class TenureRelationshipAddTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(method='POST')
         assert response.status_code == 302
         assert '/account/login/' in response.location
+        assert TenureRelationship.objects.count() == 0
+        assert Party.objects.count() == 0
+
+    def test_post_with_archived_project(self):
+        self.project.archived = True
+        self.project.save()
+        self.project.refresh_from_db()
+        response = self.request(method='POST', user=self.authorized_user)
+        assert response.status_code == 302
+        assert ("You don't have permission to add tenure relationships to "
+                "this project."
+                in [str(m) for m in get_messages(self.request)])
         assert TenureRelationship.objects.count() == 0
         assert Party.objects.count() == 0

--- a/cadasta/spatial/tests/test_views_default.py
+++ b/cadasta/spatial/tests/test_views_default.py
@@ -193,12 +193,13 @@ class LocationAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add "
-                "locations to this project."
-                in [str(m) for m in get_messages(self.request)])
+                "locations to this project." in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -228,12 +229,13 @@ class LocationAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
+        assert SpatialUnit.objects.count() == 0
         assert response.status_code == 302
         assert ("You don't have permission to add "
-                "locations to this project."
-                in [str(m) for m in get_messages(self.request)])
+                "locations to this project." in response.messages)
 
 
 class LocationDetailTest(ViewTestCase, UserTestCase, TestCase):
@@ -382,11 +384,12 @@ class LocationEditTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to update this location."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -418,14 +421,17 @@ class LocationEditTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to update this location."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
+        self.location.refresh_from_db()
+        assert self.location.type != self.post_data['type']
 
 
-class LocationDelete(ViewTestCase, UserTestCase, TestCase):
+class LocationDeleteTest(ViewTestCase, UserTestCase, TestCase):
     view_class = default.LocationDelete
     template = 'spatial/location_delete.html'
     success_url_name = 'locations:list'
@@ -488,11 +494,12 @@ class LocationDelete(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to remove this location."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -523,11 +530,12 @@ class LocationDelete(ViewTestCase, UserTestCase, TestCase):
     def test_POST_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to remove this location."
-                in [str(m) for m in get_messages(self.request)])
+                in response.messages)
         assert SpatialUnit.objects.count() == 1
         assert TenureRelationship.objects.count() == 1
 
@@ -600,12 +608,12 @@ class LocationResourceAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to "
-                "add resources to this location."
-                in [str(m) for m in get_messages(self.request)])
+                "add resources to this location." in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -638,12 +646,12 @@ class LocationResourceAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to "
-                "add resources to this location."
-                in [str(m) for m in get_messages(self.request)])
+                "add resources to this location." in response.messages)
         assert self.location.resources.count() == 1
         assert self.location.resources.first() == self.attached
 
@@ -722,12 +730,12 @@ class LocationResourceNewTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to "
-                "add resources to this location."
-                in [str(m) for m in get_messages(self.request)])
+                "add resources to this location." in response.messages)
 
     def test_post_with_authorized_user(self):
         user = UserFactory.create()
@@ -755,12 +763,12 @@ class LocationResourceNewTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to "
-                "add resources to this location."
-                in [str(m) for m in get_messages(self.request)])
+                "add resources to this location." in response.messages)
         assert self.location.resources.count() == 0
 
 
@@ -894,12 +902,12 @@ class TenureRelationshipAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_get_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add tenure relationships to "
-                "this project."
-                in [str(m) for m in get_messages(self.request)])
+                "this project." in response.messages)
 
     def test_post_new_party_with_authorized(self):
         user = UserFactory.create()
@@ -1000,8 +1008,7 @@ class TenureRelationshipAddTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add tenure relationships to "
-                "this project."
-                in response.messages)
+                "this project." in response.messages)
         assert TenureRelationship.objects.count() == 0
         assert Party.objects.count() == 0
 
@@ -1015,11 +1022,11 @@ class TenureRelationshipAddTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_with_archived_project(self):
         self.project.archived = True
         self.project.save()
-        self.project.refresh_from_db()
-        response = self.request(method='POST', user=self.authorized_user)
+        user = UserFactory.create()
+        assign_policies(user)
+        response = self.request(method='POST', user=user)
         assert response.status_code == 302
         assert ("You don't have permission to add tenure relationships to "
-                "this project."
-                in [str(m) for m in get_messages(self.request)])
+                "this project." in response.messages)
         assert TenureRelationship.objects.count() == 0
         assert Party.objects.count() == 0

--- a/cadasta/spatial/views/api.py
+++ b/cadasta/spatial/views/api.py
@@ -1,6 +1,7 @@
 from rest_framework import generics, filters, status
 from rest_framework.response import Response
 from tutelary.mixins import APIPermissionRequiredMixin
+from core.mixins import update_permissions
 
 from spatial import serializers
 from . import mixins
@@ -10,6 +11,8 @@ class SpatialUnitList(APIPermissionRequiredMixin,
                       mixins.SpatialQuerySetMixin,
                       generics.ListCreateAPIView):
     def get_actions(self, request):
+        if self.get_project().archived:
+            return ['project.view_archived', 'spatial.list']
         if self.get_project().public():
             return ['project.view', 'spatial.list']
         else:
@@ -23,7 +26,7 @@ class SpatialUnitList(APIPermissionRequiredMixin,
 
     permission_required = {
         'GET': get_actions,
-        'POST': 'spatial.create',
+        'POST': update_permissions('spatial.create'),
     }
 
     def get_perms_objects(self):
@@ -39,8 +42,8 @@ class SpatialUnitDetail(APIPermissionRequiredMixin,
     lookup_field = 'id'
     permission_required = {
         'GET': 'spatial.view',
-        'PATCH': 'spatial.update',
-        'DELETE': 'spatial.delete'
+        'PATCH': update_permissions('spatial.update'),
+        'DELETE': update_permissions('spatial.delete')
     }
 
     def destroy(self, request, *args, **kwargs):
@@ -52,7 +55,7 @@ class SpatialRelationshipCreate(APIPermissionRequiredMixin,
                                 mixins.SpatialRelationshipQuerySetMixin,
                                 generics.CreateAPIView):
 
-    permission_required = 'spatial_rel.create'
+    permission_required = update_permissions('spatial_rel.create')
     serializer_class = serializers.SpatialRelationshipWriteSerializer
 
     def get_perms_objects(self):
@@ -67,8 +70,8 @@ class SpatialRelationshipDetail(APIPermissionRequiredMixin,
     lookup_field = 'id'
     permission_required = {
         'GET': 'spatial_rel.view',
-        'PATCH': 'spatial_rel.update',
-        'DELETE': 'spatial_rel.delete'
+        'PATCH': update_permissions('spatial_rel.update'),
+        'DELETE': update_permissions('spatial_rel.delete')
     }
 
     def get_serializer_class(self):

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -4,7 +4,7 @@ import django.views.generic as base_generic
 from core.views import generic
 from django.core.urlresolvers import reverse
 
-from core.mixins import LoginPermissionRequiredMixin
+from core.mixins import LoginPermissionRequiredMixin, update_permissions
 
 from resources.forms import AddResourceFromLibraryForm
 from resources.views import mixins as resource_mixins
@@ -31,7 +31,7 @@ class LocationsAdd(LoginPermissionRequiredMixin,
                    generic.CreateView):
     form_class = forms.LocationForm
     template_name = 'spatial/location_add.html'
-    permission_required = 'spatial.add'
+    permission_required = update_permissions('spatial.add')
     permission_denied_message = error_messages.SPATIAL_CREATE
 
     def get_perms_objects(self):
@@ -82,7 +82,7 @@ class LocationEdit(LoginPermissionRequiredMixin,
                    generic.UpdateView):
     template_name = 'spatial/location_edit.html'
     form_class = forms.LocationForm
-    permission_required = 'spatial.edit'
+    permission_required = update_permissions('spatial.edit')
     permission_denied_message = error_messages.SPATIAL_UPDATE
 
 
@@ -91,7 +91,7 @@ class LocationDelete(LoginPermissionRequiredMixin,
                      organization_mixins.ProjectAdminCheckMixin,
                      generic.DeleteView):
     template_name = 'spatial/location_delete.html'
-    permission_required = 'spatial.delete'
+    permission_required = update_permissions('spatial.delete')
     permission_denied_message = error_messages.SPATIAL_DELETE
 
     def get_success_url(self):
@@ -107,7 +107,7 @@ class LocationResourceAdd(LoginPermissionRequiredMixin,
                           generic.DetailView):
     template_name = 'spatial/resources_add.html'
     form_class = AddResourceFromLibraryForm
-    permission_required = 'spatial.resources.add'
+    permission_required = update_permissions('spatial.resources.add')
     permission_denied_message = error_messages.SPATIAL_ADD_RESOURCE
 
     def post(self, request, *args, **kwargs):
@@ -124,7 +124,7 @@ class LocationResourceNew(LoginPermissionRequiredMixin,
                           resource_mixins.HasUnattachedResourcesMixin,
                           generic.CreateView):
     template_name = 'spatial/resources_new.html'
-    permission_required = 'spatial.resources.add'
+    permission_required = update_permissions('spatial.resource.add')
     permission_denied_message = error_messages.SPATIAL_ADD_RESOURCE
 
     def get_context_data(self, *args, **kwargs):
@@ -144,7 +144,7 @@ class TenureRelationshipAdd(LoginPermissionRequiredMixin,
                             generic.CreateView):
     template_name = 'spatial/relationship_add.html'
     form_class = forms.TenureRelationshipForm
-    permission_required = 'tenure_rel.create'
+    permission_required = update_permissions('tenure_rel.create')
     permission_denied_message = TENURE_REL_CREATE
 
     def get_perms_objects(self):

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -193,12 +193,14 @@
     </script>
     <script type="text/javascript" src="{% static 'js/dataTables.conditionalPaging.js' %}">
     </script>
+    <script type="text/javascript" src="{% static 'js/dataTables.selectFiltering.js' %}">
+    </script>
     {% block extra_script %}{% endblock %}
     <script>
     $(document).ready(function () {
       $('.datatable').DataTable({
         conditionalPaging: true,
-        "dom": '<"table-search"f>t<"table-entries"i><"table-num"l><"table-pagination"p>',
+        "dom": '<"table-search clearfix"f>t<"table-entries"i><"table-num"l><"table-pagination"p>',
         "language": {
           "info": 'Showing _START_ - _END_ of _TOTAL_',
           "lengthMenu": "Show _MENU_ rows",

--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -20,6 +20,7 @@
             <table class="table table-hover datatable" data-paging-type="simple">
               <thead>
                 <tr>
+                  <th class="unarchived"><div>Archived</div></th>
                   <th class="col-md-6">{% trans "Project" %}</th>
                   <th class="col-md-2">{% trans "Country" %}</th>
                   <th class="col-md-2">{% trans "Last updated" %}</th>
@@ -28,7 +29,16 @@
               <tbody>
                 {% for prj in projects %}
                 <tr class="linked" onclick="window.document.location='{% url 'organization:project-dashboard' organization=organization.slug project=prj.slug %}';">
-                  <td>{{ prj.name }}</td>
+                  {% if prj.archived %}
+                    <td class="archived"><div>True</div></td>
+                  {% else %}
+                    <td class="unarchived"><div>False</div></td>
+                  {% endif %}
+                  <td>{{ prj.name }}{% if prj.archived %}
+                  <span class="label label-danger">
+                    Archived
+                  </span>
+                  {% endif %}</td>
                   <td>{{ prj.country }}</td>
                   <td>{{ prj.last_updated }}</td>
                 </tr>
@@ -108,59 +118,5 @@
   <div>
 </div>
 <!-- /.main -->
-
-{% endblock %}
-
-{% block modals %}
-
-<div class="modal fade" id="archive_confirm" tabindex="-1" role="dialog">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-        <h3 class="modal-title">{% trans "Archive organization" %}</h3>
-      </div>
-      <div class="modal-body">
-        <p>{% trans "Are you sure you want to archive this organization?" %}</p>
-      </div>
-      <div class="modal-footer">
-        <a href="{% url 'organization:archive' organization.slug %}" class="btn btn-danger archive-final pull-right" role="button">
-          {% trans "Yes, archive this organization" %}
-        </a>
-        <button type="button" class="btn btn-link cancel" data-dismiss="modal">
-          {% trans "Cancel" %}
-        </button>
-      </div>
-    </div><!-- /.modal-content -->
-  </div><!-- /.modal-dialog -->
-</div><!-- /.modal -->
-
-<div class="modal fade" id="unarchive_confirm" tabindex="-1" role="dialog">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-        <h3 class="modal-title">{% trans "Unarchive organization" %}</h3>
-      </div>
-      <div class="modal-body">
-        <p>
-          {% trans "Are you sure you want to unarchive this organization?" %}
-        </p>
-      </div>
-      <div class="modal-footer">
-        <a href="{% url 'organization:unarchive' organization.slug %}" class="btn btn-primary unarchive-final pull-right" role="button">
-          {% trans "Yes, unarchive this organization" %}
-        </a>
-        <button type="button" class="btn btn-link cancel" data-dismiss="modal">
-          {% trans "Cancel" %}
-        </button>
-      </div>
-    </div><!-- /.modal-content -->
-  </div><!-- /.modal-dialog -->
-</div><!-- /.modal -->
 
 {% endblock %}

--- a/cadasta/templates/organization/organization_list.html
+++ b/cadasta/templates/organization/organization_list.html
@@ -32,12 +32,18 @@
 <table class="table table-hover datatable" data-paging-type="simple">
   <thead>
     <tr>
+      <th class="unarchived">{% trans Archived %}</th>
       <th class="col-md-10">{% trans "Organization" %}</th>
       <th class="col-md-2 hidden-xs">{% trans "Projects" %}</th>
     </tr>
   </thead>
   {% for org in object_list %}
   <tr class="linked" onclick="window.document.location='{% url 'organization:dashboard' slug=org.slug %}';">
+  {% if org.archived %}
+    <td class="archived"><div>True</div></td>
+  {% else %}
+    <td class="unarchived"><div>False</div></td>
+  {% endif %}
     <td>
       {% if org.logo %}
       <div class="org-logo">
@@ -46,7 +52,11 @@
       </div>
       {% endif %}
       <div class="org-text">
-        <h4>{{ org.name }}</h4>
+        <h4>{{ org.name }}
+        {% if org.archived %}
+          <span class="label label-danger">Archived</span>
+        {% endif %}
+        </h4>
         {% if org.description %}
           <p>{{ org.description }}</p>
         {% endif %}

--- a/cadasta/templates/organization/organization_wrapper.html
+++ b/cadasta/templates/organization/organization_wrapper.html
@@ -16,9 +16,15 @@
     <a class="index-link visible-md-inline visible-lg-inline" href="{% url 'organization:list' %}">
       <span class="glyphicon glyphicon-step-backward" aria-hidden="true"></span>
     </a>
-    <h1>
-      {{ organization.name }}
-    </h1>
+      <h1>
+        {{ organization.name }}
+        {% if organization.archived %}
+        <span class="label label-danger">
+          Archived
+        </span>
+        {% endif %}
+      </h1>
+
     <div class="top-btn pull-right">
 
       <!-- More options menu -->
@@ -29,6 +35,7 @@
         </a>
         <ul class="dropdown-menu" aria-labelledby="dLabel">
           <li><a class="edit" href="{% url 'organization:edit' organization.slug %}">{% trans "Edit organization" %}</a></li>
+          {% if is_administrator %}
           <li role="separator" class="divider"></li>
           <li>
             {% if organization.archived %}
@@ -37,6 +44,7 @@
             <a class="archive" href="#archive_confirm" data-toggle="modal">{% trans "Archive organization" %}</a>
             {% endif %}
           </li>
+          {% endif %}
         </ul>
       </div>
       {% endif %}
@@ -119,3 +127,57 @@
 {% endblock %}
 
 {% block content %}{% endblock %}
+
+{% block modals %}
+
+<div class="modal fade" id="archive_confirm" tabindex="-1" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h3 class="modal-title">{% trans "Archive organization" %}</h3>
+      </div>
+      <div class="modal-body">
+        <p>{% trans "Are you sure you want to archive this organization?" %}</p>
+      </div>
+      <div class="modal-footer">
+        <a href="{% url 'organization:archive' organization.slug %}" class="btn btn-danger archive-final pull-right" role="button">
+          {% trans "Yes, archive this organization" %}
+        </a>
+        <button type="button" class="btn btn-link cancel" data-dismiss="modal">
+          {% trans "Cancel" %}
+        </button>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+
+<div class="modal fade" id="unarchive_confirm" tabindex="-1" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h3 class="modal-title">{% trans "Unarchive organization" %}</h3>
+      </div>
+      <div class="modal-body">
+        <p>
+          {% trans "Are you sure you want to unarchive this organization?" %}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <a href="{% url 'organization:unarchive' organization.slug %}" class="btn btn-primary unarchive-final pull-right" role="button">
+          {% trans "Yes, unarchive this organization" %}
+        </a>
+        <button type="button" class="btn btn-link cancel" data-dismiss="modal">
+          {% trans "Cancel" %}
+        </button>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+
+{% endblock %}

--- a/cadasta/templates/organization/project_list.html
+++ b/cadasta/templates/organization/project_list.html
@@ -33,6 +33,7 @@
 <table class="table table-hover datatable" data-paging-type="simple">
   <thead>
     <tr>
+      <th class="unarchived"><div>{% trans "Archived" %}</div></th>
       <th class="col-md-8">{% trans "Project" %}</th>
       <th class="col-md-1 hidden-xs">{% trans "Organization" %}</th>
       <th class="col-md-1 hidden-xs hidden-sm">{% trans "Country" %}</th>
@@ -41,10 +42,20 @@
   </thead>
   {% for proj in object_list %}
   <tr class="linked" onclick="window.document.location='{% url 'organization:project-dashboard' organization=proj.organization.slug project=proj.slug %}';">
+    {% if proj.archived %}
+      <td class="archived"><div>True</div></td>
+    {% else %}
+      <td class="unarchived"><div>False</div></td>
+    {% endif %}
     <td>
-      <h4>{{ proj.name }}</h4>
+      <h4>{{ proj.name }}
+      {% if proj.archived %}
+          <span class="label label-danger">{% trans "Archived" %}</span>
+        {% endif %}
+        </h4>
+      </h4>
       <p>{{ proj.description }}</p>
-      <p class="visible-xs-block">Organization: {{ proj.organization.name }}</p>
+      <p class="visible-xs-block">{% trans "Organization:" %} {{ proj.organization.name }}</p>
     </td>
     <td class="hidden-xs">
       {% if proj.organization.logo %}

--- a/cadasta/templates/organization/project_wrapper.html
+++ b/cadasta/templates/organization/project_wrapper.html
@@ -19,6 +19,11 @@
         {{ object.organization.name }}
       </a>
       {{ object.name }}
+      {% if object.archived %}
+      <span class="label label-danger">
+        Archived
+      </span>
+      {% endif %}
     </h1>
     <div class="top-btn pull-right">
 
@@ -34,7 +39,7 @@
           <li><a class="edit" href="{% url 'organization:project-edit-permissions' object.organization.slug object.slug %}">{% trans "Edit member permissions" %}</a></li>
           <li role="separator" class="divider"></li>
           <li><a href="{% url 'organization:project-download' object.organization.slug object.slug %}" data-toggle="modal">{% trans "Download data" %}</a></li>
-          {% if is_superuser %}
+          {% if is_administrator %}
           <li role="separator" class="divider"></li>
           <li>
             {% if object.archived %}
@@ -44,6 +49,7 @@
             {% endif %}
           </li>
           {% endif %}
+          
         </ul>
       </div>
       {% endif %}

--- a/functional_tests/base.py
+++ b/functional_tests/base.py
@@ -106,8 +106,9 @@ class FunctionalTest(StaticLiveServerTestCase):
         return self.browser.find_element_by_xpath(
          "//h1[contains(@class, '{}')]".format(f))
 
-    def page_title(self):
-        return self.page_header("//div[contains(@class, 'page-title')]//h1")
+    def page_title(self, xpath=''):
+        return self.page_header("//div[contains(@class, 'page-title')]//h1" +
+                                xpath)
 
     def wait_for(self, function_with_assertion, timeout=DEFAULT_WAIT):
         """Wait for an assertion to become true."""

--- a/functional_tests/fixtures/common_test_data_1.py
+++ b/functional_tests/fixtures/common_test_data_1.py
@@ -16,6 +16,7 @@ def get_test_data():
         })
     test_data['users'] = users
     test_data['superuser'] = users[0]
+    test_data['adminuser'] = users[5]
 
     # Define 2 orgs and their members
     test_data['orgs'] = [
@@ -50,6 +51,7 @@ def get_test_data():
             'description': "Public project of UNESCO.",
             'country': 'DE',
             'access': 'public',
+            'archived': False,
             '_org': 0,
             '_managers': (2, 3),
         },
@@ -59,6 +61,7 @@ def get_test_data():
             'description': '',
             'country': 'AT',
             'access': 'private',
+            'archived': False,
             '_org': 0,
             '_managers': (4,),
         },
@@ -68,6 +71,7 @@ def get_test_data():
             'description': "Private project of UNICEF.",
             'country': '',
             'access': 'private',
+            'archived': False,
             '_org': 1,
             '_managers': (6, 7),
         },
@@ -77,6 +81,17 @@ def get_test_data():
             'description': "",
             'country': '',
             'access': 'public',
+            'archived': False,
+            '_org': 1,
+            '_managers': (8,),
+        },
+        {
+            'name': "Archived Project",
+            'slug': 'archived-project',
+            'description': "",
+            'country': '',
+            'access': 'public',
+            'archived': True,
             '_org': 1,
             '_managers': (8,),
         },

--- a/functional_tests/fixtures/common_test_data_2.py
+++ b/functional_tests/fixtures/common_test_data_2.py
@@ -8,7 +8,8 @@ def get_test_data():
          '_is_superuser': True},
         {'username': 'testuser', 'password': 'password',
          'email': 'testuser@example.com', 'full_name': 'Test User'},
-        {}
+        {'username': 'testadmin', 'password': 'password',
+         'email': 'testadmin@example.com', 'full_name': 'Test Admin'}
     ]
     test_data['users'] = users
     test_data['superuser'] = users[0]
@@ -18,7 +19,9 @@ def get_test_data():
         {'name': "Organization #0", 'description': "This is a test.",
          '_members': (1, 2)},
         {'name': "Organization #1", 'description': "This is a test.",
-         '_members': (1,), '_admins': (1,)}
+         '_members': (1,), '_admins': (1,)},
+        {'name': "Archived Organization", 'description': "This is archived.",
+         "archived": True, '_members': (1, 2), '_admins': (2,)},
     ]
 
     # Define 1 project.
@@ -31,6 +34,24 @@ def get_test_data():
             project.  This is a test project.  This is a test project.  This
             is a test project.  This is a test project.""",
             '_org': 0,
+            'archived': False,
+            'country': 'KE',
+            'extent': ('SRID=4326;'
+                       'POLYGON ((-5.1031494140625000 8.1299292850467957, '
+                       '-5.0482177734375000 7.6837733211111425, '
+                       '-4.6746826171875000 7.8252894725496338, '
+                       '-4.8641967773437491 8.2278005261522775, '
+                       '-5.1031494140625000 8.1299292850467957))')
+        },
+        {
+            'name': 'Archived Project',
+            'slug': 'archived-project',
+            'description': """This is a test project.  This is a test project.
+            This is a test project.  This is a test project.  This is a test
+            project.  This is a test project.  This is a test project.  This
+            is a test project.  This is a test project.""",
+            '_org': 0,
+            'archived': True,
             'country': 'KE',
             'extent': ('SRID=4326;'
                        'POLYGON ((-5.1031494140625000 8.1299292850467957, '

--- a/functional_tests/fixtures/common_test_data_2.py
+++ b/functional_tests/fixtures/common_test_data_2.py
@@ -44,8 +44,8 @@ def get_test_data():
                        '-5.1031494140625000 8.1299292850467957))')
         },
         {
-            'name': 'Archived Project',
-            'slug': 'archived-project',
+            'name': 'Another Project',
+            'slug': 'another-project',
             'description': """This is a test project.  This is a test project.
             This is a test project.  This is a test project.  This is a test
             project.  This is a test project.  This is a test project.  This

--- a/functional_tests/organizations/test_organization.py
+++ b/functional_tests/organizations/test_organization.py
@@ -83,11 +83,17 @@ class OrganizationTest(FunctionalTest):
         page.try_cancel_and_close_archive()
         page.get_archive_button()
 
-        archive = page.click_on_archive_and_confirm()
+        archive = page.click_on_archive_and_confirm(final_check=True)
         assert archive == "Unarchive organization"
 
-        archive = page.click_on_archive_and_confirm(unarchive=True)
+        archive = page.click_on_archive_and_confirm(unarchive=True,
+                                                    final_check=True)
         assert archive == "Archive organization"
+
+        archive = page.click_on_archive_and_confirm()
+        page.click_on_edit_button(success=False)
+        page.click_on_close_alert_button()
+        page.click_on_add_project_button()
 
     def test_getting_to_the_user_list(self):
         """A registered admin user can view an organization's member list,
@@ -120,7 +126,6 @@ class OrganizationTest(FunctionalTest):
         page.go_to_organization_page()
 
         title = page.click_on_project()
-        print("Organization #0\nTest Project")
         assert title == "Organization #0\nTest Project".upper()
 
     def test_new_organization_view(self):

--- a/functional_tests/organizations/test_organization_list.py
+++ b/functional_tests/organizations/test_organization_list.py
@@ -105,3 +105,36 @@ class OrganizationListTest(FunctionalTest):
 
         organization_table = page.get_new_organization_title_in_table()
         assert "Organization #2" in organization_table
+
+    def test_archived_orgs_appear_for_admin_user(self):
+        """The option to filter active/archived organizations is available to
+        organization administrators."""
+
+        LoginPage(self).login('testadmin', 'password')
+        page = OrganizationListPage(self)
+        page.go_to()
+
+        organization_title = page.get_organization_title_in_table()
+        assert organization_title == 'Organization #0'
+
+        page.click_archive_filter("Archived")
+        organization_title = page.get_organization_title_in_table()
+        assert organization_title == 'Archived Organization Archived'
+
+        first_org = page.sort_table_by("descending", col="organization")
+        assert first_org == 'Archived Organization Archived'
+        first_org = page.sort_table_by("ascending", col="organization")
+
+        page.click_archive_filter("All")
+        organization_title = page.get_organization_title_in_table()
+        assert first_org == 'Archived Organization Archived'
+
+        first_org = page.sort_table_by("descending", col="organization")
+        organization_title = page.get_organization_title_in_table()
+        assert organization_title == 'Organization #1'
+        first_org = page.sort_table_by("ascending", col="organization")
+
+        page.click_archive_filter("Archived")
+        page.click_archive_filter("Active")
+        organization_title = page.get_organization_title_in_table()
+        assert organization_title == 'Organization #0'

--- a/functional_tests/organizations/test_organization_member.py
+++ b/functional_tests/organizations/test_organization_member.py
@@ -161,3 +161,18 @@ class OrganizationMemberTest(FunctionalTest):
 
         roles = page.get_role_options()
         assert roles['selected'].text == "Administrator"
+
+    def test_editing_member_in_archived_organization(self):
+        """A user that can create a new organization and
+        is automatically made an admin."""
+
+        LoginPage(self).login('admin_user', 'password')
+        page = OrganizationMemberPage(self)
+        page.go_to()
+        OrganizationPage(self).go_to_organization_page()
+        OrganizationPage(self).get_archive_button()
+        OrganizationPage(self).click_on_archive_and_confirm()
+        OrganizationMemberListPage(self).go_to_member_list_page()
+
+        testuser_title = page.go_to_testuser_member_page(success=False)
+        assert "MEMBER: Test User" != testuser_title

--- a/functional_tests/organizations/test_organization_member_list.py
+++ b/functional_tests/organizations/test_organization_member_list.py
@@ -81,3 +81,15 @@ class OrganizationMemberListTest(FunctionalTest):
         input_box.send_keys("millenniumfalcon@example.com")
         member = page.click_submit_button()
         assert member == "MEMBER: Han Solo"
+
+    def test_adding_members_to_archived_organization(self):
+        LoginPage(self).login('admin_user', 'password')
+        page = OrganizationMemberListPage(self)
+        page.go_to()
+        OrganizationPage(self).go_to_organization_page()
+        OrganizationPage(self).get_archive_button()
+        OrganizationPage(self).click_on_archive_and_confirm()
+
+        title = page.go_to_member_list_page()
+        assert title == "Members".upper()
+        page.click_on_add_button(success=False)

--- a/functional_tests/pages/Organization.py
+++ b/functional_tests/pages/Organization.py
@@ -62,7 +62,7 @@ class OrganizationPage(Page):
         if success:
             self.test.click_through(edit, self.BY_MODAL_BACKDROP)
         else:
-            self.click_through_close(edit, self.BY_MODAL_BACKDROP)
+            self.click_through(edit, (By.CLASS_NAME, 'alert-warning'))
 
     def get_edit_modal_form(self, xpath):
         return self.test.form_field('edit-org', xpath)
@@ -116,14 +116,29 @@ class OrganizationPage(Page):
         self.click_on_more_button()
         return self.get_archive_container()
 
-    def click_on_archive_and_confirm(self, unarchive=False):
+    def click_on_archive_and_confirm(self, unarchive=False, final_check=False):
         archive = self.get_archive_container()
         self.click_through(archive, self.BY_MODAL_FADE)
 
         final = "unarchive-final" if unarchive else "archive-final"
         final = self.test.link(final)
         self.click_through_close(final, self.BY_MODAL_FADE)
-        return self.get_archive_button().text
+        if final_check:
+            return self.get_archive_button().text
+
+    def click_on_close_alert_button(self):
+        close = self.browser.find_element_by_xpath("//div[contains(@class, 'alert')]//button[contains(@class, 'close')]")
+        self.click_through_close(close, (By.CLASS_NAME, 'alert-warning'))
+
+    def get_add_project_button(self):
+        return self.browser.find_element_by_xpath("//a[contains(@href, '/projects/new/')]")
+
+    def click_on_add_project_button(self, success=False):
+        button = self.get_add_project_button()
+        if success:
+            self.test.click_through(button, self.BY_MODAL_BACKDROP)
+        else:
+            self.click_through(button, (By.CLASS_NAME, 'alert-warning'))
 
     def try_cancel_and_close_archive(self):
         close_buttons = ["cancel", "close"]
@@ -171,3 +186,15 @@ class OrganizationPage(Page):
     def go_back_to_organization_list(self):
         back_button = self.test.link('index-link')
         self.click_through(back_button, (By.CLASS_NAME, 'add-org'))
+
+    def get_archived_project_filter(self):
+        return self.browser.find_element_by_xpath(
+            "//select[contains(@id, 'archive-filter')]" + xpath)
+
+    def get_archive_option(self, option):
+        return self.get_archive_filter(
+            "//option[contains(@value, '{}')]".format(option))
+
+    def click_archive_filter(self, option):
+        option = self.get_archive_option(option)
+        self.test.click_through(option, (By.CLASS_NAME, 'sorting_asc'))

--- a/functional_tests/pages/Organization.py
+++ b/functional_tests/pages/Organization.py
@@ -62,7 +62,7 @@ class OrganizationPage(Page):
         if success:
             self.test.click_through(edit, self.BY_MODAL_BACKDROP)
         else:
-            self.click_through(edit, (By.CLASS_NAME, 'alert-warning'))
+            self.click_through(edit, self.test.BY_ALERT)
 
     def get_edit_modal_form(self, xpath):
         return self.test.form_field('edit-org', xpath)
@@ -128,17 +128,18 @@ class OrganizationPage(Page):
 
     def click_on_close_alert_button(self):
         close = self.browser.find_element_by_xpath("//div[contains(@class, 'alert')]//button[contains(@class, 'close')]")
-        self.click_through_close(close, (By.CLASS_NAME, 'alert-warning'))
+        self.click_through_close(close, self.test.BY_ALERT)
 
     def get_add_project_button(self):
-        return self.browser.find_element_by_xpath("//a[contains(@href, '/projects/new/')]")
+        return self.browser.find_element_by_xpath(
+            "//a[contains(@href, '/projects/new/')]")
 
     def click_on_add_project_button(self, success=False):
         button = self.get_add_project_button()
         if success:
             self.test.click_through(button, self.BY_MODAL_BACKDROP)
         else:
-            self.click_through(button, (By.CLASS_NAME, 'alert-warning'))
+            self.click_through(button, self.test.BY_ALERT)
 
     def try_cancel_and_close_archive(self):
         close_buttons = ["cancel", "close"]

--- a/functional_tests/pages/OrganizationList.py
+++ b/functional_tests/pages/OrganizationList.py
@@ -38,8 +38,7 @@ class OrganizationListPage(Page):
 
     def sort_table_by(self, order, col):
         order = "asc" if order == "ascending" else "desc"
-        col = "[1]" if col == "organization" else "[2]"
-
+        col = "[2]" if col == "organization" else "[3]"
         self.click_through(
             self.get_table_headers(col),
             (By.CLASS_NAME, 'sorting_{}'.format(order))
@@ -49,6 +48,18 @@ class OrganizationListPage(Page):
 
     def get_search_box(self):
         return self.test.search_box("DataTables_Table_0")
+
+    def get_archive_filter(self, xpath):
+        return self.browser.find_element_by_xpath(
+            "//select[contains(@id, 'archive-filter')]" + xpath)
+
+    def get_archive_option(self, option):
+        return self.get_archive_filter(
+            "//option[contains(@value, '{}')]".format(option))
+
+    def click_archive_filter(self, option):
+        option = self.get_archive_option(option)
+        self.click_through(option, (By.CLASS_NAME, 'sorting_asc'))
 
     def click_add_button(self):
         add_button = self.test.link("add-org")

--- a/functional_tests/pages/OrganizationMember.py
+++ b/functional_tests/pages/OrganizationMember.py
@@ -28,13 +28,16 @@ class OrganizationMemberPage(Page):
     def get_member_title(self):
         return self.test.page_content("//h2").text
 
-    def go_to_testuser_member_page(self):
+    def go_to_testuser_member_page(self, success=True):
         testuser_page = self.get_table_row(
             "[contains(@onclick, '/testuser/')]"
         )
-        self.click_through(testuser_page, (By.CLASS_NAME, 'page-title'))
-        testuser_title = self.get_member_title()
-        return testuser_title
+        if success:
+            self.click_through(testuser_page, (By.CLASS_NAME, 'page-title'))
+            testuser_title = self.get_member_title()
+            return testuser_title
+        else:
+            self.click_through(testuser_page, (By.CLASS_NAME, 'alert-warning'))
 
     def go_to_admin_member_page(self):
         testuser_page = self.get_table_row(

--- a/functional_tests/pages/OrganizationMemberList.py
+++ b/functional_tests/pages/OrganizationMemberList.py
@@ -38,9 +38,12 @@ class OrganizationMemberListPage(Page):
         title = self.get_page_content("//h2").text
         return title
 
-    def click_on_add_button(self):
+    def click_on_add_button(self, success=True):
         add_button = self.get_page_content("//a[contains(@href, '/add/')]")
-        self.click_through(add_button, self.BY_MODAL_BACKDROP)
+        if success:
+            self.click_through(add_button, self.BY_MODAL_BACKDROP)
+        else:
+            self.click_through(add_button, (By.CLASS_NAME, 'alert-warning'))
 
     def get_modal(self, xpath):
         return self.browser.find_element_by_xpath(

--- a/functional_tests/pages/Project.py
+++ b/functional_tests/pages/Project.py
@@ -1,8 +1,8 @@
 from .base import Page
+from selenium.webdriver.common.by import By
 
 
 class ProjectPage(Page):
-
     def __init__(self, test, org_slug, project_slug):
         super().__init__(test)
         self.path = '/organizations/{}/projects/{}/'.format(
@@ -21,6 +21,15 @@ class ProjectPage(Page):
     def go_to(self):
         self.browser.get(self.url)
         return self
+
+    def get_page_header(self, xpath):
+        return self.test.page_header(xpath)
+
+    def click_through(self, button, wait, screenshot=None):
+        return self.test.click_through(button, wait, screenshot)
+
+    def click_through_close(self, button, wait):
+        return self.test.click_through_close(button, wait)
 
     def get_org_name(self):
         return self.BY_CSS('.org-name').text
@@ -41,3 +50,179 @@ class ProjectPage(Page):
         assert self.get_org_name() == target_project['_org_name']
         assert self.get_project_name() == target_project['name'].upper()
         assert self.get_project_description() == target_project['description']
+
+    # START OF ARCHIVE TESTS
+    def click_on_close_alert_button(self):
+        close = self.browser.find_element_by_xpath(
+            "//div[contains(@class, 'alert')]" +
+            "//button[contains(@class, 'close')]")
+        self.click_through_close(close, self.test.BY_ALERT)
+
+    def click_on_edit_button(self, success=True):
+        self.click_on_content_more_button()
+        button = self.test.page_content(
+            "//ul[contains(@class, 'dropdown-menu')]" +
+            "//a[contains(@href, '/edit/')]")
+        if success:
+            # Finish writing this
+            assert False
+        else:
+            self.click_through(button, self.test.BY_ALERT)
+            self.click_on_close_alert_button()
+
+    def click_on_delete_button(self, success=True):
+        self.click_on_content_more_button()
+        button = self.test.page_content(
+            "//ul[contains(@class, 'dropdown-menu')]" +
+            "//a[contains(@href, '/delete/')]")
+        if success:
+            # Finish writing this
+            assert False
+        else:
+            self.click_through(button, self.test.BY_ALERT)
+            self.click_on_close_alert_button()
+
+    def click_on_add_button(self, location, success=True):
+        button = self.test.page_content(
+            "//div[contains(@class, '{}')]".format(location) +
+            "//a[contains(@class, 'btn-primary')]")
+        if success:
+            # Finish writing this
+            assert False
+        else:
+            self.click_through(button, self.test.BY_ALERT)
+            self.click_on_close_alert_button()
+
+    def click_on_detatch_resource_button(self, location, success=True):
+        button = self.test.page_content(
+            "//div[contains(@class, '{}')]".format(location) +
+            "//button[contains(@class, 'btn-danger')]")
+        if success:
+            # Finish writing this
+            assert False
+        else:
+            self.click_through(button, self.test.BY_ALERT)
+            self.click_on_close_alert_button()
+
+    # MAIN PROJECT HEADER BUTTONS
+    def click_on_add_location_button(self, success=True):
+        button = self.browser.find_element_by_xpath(
+            "//a[contains(@href, '/locations/new/')]")
+        if success:
+            # Finish writing this
+            assert False
+        else:
+            self.click_through(button, self.test.BY_ALERT)
+            self.click_on_close_alert_button()
+
+    def click_on_add_resource_button_from_dropdown(self, success=True):
+        button = self.get_page_header(
+            "//div//button[contains(@class, 'dropdown-toggle')]")
+        self.click_through(button, (By.CLASS_NAME, "open"))
+        button = self.browser.find_element_by_xpath(
+            "//a[contains(@href, '/resources/add/')]")
+        if success:
+            # Finish writing this
+            assert False
+        else:
+            self.click_through(button, self.test.BY_ALERT)
+            self.click_on_close_alert_button()
+
+    def click_on_header_more_button(self):
+        more = self.get_page_header(
+                "//div[contains(@class, 'btn-more')]")
+        self.click_through(
+            more, (By.CSS_SELECTOR, "div.dropdown.pull-right.btn-more.open"))
+
+    def click_on_edit_boundary_button(self, location, success=True):
+        self.click_on_header_more_button()
+        button = self.get_page_header(
+            "//a[contains(@href, '/edit/{}/')]".format(location))
+        if success:
+            # Finish writing this
+            assert False
+        else:
+            self.click_through(button, self.test.BY_ALERT)
+            self.click_on_close_alert_button()
+
+    # SPATIAL UNIT PAGE
+    def click_on_location(self):
+        button = self.browser.find_element_by_xpath(
+            "//*[contains(@class, 'leaflet-clickable')]")
+        self.click_through(button, (By.CLASS_NAME, 'leaflet-popup'))
+        button = self.browser.find_element_by_xpath(
+            "//div[contains(@class, 'leaflet-popup')]" +
+            "//a[contains(@href, 'records/locations')]")
+        self.click_through(button, (By.CLASS_NAME, 'tab-content'))
+
+    def click_on_content_more_button(self):
+        button = self.test.page_content("//div[contains(@class, ' btn-more')]")
+        self.click_through(
+            button, (By.CSS_SELECTOR, "div.dropdown.pull-right.btn-more.open"))
+
+    # SPATIAL UNIT RESOURCES TAB
+    def click_on_location_resource_tab(self):
+        button = self.test.page_content("//a[@href='#resources']")
+        self.click_through(
+            button, (By.CSS_SELECTOR, "div.tab-pane.active#resources"))
+
+    # SPATIAL UNIT RELATIONSHIPS TAB
+    def click_on_location_relationship_tab(self):
+        button = self.test.page_content("//a[@href='#relationships']")
+        self.click_through(
+            button, (By.CSS_SELECTOR, "div.tab-pane.active#relationships"))
+
+    def click_on_relationship_in_table(self):
+        button = self.test.table_body(
+            "DataTables_Table_0", "//tr[contains(@class, 'linked')]")
+        self.test.click_through_close(button, (By.CLASS_NAME, 'nav-tabs'))
+
+    # PARTY PAGE
+    def click_on_party_in_table(self):
+        button = self.test.table_body(
+            "DataTables_Table_0", "//tr//a")
+        self.test.click_through_close(
+            button, (By.CLASS_NAME, 'leaflet-container'))
+
+    # RESOURCES PAGE
+    def click_on_resources_tab(self):
+        button = self.browser.find_element_by_xpath(
+            "//div[@id='sidebar']//li[@class='resources']")
+        self.click_through(button, (By.CLASS_NAME, 'resources'))
+        assert self.test.page_content(
+            "//div[@class='page-title']").text == 'RESOURCES'
+
+    def get_resource_in_table(self, xpath=''):
+        return self.browser.find_element_by_xpath(
+            "//tr[contains(@class, 'linked-resource')]" + xpath)
+
+    def click_on_resource_in_table(self):
+        button = self.get_resource_in_table()
+        self.click_through(button, (By.CLASS_NAME, 'resources'))
+        assert self.test.page_content(
+            "//div[@class='page-title']").text == 'RESOURCE DETAIL'
+
+    def click_on_edit_resource_button(self, success=True):
+        button = self.browser.find_element_by_xpath(
+            "//ul[contains(@class, 'resource-actions')]" +
+            "//a[contains(@href, 'edit')]")
+        if success:
+            # Finish writing this
+            assert False
+        else:
+            self.click_through(button, self.test.BY_ALERT)
+            self.click_on_close_alert_button()
+
+    def click_on_delete_resource_button_and_confirm(self, success=True):
+        button = self.browser.find_element_by_xpath(
+            "//ul[contains(@class, 'resource-actions')]" +
+            "//a[contains(@href, 'delete')]")
+        self.click_through(button, (By.CSS_SELECTOR, "div.modal.fade.in"))
+        button = self.browser.find_element_by_xpath(
+            "//a[contains(@class, 'archive-final')]")
+        if success:
+            # Finish writing this
+            assert False
+        else:
+            self.click_through(button, self.test.BY_ALERT)
+            self.click_on_close_alert_button()

--- a/functional_tests/pages/ProjectList.py
+++ b/functional_tests/pages/ProjectList.py
@@ -1,4 +1,5 @@
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
 
 from .base import Page
 from django_countries import countries
@@ -44,20 +45,20 @@ class ProjectListPage(Page):
             cells = row.find_elements_by_tag_name('td')
             actual_org_slug = onclick_items[2]
             try:
-                img = cells[1].find_element_by_tag_name('img')
+                img = cells[2].find_element_by_tag_name('img')
                 actual_org_logo = img.get_attribute('src')
                 actual_org_name = img.get_attribute('alt')
             except NoSuchElementException:
                 actual_org_logo = None
-                alt = cells[1].find_elements_by_class_name('org-name-alt')
+                alt = cells[2].find_elements_by_class_name('org-name-alt')
                 actual_org_name = alt[0].text
             actual_project_name = (
-                cells[0].find_element_by_tag_name('h4').text
+                cells[1].find_element_by_tag_name('h4').text
             )
             actual_project_description = (
-                cells[0].find_element_by_tag_name('p').text
+                cells[1].find_element_by_tag_name('p').text
             )
-            actual_country = cells[2].text
+            actual_country = cells[3].text
 
             target_project = None
             for project in projects:
@@ -83,3 +84,35 @@ class ProjectListPage(Page):
             assert actual_country == expected_country
 
             # TODO Check also last updated column
+
+    def get_table_headers(self, xpath):
+        table_head = self.test.table('DataTables_Table_0')
+        return table_head.find_element_by_xpath("//thead//tr//th" + xpath)
+
+    def get_table_data(self, xpath, row):
+        return self.test.table_body(
+            "DataTables_Table_0", "//tr{}//td".format(row) + xpath)
+
+    def get_project_title_in_table(self, row="[1]"):
+        return self.get_table_data("//h4", row).text
+
+    def sort_table_by(self, order):
+        order = "asc" if order == "ascending" else "desc"
+        self.test.click_through(
+            self.get_table_headers("[2]"),
+            (By.CLASS_NAME, 'sorting_{}'.format(order))
+        )
+        project_title = self.get_project_title_in_table()
+        return project_title
+
+    def get_archive_filter(self, xpath):
+        return self.browser.find_element_by_xpath(
+            "//select[contains(@id, 'archive-filter')]" + xpath)
+
+    def get_archive_option(self, option):
+        return self.get_archive_filter(
+            "//option[contains(@value, '{}')]".format(option))
+
+    def click_archive_filter(self, option):
+        option = self.get_archive_option(option)
+        self.test.click_through(option, (By.CLASS_NAME, 'sorting_asc'))

--- a/functional_tests/projects/test_project.py
+++ b/functional_tests/projects/test_project.py
@@ -1,0 +1,123 @@
+from base import FunctionalTest
+from fixtures import load_test_data
+from fixtures.common_test_data_2 import get_test_data
+from django.contrib.gis.geos import GEOSGeometry
+
+from core.tests.factories import PolicyFactory
+from organization.models import OrganizationRole
+from accounts.tests.factories import UserFactory
+from organization.tests.factories import ProjectFactory
+from resources.tests.factories import ResourceFactory
+from spatial.tests.factories import SpatialUnitFactory
+from party.tests.factories import PartyFactory, TenureRelationshipFactory
+from party.models import TenureRelationshipType
+
+from pages.Login import LoginPage
+from pages.Project import ProjectPage
+
+
+class ProjectTest(FunctionalTest):
+    def setUp(self):
+        super().setUp()
+        PolicyFactory.load_policies()
+        test_objs = load_test_data(get_test_data())
+        self.org = test_objs['organizations'][0]
+        self.prj = test_objs['projects'][1]
+        OrganizationRole.objects.create(
+                organization=self.org,
+                user=UserFactory.create(
+                        username='admin_user',
+                        password='password'),
+                admin=True)
+        ResourceFactory.create_batch(
+            2, content_object=self.prj,
+            project=self.prj)
+        su = SpatialUnitFactory(
+            geometry=GEOSGeometry('{"type": "Polygon",'
+                                  '"coordinates": [['
+                                  '[-5.1031494140625000,'
+                                  ' 8.1299292850467957], '
+                                  '[-5.0482177734375000, '
+                                  '7.6837733211111425], '
+                                  '[-4.6746826171875000, '
+                                  '7.8252894725496338], '
+                                  '[-4.8641967773437491, '
+                                  '8.2278005261522775], '
+                                  '[-5.1031494140625000, '
+                                  '8.1299292850467957]]]}'),
+            project=self.prj,
+            type='MI',
+            attributes={})
+        ResourceFactory.create(
+            content_object=su,
+            project=self.prj)
+        party = PartyFactory.create(project=test_objs['projects'][1])
+        tenure = TenureRelationshipFactory.create(
+            project=self.prj,
+            party=party,
+            spatial_unit=su,
+            tenure_type=TenureRelationshipType.objects.create(
+                id='CR',
+                label='Customary Rights'))
+        ResourceFactory.create(
+            content_object=su,
+            project=self.prj)
+        ResourceFactory.create(
+            content_object=party,
+            project=self.prj)
+        ResourceFactory.create(
+            content_object=tenure,
+            project=self.prj)
+
+    def test_project_archived_view(self):
+        LoginPage(self).login('admin_user', 'password')
+        page = ProjectPage(self, self.org.slug, self.prj.slug)
+        page.go_to()
+        self.get_screenshot('project page')
+        assert 'ARCHIVED' in page.get_project_name()
+
+        # Test main dashboard page
+        page.click_on_add_location_button(success=False)
+        page.click_on_add_resource_button_from_dropdown(success=False)
+        page.click_on_edit_boundary_button('geometry', success=False)
+        page.click_on_edit_boundary_button('details', success=False)
+        page.click_on_edit_boundary_button('permissions', success=False)
+
+        # Test spatial unit
+        page.click_on_location()
+        page.click_on_edit_button(success=False)
+        page.click_on_delete_button(success=False)
+
+        # Test spatial unit resource tab
+        page.click_on_location_resource_tab()
+        page.click_on_add_button('active', success=False)
+        page.click_on_location_resource_tab()
+        page.click_on_detatch_resource_button('detail', success=False)
+
+        # Test spatial unit relationship tab
+        page.click_on_location_relationship_tab()
+        page.click_on_add_button('active', success=False)
+        page.click_on_location_relationship_tab()
+
+        # Test spatial unit relationship tab
+        page.click_on_relationship_in_table()
+        page.click_on_edit_button(success=False)
+        page.click_on_delete_button(success=False)
+        page.click_on_add_button('detail', success=False)
+        page.click_on_detatch_resource_button('detail', success=False)
+
+        # Test party page
+        page.click_on_party_in_table()
+        page.click_on_edit_button(success=False)
+        page.click_on_delete_button(success=False)
+        page.click_on_add_button('panel-body', success=False)
+        page.click_on_detatch_resource_button('panel-body', success=False)
+
+        # Test project resource page
+        page.click_on_resources_tab()
+        page.click_on_add_button('panel-body', success=False)
+        page.click_on_detatch_resource_button('panel-body', success=False)
+
+        page.click_on_resource_in_table()
+        page.click_on_edit_resource_button(success=False)
+        page.click_on_delete_resource_button_and_confirm(success=False)

--- a/functional_tests/projects/test_project_access.py
+++ b/functional_tests/projects/test_project_access.py
@@ -44,10 +44,10 @@ class ProjectAccessTest(FunctionalTest):
             project_page = ProjectPage(self, org['slug'], project['slug'])
             project_page.go_to()
 
-            if is_visible:
+            if is_visible and project['archived'] is False:
                 assert project_page.is_on_page()
                 project_page.check_page_contents(project_copy)
-            else:
+            elif project['archived'] is False:
                 assert DashboardPage(self).is_on_page()
                 self.assert_has_message('alert', "have permission")
 


### PR DESCRIPTION
### Proposed changes in this pull request
- Archiving an organization or project freezes all actions besides view and unarchive.
- Only people able to view archived orgs and projects are org_admins and superusers.
- Archived orgs and projects are hidden from list views.
    - If the user is a superuser or org admin they have a select dropdown to filter active/archived projects.
- upgrade to django-tutelary 0.1.17
- Fixes #550 

### When should this PR be merged
Depends. There are still a _lot_ of functional tests missing since the `projects` section was never updated to reflect the implementation of `records`, and I'm going to continue writing those up. I doubt I'll be able to finish writing those today, so I wanted to open this up for other people to look at it in the meantime.

There are also a lot of new unit tests, but they don't change the original structure of the tests except in a couple of instances (sorry @oliverroick ).

### Risks
There shouldn't be any risks, since all of the actions caused are reversible by unarchiving the object.

### Follow up actions
- Finish writing functional tests
- After merge, run `./manage.py loadstatic --update-policies`