### PR TITLE
Fixes #669, #670 and #671

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,14 @@
+{
+    "extends": "airbnb",
+    "globals": {
+        "describe": true,
+        "it": true,
+        "expect": true,
+        "sinon": true,
+        "assert": true,
+        "beforeEach": true,
+        "afterEach": true
+    }   
+}
+
+﻿

--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -260,6 +260,8 @@ ICON_URL = ('https://s3-us-west-2.amazonaws.com/cadasta-platformprod'
 MIME_LOOKUPS = {
     'application/pdf': 'pdf',
     'audio/mpeg3': 'mp3',
+    'audio/mpeg': 'mp3',
+    'audio/mp3': 'mp3',
     'audio/x-mpeg-3': 'mp3',
     'video/mpeg': 'mp3',
     'video/x-mpeg': 'mp3',
@@ -272,6 +274,7 @@ MIME_LOOKUPS = {
     'application/vnd.openxmlformats-'
     'officedocument.spreadsheetml.sheet': 'xlsx',
     'text/xml': 'xml',
+    'application/xml': 'xml',
     'image/jpeg': 'jpg',
     'image/png': 'png',
     'image/gif': 'gif',

--- a/cadasta/resources/models.py
+++ b/cadasta/resources/models.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.db.models import GeometryCollectionField
+from django.contrib.gis.gdal.error import GDALException
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.dispatch import receiver
@@ -24,6 +25,8 @@ from .utils import io, thumbnail
 from .validators import ACCEPTED_TYPES, validate_file_type
 
 content_types = models.Q(app_label='organization', model='project')
+
+GPX_MIME_TYPES = ('application/xml', 'text/xml', 'application/gpx+xml')
 
 
 @permissioned_model
@@ -145,7 +148,7 @@ def create_thumbnails(sender, instance, created, **kwargs):
 @receiver(models.signals.post_save, sender=Resource)
 def create_spatial_resource(sender, instance, created, **kwargs):
     if created or instance._original_url != instance.file.url:
-        if 'xml' in instance.mime_type:
+        if instance.mime_type in GPX_MIME_TYPES:
             io.ensure_dirs()
             file_name = instance.file.url.split('/')[-1]
             write_path = os.path.join(settings.MEDIA_ROOT,
@@ -157,9 +160,14 @@ def create_spatial_resource(sender, instance, created, **kwargs):
             # of gpx mime type is not reliable
             mime = magic.Magic(mime=True)
             mime_type = str(mime.from_file(write_path), 'utf-8')
-            if mime_type in ('application/xml', 'text/xml'):
-                processor = GPXProcessor(write_path)
-                layers = processor.get_layers()
+            if mime_type in GPX_MIME_TYPES:
+                try:
+                    processor = GPXProcessor(write_path)
+                    layers = processor.get_layers()
+                except GDALException:
+                    raise InvalidGPXFile(
+                        _('Invalid GPX file')
+                    )
                 for layer in layers.keys():
                     if len(layers[layer]) > 0:
                         SpatialResource.objects.create(

--- a/cadasta/resources/tests/files/invalidgpx.xml
+++ b/cadasta/resources/tests/files/invalidgpx.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0'?>
+    <test_standard_questionnaire
+        id="test_standard_questionnaire" version="20160727122110">
+        <start>2016-07-07T16:38:20.310-04</start>
+        <end>2016-07-07T16:39:23.673-04</end>
+        <today>2016-07-07</today>
+        <deviceid>00:bb:3a:44:d0:fb</deviceid>
+        <title />
+        <party_type>IN</party_type>
+        <party_name>Bilbo Baggins</party_name>
+        <location_geometry>40.6890612 -73.9925067 0.0 0.0;</location_geometry>
+        <location_type>MI</location_type>
+        <location_photo>test_image_one.png</location_photo>
+        <party_photo>test_image_two.png</party_photo>
+        <tenure_type>LH</tenure_type>
+        <location_attributes>
+            <name>Middle Earth</name>
+        </location_attributes>
+        <party_attributes_default>
+            <notes>Party attribute default notes.</notes>
+        </party_attributes_default>
+        <party_attributes_individual>
+            <gender>f</gender>
+            <homeowner>no</homeowner>
+            <dob>2016-07-07</dob>
+        </party_attributes_individual>
+        <party_relationship_attributes>
+            <notes>Party relationship notes.</notes>
+        </party_relationship_attributes>
+        <tenure_relationship_attributes>
+            <notes>Tenure relationship notes.</notes>
+        </tenure_relationship_attributes>
+        <meta>
+            <instanceID>uuid:b3f225d3-0fac-4a0b-80c7-60e6db4cc0ad</instanceID>
+        </meta>
+    </test_standard_questionnaire>


### PR DESCRIPTION
### Proposed changes in this pull request

#### Fixes: #669, #670, #671 

- Add _audio/mp3_ and _audio/mpeg_ to _MIME_LOOKUPS_ in default settings
- Tighten up mime-type checking for GPX uploads
- Add exception handling for _GDALExceptions_
- Updated tests
- Add _.eslintrc_ which was removed in previous commit

### When should this PR be merged

Immediately

### Risks

None

### Follow up actions

None required

