### PR TITLE
Tiff default icon used for preview image

### DIFF
--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -278,5 +278,6 @@ MIME_LOOKUPS = {
     'image/jpeg': 'jpg',
     'image/png': 'png',
     'image/gif': 'gif',
+    'image/tif': 'tiff',
     'image/tiff': 'tiff'
 }

--- a/cadasta/resources/models.py
+++ b/cadasta/resources/models.py
@@ -92,7 +92,7 @@ class Resource(RandomIDModel):
     def thumbnail(self):
         if not hasattr(self, '_thumbnail'):
             icon = settings.MIME_LOOKUPS.get(self.mime_type, None)
-            if 'image' in self.mime_type:
+            if 'image' in self.mime_type and 'tif' not in self.mime_type:
                 ext = self.file_name.split('.')[-1]
                 base_url = self.file.url[:self.file.url.rfind('.')]
                 self._thumbnail = base_url + '-128x128.' + ext

--- a/cadasta/templates/resources/form.html
+++ b/cadasta/templates/resources/form.html
@@ -9,7 +9,7 @@
       <label class="pull-right control-label">{{ form.file.errors }}</label>
       <div class="well file-well">
         {{ form.file }}
-        <p class="help-block">Accepted file types: pdf, mp3, mp4, doc, docx, jpg, png, xml (gpx)</p>
+        <p class="help-block">Accepted file types: pdf, mp3, mp4, doc, docx, jpg, gif, png, tiff, xls, xlsx, xml (gpx)</p>
       </div>
     </div>
     <hr class="divider">


### PR DESCRIPTION
### Proposed changes in this pull request

- Added tif to accepted mime types
- Forced default icon for tiff files since preview is inconsistent for this file type
- Updated acceptable file type note to reflect recent changes

### When should this PR be merged

- As soon as possible - for Sprint 8

### Risks

- None foreseen

### Follow up actions

- None

---------------------------------------------------------------------------------
Completes #668 

Added to mime type and forced default preview icon

Updated acceptable file types text

For resource file uploads