### PR TITLE
Fix #478 -- Display correct labels for choice fields

### DIFF
--- a/cadasta/party/forms.py
+++ b/cadasta/party/forms.py
@@ -1,8 +1,9 @@
 from jsonattrs.forms import AttributeModelForm
 from .models import Party, TenureRelationshipType, TenureRelationship
+from questionnaires.forms import OptionLabelsFix
 
 
-class PartyForm(AttributeModelForm):
+class PartyForm(OptionLabelsFix, AttributeModelForm):
     attributes_field = 'attributes'
 
     class Meta:
@@ -10,8 +11,8 @@ class PartyForm(AttributeModelForm):
         fields = ['name', 'type']
 
     def __init__(self, project_id=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self.project_id = project_id
+        super().__init__(*args, **kwargs)
 
     def save(self):
         instance = super().save(commit=False)
@@ -20,7 +21,7 @@ class PartyForm(AttributeModelForm):
         return instance
 
 
-class TenureRelationshipEditForm(AttributeModelForm):
+class TenureRelationshipEditForm(OptionLabelsFix, AttributeModelForm):
     attributes_field = 'attributes'
 
     class Meta:
@@ -28,6 +29,7 @@ class TenureRelationshipEditForm(AttributeModelForm):
         fields = ['tenure_type']
 
     def __init__(self, *args, **kwargs):
+        self.project_id = kwargs.pop('project_id', None)
         super().__init__(*args, **kwargs)
         tenuretypes = sorted(
             TenureRelationshipType.objects.values_list('id', 'label')

--- a/cadasta/party/tests/test_forms.py
+++ b/cadasta/party/tests/test_forms.py
@@ -65,7 +65,9 @@ class PartyFormTest(UserTestCase, TestCase):
 
 class TenureRelationshipEditFormTest(UserTestCase, TestCase):
     def test_init(self):
-        form = forms.TenureRelationshipEditForm(schema_selectors=())
+        project = ProjectFactory.create()
+        form = forms.TenureRelationshipEditForm(schema_selectors=(),
+                                                project_id=project.id)
         tenuretypes = sorted(
             TenureRelationshipType.objects.values_list('id', 'label')
         )

--- a/cadasta/party/tests/test_views_default.py
+++ b/cadasta/party/tests/test_views_default.py
@@ -111,7 +111,8 @@ class PartiesAddTest(ViewTestCase, UserTestCase, TestCase):
     def setup_template_context(self):
         return {
             'object': self.project,
-            'form': forms.PartyForm(schema_selectors=())
+            'form': forms.PartyForm(schema_selectors=(),
+                                    project_id=self.project.id)
         }
 
     def setup_url_kwargs(self):
@@ -296,7 +297,8 @@ class PartiesEditTest(ViewTestCase, UserTestCase, TestCase):
     def setup_template_context(self):
         return {'object': self.project,
                 'party': self.party,
-                'form': forms.PartyForm(instance=self.party)}
+                'form': forms.PartyForm(instance=self.party,
+                                        project_id=self.project.id)}
 
     def setup_url_kwargs(self):
         return {
@@ -849,7 +851,8 @@ class PartyRelationshipEditTest(ViewTestCase, UserTestCase, TestCase):
         )
 
     def setup_template_context(self):
-        form = forms.TenureRelationshipEditForm(instance=self.relationship)
+        form = forms.TenureRelationshipEditForm(instance=self.relationship,
+                                                project_id=self.project.id)
         return {'object': self.project,
                 'relationship': self.relationship,
                 'location': self.relationship.spatial_unit,

--- a/cadasta/party/views/default.py
+++ b/cadasta/party/views/default.py
@@ -1,7 +1,7 @@
 from core.views import generic
 import django.views.generic as base_generic
 from django.core.urlresolvers import reverse
-from jsonattrs.mixins import JsonAttrsMixin
+from questionnaires.views.mixins import JsonAttrsMixin
 from core.mixins import LoginPermissionRequiredMixin, update_permissions
 
 from organization.views import mixins as organization_mixins
@@ -127,6 +127,12 @@ class PartyRelationshipEdit(LoginPermissionRequiredMixin,
 
     def get_success_url(self):
         return reverse('parties:relationship_detail', kwargs=self.kwargs)
+
+    def get_form_kwargs(self, *args, **kwargs):
+        form_kwargs = super().get_form_kwargs(*args, **kwargs)
+        project = self.get_project()
+        form_kwargs['project_id'] = project.id
+        return form_kwargs
 
 
 class PartyRelationshipDelete(LoginPermissionRequiredMixin,

--- a/cadasta/questionnaires/forms.py
+++ b/cadasta/questionnaires/forms.py
@@ -1,0 +1,16 @@
+from organization.models import Project
+from questionnaires.models import QuestionOption
+
+
+class OptionLabelsFix:
+    def add_attribute_fields(self, schema_selectors):
+        super().add_attribute_fields(schema_selectors)
+
+        strip_length = len(self.attributes_field) + 2
+        prj = Project.objects.get(id=self.project_id)
+        for f in self.fields:
+            options = QuestionOption.objects.filter(
+                    question__questionnaire_id=prj.current_questionnaire,
+                    question__name=f[strip_length:])
+            if options.exists():
+                self.fields[f].choices = options.values_list('name', 'label')

--- a/cadasta/questionnaires/views/mixins.py
+++ b/cadasta/questionnaires/views/mixins.py
@@ -1,0 +1,20 @@
+from jsonattrs.mixins import JsonAttrsMixin as TJsonAttrsMixin
+from questionnaires.models import QuestionOption
+
+
+class JsonAttrsMixin(TJsonAttrsMixin):
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        project = context['object']
+        vals = []
+        for f in context[self.attributes_field]:
+            options = QuestionOption.objects.filter(
+                question__questionnaire_id=project.current_questionnaire,
+                question__label=f[0])
+
+            if options.exists():
+                vals.append((f[0], options.get(name=f[1]).label))
+            else:
+                vals.append(f)
+        context[self.attributes_field] = vals
+        return context

--- a/cadasta/spatial/tests/test_forms.py
+++ b/cadasta/spatial/tests/test_forms.py
@@ -9,6 +9,7 @@ from core.tests.utils.cases import UserTestCase
 from organization.tests.factories import ProjectFactory
 from party.tests.factories import PartyFactory
 from party.models import TenureRelationship, Party, TENURE_RELATIONSHIP_TYPES
+from questionnaires.tests import factories as q_fact
 from .factories import SpatialUnitFactory
 from ..models import SpatialUnit
 from .. import forms
@@ -43,10 +44,16 @@ class LocationFormTest(UserTestCase, TestCase):
                         '0.1411271095275879,51.55254631651022],[-0.14181375503'
                         '54004,51.55240622205599]]]}',
             'type': 'CB',
-            'attributes::fname': 'test'
+            'attributes::fname': 'test',
+            'attributes::choice': 'IN'
         }
 
-        project = ProjectFactory.create()
+        question = q_fact.QuestionFactory.create(name='choice',
+                                                 label='Choice Label')
+        q_fact.QuestionOptionFactory.create(question=question, name='IN')
+
+        project = ProjectFactory.create(
+            current_questionnaire=question.questionnaire_id)
         content_type = ContentType.objects.get(
             app_label='spatial', model='spatialunit')
         schema = Schema.objects.create(
@@ -58,6 +65,14 @@ class LocationFormTest(UserTestCase, TestCase):
             name='fname', long_name='Test field',
             attr_type=attr_type, index=0,
             required=False, omit=False
+        )
+
+        attr_type = AttributeType.objects.get(name='select_one')
+        Attribute.objects.create(
+            schema=schema,
+            name='choice', long_name='Test field',
+            attr_type=attr_type, index=1,
+            required=False, omit=False, choices=['IN']
         )
 
         form = forms.LocationForm(project_id=project.id,

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -1,5 +1,5 @@
 import json
-from jsonattrs.mixins import JsonAttrsMixin
+from questionnaires.views.mixins import JsonAttrsMixin
 import django.views.generic as base_generic
 from core.views import generic
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #478
- Adds form mixin `questionnaires.forms.OptionLabelsFix` that reads names and labels of choice fields from the database and replaces the original `choices` value of the field. The mixin is applied to all forms that deal with questionnaire attributes. 
- Adds view mixin `questionnaires.forms.JsonAttrsMixin`, which reads the correct value labels for choice fields for display on detail pages. 

### When should this PR be merged

High priority issue, should be merged soon.

### Risks

I’m very hesitant to have this PR merged since it only masks the actual problem instead of fixing it. We may want to consider using clear labels in forms and fix this issue properly when we work on updating questionnaires.

In any case, this must only be a temporary fix. For a proper fix of this issue, we need to change how json_attrs handles choices. Currently, only option names are stored with an `Attribute` instance, what we need is the name and the label, though. 

### Follow up actions

None

