### PR TITLE
[v2] Insert link to email into "contact us" phrases

### DIFF
--- a/cadasta/templates/allauth/account/password_reset_done.html
+++ b/cadasta/templates/allauth/account/password_reset_done.html
@@ -12,5 +12,5 @@
     {% include "account/snippets/already_logged_in.html" %}
     {% endif %}
     
-    <p>{% blocktrans %}We have sent you an e-mail. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+    <p>{% blocktrans %}We have sent you an e-mail. Please <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
 {% endblock %}

--- a/cadasta/templates/allauth/account/verification_sent.html
+++ b/cadasta/templates/allauth/account/verification_sent.html
@@ -7,6 +7,6 @@
 {% block content %}
     <h1>{% trans "Verify Your E-mail Address" %}</h1>
 
-    <p>{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+    <p>{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. Please <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
 
 {% endblock %}

--- a/cadasta/templates/allauth/account/verified_email_required.html
+++ b/cadasta/templates/allauth/account/verified_email_required.html
@@ -15,7 +15,7 @@ verify ownership of your e-mail address. {% endblocktrans %}</p>
 
 <p>{% blocktrans %}We have sent an e-mail to you for
 verification. Please click on the link inside this e-mail. Please
-contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+<a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
 
 <p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your e-mail address</a>.{% endblocktrans %}</p>
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Insert link to email into "contact us" phrases.
See https://github.com/Cadasta/cadasta-platform/issues/631

### When should this PR be merged

Anytime

### Risks

None

### Follow up actions

Proceed with translation in Transifex