### PR TITLE
Filter "Project extent" from location types

### DIFF
--- a/cadasta/spatial/forms.py
+++ b/cadasta/spatial/forms.py
@@ -9,7 +9,7 @@ from jsonattrs.forms import form_field_from_name, AttributeModelForm
 from leaflet.forms.widgets import LeafletWidget
 from core.util import ID_FIELD_LENGTH
 from party.models import Party, TenureRelationship, TenureRelationshipType
-from .models import SpatialUnit
+from .models import SpatialUnit, TYPE_CHOICES
 from .widgets import SelectPartyWidget, NewEntityWidget
 
 
@@ -20,6 +20,9 @@ class LocationForm(AttributeModelForm):
             'required': _('No map location was provided. Please use the tools '
                           'provided on the left side of the map to mark your '
                           'new location.')}
+    )
+    type = forms.ChoiceField(
+        choices=filter(lambda c: c[0] != 'PX', TYPE_CHOICES)
     )
     attributes_field = 'attributes'
 

--- a/cadasta/spatial/tests/test_forms.py
+++ b/cadasta/spatial/tests/test_forms.py
@@ -32,6 +32,7 @@ class LocationFormTest(UserTestCase, TestCase):
         form.is_valid()
         form.save()
 
+        assert all([c[0] != 'PX' for c in form.fields['type'].choices])
         assert SpatialUnit.objects.filter(project=project).count() == 1
 
     def test_create_location_with_attributes(self):


### PR DESCRIPTION
### Proposed changes in this pull request

 - Fix #598
 - Filter "Project extent" spatial unit type from the location type dropdown in the location form.

### When should this PR be merged

Any time.

### Risks

None.

### Follow up actions

None.