### PR TITLE
Extend worker process timeout from 20s to 60s

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -14,6 +14,6 @@ chmod-socket = 666
 vacuum = true
 
 pidfile = /tmp/cadasta-master.pid
-harakiri = 20
+harakiri = 60
 max-requests = 5000
 daemonize = /var/log/uwsgi/cadasta.log


### PR DESCRIPTION
### Proposed changes in this pull request

Changes uWSGI worker process timeout (harakiri) from 20 seconds to 60 seconds. This mitigates questionnaire upload failure on slower connections.

### When should this PR be merged

Anytime; this is a deployment-only change that is already in place on staging, demo, and prod.

### Risks

None

### Follow up actions

None