### PR TITLE
API cleanup

### DIFF
--- a/cadasta/config/urls/default.py
+++ b/cadasta/config/urls/default.py
@@ -33,7 +33,7 @@ api_v1 = [
         include('organization.urls.api.users',
                 namespace='user')),
     url(r'^organizations/(?P<organization>[-\w]+)/projects/'
-        '(?P<project_id>[-\w]+)/',
+        '(?P<project>[-\w]+)/',
         include('questionnaires.urls.api',
                 namespace='questionnaires')),
     url(r'^organizations/(?P<organization>[-\w]+)/projects/'

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -101,6 +101,19 @@ class ProjectSerializer(DetailSerializer, serializers.ModelSerializer):
         )
 
 
+class NestedProjectSerializer(DetailSerializer, FieldSelectorSerializer,
+                              serializers.ModelSerializer):
+    organization = OrganizationSerializer(
+        read_only=True, fields=('id', 'name', 'slug')
+    )
+
+    class Meta:
+        model = Project
+        fields = ('id', 'organization', 'name', 'slug')
+        read_only_fields = ('id', 'slug')
+        detail_only_fields = ('organization',)
+
+
 class ProjectGeometrySerializer(geo_serializers.GeoFeatureModelSerializer):
     org = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()

--- a/cadasta/organization/tests/test_urls_api.py
+++ b/cadasta/organization/tests/test_urls_api.py
@@ -15,29 +15,30 @@ class OrganizationUrlTest(TestCase):
 
     def test_organization_detail(self):
         assert (reverse(version_ns('organization:detail'),
-                        kwargs={'slug': 'org-slug'}) ==
+                        kwargs={'organization': 'org-slug'}) ==
                 version_url('/organizations/org-slug/'))
 
         resolved = resolve(version_url('/organizations/org-slug/'))
         assert resolved.func.__name__ == api.OrganizationDetail.__name__
-        assert resolved.kwargs['slug'] == 'org-slug'
+        assert resolved.kwargs['organization'] == 'org-slug'
 
     def test_organization_users(self):
         assert (reverse(version_ns('organization:users'),
-                        kwargs={'slug': 'org-slug'}) ==
+                        kwargs={'organization': 'org-slug'}) ==
                 version_url('/organizations/org-slug/users/'))
 
         resolved = resolve(version_url('/organizations/org-slug/users/'))
         assert resolved.func.__name__ == api.OrganizationUsers.__name__
-        assert resolved.kwargs['slug'] == 'org-slug'
+        assert resolved.kwargs['organization'] == 'org-slug'
 
     def test_organization_users_detail(self):
         assert (reverse(version_ns('organization:users_detail'),
-                        kwargs={'slug': 'org-slug', 'username': 'n_smith'}) ==
+                        kwargs={'organization': 'org-slug',
+                                'username': 'n_smith'}) ==
                 version_url('/organizations/org-slug/users/n_smith/'))
 
         assert (reverse(version_ns('organization:users_detail'),
-                        kwargs={'slug': 'org-slug',
+                        kwargs={'organization': 'org-slug',
                                 'username': 'n_smith-@+.'}) ==
                 version_url('/organizations/org-slug/users/n_smith-@+./'))
 
@@ -45,14 +46,14 @@ class OrganizationUrlTest(TestCase):
             version_url('/organizations/org-slug/users/n_smith/'))
 
         assert resolved.func.__name__ == api.OrganizationUsersDetail.__name__
-        assert resolved.kwargs['slug'] == 'org-slug'
+        assert resolved.kwargs['organization'] == 'org-slug'
         assert resolved.kwargs['username'] == 'n_smith'
 
         resolved = resolve(
             version_url('/organizations/org-slug/users/n_smith-@+./'))
 
         assert resolved.func.__name__ == api.OrganizationUsersDetail.__name__
-        assert resolved.kwargs['slug'] == 'org-slug'
+        assert resolved.kwargs['organization'] == 'org-slug'
         assert resolved.kwargs['username'] == 'n_smith-@+.'
 
 
@@ -72,7 +73,7 @@ class ProjectUrlTest(TestCase):
     def test_organization_project_list(self):
         actual = reverse(
             version_ns('organization:project_list'),
-            kwargs={'slug': 'habitat'}
+            kwargs={'organization': 'habitat'}
         )
 
         expected = version_url('/organizations/habitat/projects/')
@@ -81,7 +82,7 @@ class ProjectUrlTest(TestCase):
 
         resolved = resolve(version_url('/organizations/habitat/projects/'))
         assert resolved.func.__name__ == api.OrganizationProjectList.__name__
-        assert resolved.kwargs['slug'] == 'habitat'
+        assert resolved.kwargs['organization'] == 'habitat'
 
     def test_project_users(self):
         actual = reverse(

--- a/cadasta/organization/tests/test_views_api_organizations.py
+++ b/cadasta/organization/tests/test_views_api_organizations.py
@@ -219,7 +219,7 @@ class OrganizationDetailAPITest(UserTestCase):
         url = '/v1/organizations/{slug}/'
         request = APIRequestFactory().get(url.format(slug=slug))
         force_authenticate(request, user=user)
-        response = self.view(request, slug=slug).render()
+        response = self.view(request, organization=slug).render()
         content = json.loads(response.content.decode('utf-8'))
         if status is not None:
             assert response.status_code == status
@@ -231,7 +231,7 @@ class OrganizationDetailAPITest(UserTestCase):
         url = '/v1/organizations/{slug}/'
         request = APIRequestFactory().patch(url.format(slug=slug), data)
         force_authenticate(request, user=user)
-        response = self.view(request, slug=slug).render()
+        response = self.view(request, organization=slug).render()
         content = json.loads(response.content.decode('utf-8'))
         if status is not None:
             assert response.status_code == status
@@ -327,7 +327,7 @@ class OrganizationUsersAPITest(UserTestCase):
         url = '/v1/organizations/{slug}/users/'
         request = APIRequestFactory().get(url.format(slug=org.slug))
         force_authenticate(request, user=user)
-        response = self.view(request, slug=org.slug).render()
+        response = self.view(request, organization=org.slug).render()
         content = json.loads(response.content.decode('utf-8'))
         if status is not None:
             assert response.status_code == status
@@ -345,7 +345,7 @@ class OrganizationUsersAPITest(UserTestCase):
         url = '/v1/organizations/{slug}/users/'
         request = APIRequestFactory().post(url.format(slug=slug), data)
         force_authenticate(request, user=user)
-        response = self.view(request, slug=slug).render()
+        response = self.view(request, organization=slug).render()
         content = json.loads(response.content.decode('utf-8'))
         if status is not None:
             assert response.status_code == status
@@ -419,7 +419,7 @@ class OrganizationUsersDetailAPITest(UserTestCase):
         request = APIRequestFactory().get(url.format(org=org.slug,
                                                      username=username))
         force_authenticate(request, user=user)
-        response = self.view(request, slug=org.slug,
+        response = self.view(request, organization=org.slug,
                              username=username).render()
         content = json.loads(response.content.decode('utf-8'))
         if status is not None:
@@ -434,7 +434,7 @@ class OrganizationUsersDetailAPITest(UserTestCase):
             url.format(org=org.slug, username=username),
             data=data, format='json')
         force_authenticate(request, user=user)
-        response = self.view(request, slug=org.slug,
+        response = self.view(request, organization=org.slug,
                              username=username).render()
         content = json.loads(response.content.decode('utf-8'))
         if status is not None:
@@ -455,7 +455,8 @@ class OrganizationUsersDetailAPITest(UserTestCase):
         request = APIRequestFactory().delete(url.format(org=slug,
                                                         username=username))
         force_authenticate(request, user=user)
-        response = self.view(request, slug=slug, username=username).render()
+        response = self.view(request, organization=slug,
+                             username=username).render()
         content = None
         if len(response.content) > 0:
             content = json.loads(response.content.decode('utf-8'))

--- a/cadasta/organization/tests/test_views_api_projects.py
+++ b/cadasta/organization/tests/test_views_api_projects.py
@@ -293,8 +293,8 @@ class OrganizationProjectListAPITest(UserTestCase):
         if query is not None:
             setattr(request, 'GET', QueryDict(query))
         force_authenticate(request, user=user)
-        response = api.OrganizationProjectList.as_view()(request,
-                                                         slug=org).render()
+        response = api.OrganizationProjectList.as_view()(
+            request, organization=org).render()
         content = json.loads(response.content.decode('utf-8'))
         if status is not None:
             assert response.status_code == status
@@ -583,7 +583,7 @@ class ProjectCreateAPITest(UserTestCase):
         request = APIRequestFactory().post(url.format(org=org), data)
         force_authenticate(request, user=user)
         response = api.OrganizationProjectList.as_view()(
-            request, slug=org
+            request, organization=org
         ).render()
         content = json.loads(response.content.decode('utf-8'))
         if status is not None:

--- a/cadasta/organization/urls/api/organizations.py
+++ b/cadasta/organization/urls/api/organizations.py
@@ -8,19 +8,19 @@ urlpatterns = [
         api.OrganizationList.as_view(),
         name='list'),
     url(
-        r'^(?P<slug>[-\w]+)/$',
+        r'^(?P<organization>[-\w]+)/$',
         api.OrganizationDetail.as_view(),
         name='detail'),
     url(
-        r'^(?P<slug>[-\w]+)/users/$',
+        r'^(?P<organization>[-\w]+)/users/$',
         api.OrganizationUsers.as_view(),
         name='users'),
     url(
-        r'^(?P<slug>[-\w]+)/users/(?P<username>[-@+.\w]+)/$',
+        r'^(?P<organization>[-\w]+)/users/(?P<username>[-@+.\w]+)/$',
         api.OrganizationUsersDetail.as_view(),
         name='users_detail'),
     url(
-        r'^(?P<slug>[-\w]+)/projects/$',
+        r'^(?P<organization>[-\w]+)/projects/$',
         api.OrganizationProjectList.as_view(),
         name='project_list'),
     url(

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -11,6 +11,8 @@ from . import mixins
 
 
 class OrganizationList(APIPermissionRequiredMixin, generics.ListCreateAPIView):
+    lookup_url_kwarg = 'organization'
+    lookup_field = 'slug'
     queryset = Organization.objects.all()
     serializer_class = serializers.OrganizationSerializer
     filter_backends = (filters.DjangoFilterBackend,
@@ -38,6 +40,8 @@ class OrganizationDetail(APIPermissionRequiredMixin,
                 return ('org.update', 'org.unarchive')
         return 'org.update'
 
+    lookup_url_kwarg = 'organization'
+    lookup_field = 'slug'
     queryset = Organization.objects.all()
     serializer_class = serializers.OrganizationSerializer
     lookup_field = 'slug'
@@ -50,6 +54,9 @@ class OrganizationDetail(APIPermissionRequiredMixin,
 class OrganizationUsers(APIPermissionRequiredMixin,
                         mixins.OrganizationRoles,
                         generics.ListCreateAPIView):
+
+    lookup_url_kwarg = 'organization'
+    lookup_field = 'slug'
     serializer_class = serializers.OrganizationUserSerializer
     permission_required = {
         'GET': 'org.users.list',
@@ -60,6 +67,7 @@ class OrganizationUsers(APIPermissionRequiredMixin,
 class OrganizationUsersDetail(APIPermissionRequiredMixin,
                               mixins.OrganizationRoles,
                               generics.RetrieveUpdateDestroyAPIView):
+
     serializer_class = serializers.OrganizationUserSerializer
     permission_required = 'org.users.remove'
 
@@ -101,6 +109,7 @@ class OrganizationProjectList(APIPermissionRequiredMixin,
                               mixins.OrganizationMixin,
                               mixins.ProjectQuerySetMixin,
                               generics.ListCreateAPIView):
+    org_lookup = 'organization'
     serializer_class = serializers.ProjectSerializer
     filter_backends = (filters.DjangoFilterBackend,
                        filters.SearchFilter,
@@ -123,7 +132,7 @@ class OrganizationProjectList(APIPermissionRequiredMixin,
 
     def get_queryset(self):
         return super().get_queryset().filter(
-            organization__slug=self.kwargs['slug']
+            organization__slug=self.kwargs['organization']
         )
 
 

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -11,6 +11,9 @@ from ..models import Organization, Project, OrganizationRole, ProjectRole
 
 class OrganizationMixin:
     def get_organization(self, lookup_kwarg='slug'):
+        if lookup_kwarg == 'slug' and hasattr(self, 'org_lookup'):
+            lookup_kwarg = self.org_lookup
+
         if not hasattr(self, 'org'):
             self.org = get_object_or_404(Organization,
                                          slug=self.kwargs[lookup_kwarg])
@@ -22,6 +25,7 @@ class OrganizationMixin:
 
 class OrganizationRoles(OrganizationMixin):
     lookup_field = 'username'
+    org_lookup = 'organization'
 
     def get_queryset(self):
         self.org = self.get_organization()

--- a/cadasta/party/serializers.py
+++ b/cadasta/party/serializers.py
@@ -5,18 +5,24 @@ from rest_framework import serializers
 
 from .models import Party, PartyRelationship, TenureRelationship
 from core.serializers import DetailSerializer, FieldSelectorSerializer
+from organization.serializers import NestedProjectSerializer
 from spatial.serializers import SpatialUnitSerializer
 
 
 class PartySerializer(DetailSerializer, FieldSelectorSerializer,
                       serializers.ModelSerializer):
+    project = NestedProjectSerializer(read_only=True)
 
     class Meta:
         model = Party
-        fields = ('id', 'name', 'type',
-                  'contacts', 'attributes', 'project', 'relationships')
-        read_only_fields = ('id',)
-        detail_only_fields = []
+        fields = ('id', 'name', 'type', 'contacts', 'attributes', 'project',)
+        read_only_fields = ('id', 'project',)
+        detail_only_fields = ('project',)
+
+    def create(self, validated_data):
+        project = self.context['project']
+        return Party.objects.create(
+            project=project, **validated_data)
 
 
 class PartyRelationshipReadSerializer(serializers.ModelSerializer):

--- a/cadasta/party/tests/test_serializers.py
+++ b/cadasta/party/tests/test_serializers.py
@@ -1,24 +1,35 @@
 """Party serializer test cases."""
 
-from rest_framework.test import APIRequestFactory
-
 from core.tests.base_test_case import UserTestCase
-from accounts.tests.factories import UserFactory
 from organization.tests.factories import ProjectFactory
 from party import serializers
 
+from .factories import PartyFactory
+
 
 class PartySerializerTest(UserTestCase):
+    def test_serialize_party(self):
+        party = PartyFactory.create()
+        serializer = serializers.PartySerializer(party)
+        serialized = serializer.data
+
+        assert serialized['id'] == party.id
+        assert serialized['name'] == party.name
+        assert serialized['type'] == party.type
+        assert 'attributes' in serialized
+        assert 'contacts' in serialized
+
+        assert serialized['project']['id'] == party.project.id
+        assert (serialized['project']['organization']['id'] ==
+                party.project.organization.id)
+
     def test_create_party(self,):
-        request = APIRequestFactory().post('/')
-        user = UserFactory.create()
         project = ProjectFactory.create(name='Test Project')
 
-        setattr(request, 'user', user)
-        party_data = {'name': 'Tea Party', 'project': project.id}
+        party_data = {'name': 'Tea Party'}
         serializer = serializers.PartySerializer(
             data=party_data,
-            context={'request', request}
+            context={'project': project}
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/cadasta/party/tests/test_views_api_parties.py
+++ b/cadasta/party/tests/test_views_api_parties.py
@@ -189,7 +189,6 @@ class PartyCreateAPITest(UserTestCase):
         data = {
             'name': 'TestParty',
             'description': 'Some description',
-            'project': self.prj.id
         }
         self._post(self.org.slug,
                    self.prj.slug,

--- a/cadasta/questionnaires/tests/test_urls_api.py
+++ b/cadasta/questionnaires/tests/test_urls_api.py
@@ -8,11 +8,11 @@ from ..views import api
 class QuestionnaireUrlTest(TestCase):
     def test_questionnaire(self):
         assert (reverse(version_ns('questionnaires:detail'),
-                        kwargs={'organization': 'org', 'project_id': 'prj'}) ==
+                        kwargs={'organization': 'org', 'project': 'prj'}) ==
                 version_url('/organizations/org/projects/prj/questionnaire/'))
 
         resolved = resolve(
             version_url('/organizations/org/projects/prj/questionnaire/'))
         assert resolved.func.__name__ == api.QuestionnaireDetail.__name__
         assert resolved.kwargs['organization'] == 'org'
-        assert resolved.kwargs['project_id'] == 'prj'
+        assert resolved.kwargs['project'] == 'prj'

--- a/cadasta/questionnaires/tests/test_views_api.py
+++ b/cadasta/questionnaires/tests/test_views_api.py
@@ -60,7 +60,7 @@ class QuestionnaireDetailTest(UserTestCase):
         response = api.QuestionnaireDetail.as_view()(
             request,
             organization=self.org.slug,
-            project_id=(project or self.prj.id)).render()
+            project=(project or self.prj.slug)).render()
         content = json.loads(response.content.decode('utf-8'))
 
         if status is not None:
@@ -76,7 +76,7 @@ class QuestionnaireDetailTest(UserTestCase):
         response = api.QuestionnaireDetail.as_view()(
             request,
             organization=self.org.slug,
-            project_id=self.prj.id).render()
+            project=self.prj.slug).render()
         content = json.loads(response.content.decode('utf-8'))
 
         if status is not None:

--- a/cadasta/questionnaires/views/api.py
+++ b/cadasta/questionnaires/views/api.py
@@ -33,12 +33,12 @@ class QuestionnaireDetail(APIPermissionRequiredMixin,
     def get_project(self):
         if not hasattr(self, 'project_object'):
             org_slug = self.kwargs['organization']
-            prj_id = self.kwargs['project_id']
+            prj_slug = self.kwargs['project']
 
             self.project_object = get_object_or_404(
                 Project,
                 organization__slug=org_slug,
-                pk=prj_id
+                slug=prj_slug
             )
 
         return self.project_object

--- a/cadasta/spatial/serializers.py
+++ b/cadasta/spatial/serializers.py
@@ -4,36 +4,20 @@ from rest_framework import serializers
 from rest_framework_gis import serializers as geo_serializers
 
 from .models import SpatialUnit, SpatialRelationship
-from organization.models import Project
 from core.serializers import DetailSerializer, FieldSelectorSerializer
-from organization.serializers import OrganizationSerializer
-
-
-class ProjectSpatialUnitSerializer(DetailSerializer, FieldSelectorSerializer,
-                                   serializers.ModelSerializer):
-    organization = OrganizationSerializer(
-        read_only=True, fields=('id', 'name', 'slug')
-    )
-
-    class Meta:
-        model = Project
-        fields = ('id', 'organization', 'name', 'slug')
-        read_only_fields = ('id', 'slug')
-        detail_only_fields = ('organization',)
+from organization.serializers import NestedProjectSerializer
 
 
 class SpatialUnitSerializer(DetailSerializer, FieldSelectorSerializer,
                             geo_serializers.GeoFeatureModelSerializer):
-    project = ProjectSpatialUnitSerializer(read_only=True)
+    project = NestedProjectSerializer(read_only=True)
 
     class Meta:
         model = SpatialUnit
         context_key = 'project'
         geo_field = 'geometry'
         id_field = False
-        fields = ('id',
-                  'geometry', 'type', 'attributes',
-                  'relationships', 'project',)
+        fields = ('id', 'geometry', 'type', 'attributes', 'project',)
         read_only_fields = ('id', 'project',)
         detail_only_fields = ('project',)
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds some tidying to the API; fixes #447. 

- Change questionnaire URL patterns and corresponding view to use project slug instead of project ID to identify project. 
- Make `PartySerializer` consistent with all other entity serializers; the project is now provided via the serializer context
- Change organization URL patters to use `organization` keyword instead of `slug` to be consistent with all other endpoints.
- Introduce `NestedProjectSerializer`, which replaces `ProjectSpatialUnitSerializer` and is also applied to `PartySerializer`
- Remove serialization of `relationships` for `PartySerializer` and `SpatialUnitSerializer`.

### When should this PR be merged

Anytime

### Risks

None.

### Follow up actions

None.