### PR TITLE
Fix for show username in member permissions page

### DIFF
--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -67,6 +67,17 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
         """
         return self.full_name
 
+    def get_display_name(self):
+        """
+        Returns the display name.
+        If full name is present then return full name as display name
+        else return username.
+        """
+        if self.full_name != '':
+            return self.full_name
+        else:
+            return self.username
+
 
 @receiver(models.signals.post_save, sender=User)
 def assign_default_policy(sender, instance, **kwargs):

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -90,6 +90,22 @@ class ProfileFormTest(UserTestCase, TestCase):
         user.refresh_from_db()
         assert user.full_name == 'John Lennon'
 
+    def test_display_name(self):
+        user = UserFactory.create(username='imagine71',
+                                  email='john@beatles.uk')
+        assert user.get_display_name() == 'imagine71'
+
+        data = {
+            'username': 'imagine71',
+            'email': 'john@beatles.uk',
+            'full_name': 'John Lennon',
+        }
+        form = ProfileForm(data, instance=user)
+        form.save()
+
+        user.refresh_from_db()
+        assert user.get_display_name() == 'John Lennon'
+
     def test_update_user_with_existing_username(self):
         UserFactory.create(username='existing')
         user = UserFactory.create(username='imagine71',

--- a/cadasta/templates/organization/organization_members.html
+++ b/cadasta/templates/organization/organization_members.html
@@ -34,7 +34,7 @@
             <tbody>
             {% for user in organization.users.all %}
               <tr class="linked" onclick="window.document.location='{% url 'organization:members_edit' slug=organization.slug username=user.username %}';">
-                <td>{{ user.get_full_name }}
+                <td>{{ user.get_display_name }}
                   <div class="hidden-sm hidden-md hidden-lg">
                     {{ user.username }}<br />
                     {{ user.email }}

--- a/cadasta/templates/organization/organization_members_edit.html
+++ b/cadasta/templates/organization/organization_members_edit.html
@@ -13,7 +13,7 @@
   <div class="row">
     <!-- Main text  -->
     <div class="col-md-12 main-text">
-      <h2>{% trans "Member" %}: <span class="text-capitalize">{{ object.get_full_name }}</span></h2>
+      <h2>{% trans "Member" %}: <span class="text-capitalize">{{ object.get_display_name }}</span></h2>
       <form method="POST" action="" class="org-member-edit" novalidate>
       {% csrf_token %}
         <div class="row">


### PR DESCRIPTION
### Proposed changes in this pull request

 - Fixes #626.
 - If a user's full name is empty, display the username instead in the organization members list and organization members edit views.

### When should this PR be merged
No Precondtions

### Risks
No Potential Risks