### PR TITLE
Removed hyphen from email in text

### DIFF
--- a/cadasta/config/locale/ar/LC_MESSAGES/django.po
+++ b/cadasta/config/locale/ar/LC_MESSAGES/django.po
@@ -1082,11 +1082,11 @@ msgid "Account"
 msgstr "حساب"
 
 #: templates/allauth/account/email.html:8
-msgid "E-mail Addresses"
+msgid "Email Addresses"
 msgstr "عناوين البريد الإلكتروني"
 
 #: templates/allauth/account/email.html:10
-msgid "The following e-mail addresses are associated with your account:"
+msgid "The following email addresses are associated with your account:"
 msgstr "ترتبط عناوين البريد الإلكتروني التالي مع حسابك:"
 
 #: templates/allauth/account/email.html:24
@@ -1120,21 +1120,21 @@ msgstr "تحذير:"
 
 #: templates/allauth/account/email.html:43
 msgid ""
-"You currently do not have any e-mail address set up. You should really add "
-"an e-mail address so you can receive notifications, reset your password, "
+"You currently do not have an email address set up. You should really add "
+"an email address so you can receive notifications, reset your password, "
 "etc."
 msgstr "أنت حاليا لم يكن لديك أي عنوان البريد الإلكتروني اقامة. يجب أن تضيف قيمة حقيقية عنوان البريد الإلكتروني حتى تتمكن من تلقي الإخطارات، إعادة تعيين كلمة المرور الخاصة بك، الخ"
 
 #: templates/allauth/account/email.html:48
-msgid "Add E-mail Address"
+msgid "Add Email Address"
 msgstr "إضافة عنوان البريد الإلكتروني"
 
 #: templates/allauth/account/email.html:53
-msgid "Add E-mail"
+msgid "Add Email"
 msgstr "أضف بريدك الإلكتروني"
 
 #: templates/allauth/account/email.html:62
-msgid "Do you really want to remove the selected e-mail address?"
+msgid "Do you really want to remove the selected email address?"
 msgstr "هل تريد حقا لإزالة عنوان البريد الإلكتروني المحدد؟"
 
 #: templates/allauth/account/email/email_confirmation_message.txt:1
@@ -1142,7 +1142,7 @@ msgstr "هل تريد حقا لإزالة عنوان البريد الإلكتر
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because user %(user_display)s at Cadasta Platform has given yours as an e-mail address to connect their account.\n"
+"You're receiving this email because user %(user_display)s at Cadasta Platform has given yours as an email address to connect their account.\n"
 "\n"
 "To confirm this is correct, go to %(activate_url)s\n"
 msgstr ""
@@ -1152,14 +1152,14 @@ msgid "Thank you from Cadasta."
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_subject.txt:3
-msgid "Please Confirm Your E-mail Address"
+msgid "Please Confirm Your Email Address"
 msgstr "يرجى تأكيد عنوان البريد الإلكتروني الخاص بك"
 
 #: templates/allauth/account/email/password_reset_key_message.txt:1
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because you or someone else has requested a password for your user account at Cadasta Platform.\n"
+"You're receiving this email because you or someone else has requested a password for your user account at Cadasta Platform.\n"
 "It can be safely ignored if you did not request a password reset. Click the link below to reset your password."
 msgstr ""
 
@@ -1173,18 +1173,18 @@ msgid "Thank you for using Cadasta Platform!\n"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_subject.txt:3
-msgid "Password Reset E-mail"
+msgid "Password Reset Email"
 msgstr "إعادة تعيين كلمة المرور البريد الإلكتروني"
 
 #: templates/allauth/account/email_confirm.html:6
 #: templates/allauth/account/email_confirm.html:10
-msgid "Confirm E-mail Address"
+msgid "Confirm Email Address"
 msgstr "أكد عنوانك الإلكتروني"
 
 #: templates/allauth/account/email_confirm.html:16
 #, python-format
 msgid ""
-"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an e-mail "
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
 "address for user %(user_display)s."
 msgstr ""
 
@@ -1195,8 +1195,8 @@ msgstr "أكد"
 #: templates/allauth/account/email_confirm.html:27
 #, python-format
 msgid ""
-"This e-mail confirmation link expired or is invalid. Please <a "
-"href=\"%(email_url)s\">issue a new e-mail confirmation request</a>."
+"This email confirmation link expired or is invalid. Please <a "
+"href=\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr ""
 
 #: templates/allauth/account/login.html:10
@@ -1224,12 +1224,12 @@ msgstr "هل أنت متأكد أنك تريد الخروج؟"
 
 #: templates/allauth/account/messages/cannot_delete_primary_email.txt:2
 #, python-format
-msgid "You cannot remove your primary e-mail address (%(email)s)."
+msgid "You cannot remove your primary email address (%(email)s)."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmation_sent.txt:2
 #, python-format
-msgid "Confirmation e-mail sent to %(email)s."
+msgid "Confirmation email sent to %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmed.txt:2
@@ -1239,7 +1239,7 @@ msgstr ""
 
 #: templates/allauth/account/messages/email_deleted.txt:2
 #, python-format
-msgid "Removed e-mail address %(email)s."
+msgid "Removed email address %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/logged_in.txt:4
@@ -1260,11 +1260,11 @@ msgid "Password successfully set."
 msgstr "ضبط كلمة السر بنجاح."
 
 #: templates/allauth/account/messages/primary_email_set.txt:2
-msgid "Primary e-mail address set."
+msgid "Primary email address set."
 msgstr "الابتدائي عنوان البريد الإلكتروني مجموعة."
 
 #: templates/allauth/account/messages/unverified_primary_email.txt:2
-msgid "Your primary e-mail address must be verified."
+msgid "Your primary email address must be verified."
 msgstr "يجب التحقق من عنوان البريد الإلكتروني الأساسي الخاص بك."
 
 #: templates/allauth/account/password_change.html:6
@@ -1307,7 +1307,7 @@ msgstr "أدخل البريد الإلكتروني"
 
 #: templates/allauth/account/password_reset_done.html:15
 msgid ""
-"We have sent you an e-mail. Please contact us if you do not receive it "
+"We have sent you an email. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr "لقد قمنا بإرسال رسالة عبر البريد الإلكتروني. يرجى الاتصال بنا إذا كنت لا تحصل عليه في غضون بضع دقائق."
 
@@ -1365,12 +1365,12 @@ msgstr ""
 #: templates/allauth/account/verification_sent.html:8
 #: templates/allauth/account/verified_email_required.html:5
 #: templates/allauth/account/verified_email_required.html:8
-msgid "Verify Your E-mail Address"
+msgid "Verify Your Email Address"
 msgstr "أكد بريدك الالكتروني"
 
 #: templates/allauth/account/verification_sent.html:10
 msgid ""
-"We have sent an e-mail to you for verification. Follow the link provided to "
+"We have sent an email to you for verification. Follow the link provided to "
 "finalize the signup process. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr "لقد قمنا بإرسال رسالة عبر البريد الإلكتروني لك للتحقق منها. اتبع الرابط المقدم لإتمام عملية التسجيل. يرجى الاتصال بنا إذا كنت لا تحصل عليه في غضون بضع دقائق."
@@ -1379,13 +1379,13 @@ msgstr "لقد قمنا بإرسال رسالة عبر البريد الإلكت
 msgid ""
 "This part of the site requires us to verify that\n"
 "you are who you claim to be. For this purpose, we require that you\n"
-"verify ownership of your e-mail address. "
+"verify ownership of your email address. "
 msgstr "هذا الجزء من الموقع يتطلب منا للتحقق من أنك أنت الذي يدعي أن يكون. لهذا الغرض، نطلب منك التحقق من ملكية عنوان البريد الإلكتروني الخاص بك."
 
 #: templates/allauth/account/verified_email_required.html:16
 msgid ""
-"We have sent an e-mail to you for\n"
-"verification. Please click on the link inside this e-mail. Please\n"
+"We have sent an email to you for\n"
+"verification. Please click on the link inside this email. Please\n"
 "contact us if you do not receive it within a few minutes."
 msgstr "لقد قمنا بإرسال رسالة عبر البريد الإلكتروني لك للتحقق منها. الرجاء النقر على الرابط داخل هذا البريد الإلكتروني. يرجى الاتصال بنا إذا كنت لا تحصل عليه في غضون بضع دقائق."
 
@@ -1393,7 +1393,7 @@ msgstr "لقد قمنا بإرسال رسالة عبر البريد الإلكت
 #, python-format
 msgid ""
 "<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your "
-"e-mail address</a>."
+"email address</a>."
 msgstr ""
 
 #: templates/allauth/openid/login.html:9

--- a/cadasta/config/locale/de/LC_MESSAGES/django.po
+++ b/cadasta/config/locale/de/LC_MESSAGES/django.po
@@ -1082,11 +1082,11 @@ msgid "Account"
 msgstr ""
 
 #: templates/allauth/account/email.html:8
-msgid "E-mail Addresses"
+msgid "Email Addresses"
 msgstr ""
 
 #: templates/allauth/account/email.html:10
-msgid "The following e-mail addresses are associated with your account:"
+msgid "The following email addresses are associated with your account:"
 msgstr ""
 
 #: templates/allauth/account/email.html:24
@@ -1120,21 +1120,21 @@ msgstr ""
 
 #: templates/allauth/account/email.html:43
 msgid ""
-"You currently do not have any e-mail address set up. You should really add "
-"an e-mail address so you can receive notifications, reset your password, "
+"You currently do not have an email address set up. You should really add "
+"an email address so you can receive notifications, reset your password, "
 "etc."
 msgstr ""
 
 #: templates/allauth/account/email.html:48
-msgid "Add E-mail Address"
+msgid "Add Email Address"
 msgstr ""
 
 #: templates/allauth/account/email.html:53
-msgid "Add E-mail"
+msgid "Add Email"
 msgstr ""
 
 #: templates/allauth/account/email.html:62
-msgid "Do you really want to remove the selected e-mail address?"
+msgid "Do you really want to remove the selected email address?"
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_message.txt:1
@@ -1142,7 +1142,7 @@ msgstr ""
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because user %(user_display)s at Cadasta Platform has given yours as an e-mail address to connect their account.\n"
+"You're receiving this email because user %(user_display)s at Cadasta Platform has given yours as an email address to connect their account.\n"
 "\n"
 "To confirm this is correct, go to %(activate_url)s\n"
 msgstr ""
@@ -1152,14 +1152,14 @@ msgid "Thank you from Cadasta."
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_subject.txt:3
-msgid "Please Confirm Your E-mail Address"
+msgid "Please Confirm Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_message.txt:1
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because you or someone else has requested a password for your user account at Cadasta Platform.\n"
+"You're receiving this email because you or someone else has requested a password for your user account at Cadasta Platform.\n"
 "It can be safely ignored if you did not request a password reset. Click the link below to reset your password."
 msgstr ""
 
@@ -1173,18 +1173,18 @@ msgid "Thank you for using Cadasta Platform!\n"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_subject.txt:3
-msgid "Password Reset E-mail"
+msgid "Password Reset Email"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:6
 #: templates/allauth/account/email_confirm.html:10
-msgid "Confirm E-mail Address"
+msgid "Confirm Email Address"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:16
 #, python-format
 msgid ""
-"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an e-mail "
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
 "address for user %(user_display)s."
 msgstr ""
 
@@ -1195,8 +1195,8 @@ msgstr ""
 #: templates/allauth/account/email_confirm.html:27
 #, python-format
 msgid ""
-"This e-mail confirmation link expired or is invalid. Please <a "
-"href=\"%(email_url)s\">issue a new e-mail confirmation request</a>."
+"This email confirmation link expired or is invalid. Please <a "
+"href=\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr ""
 
 #: templates/allauth/account/login.html:10
@@ -1224,12 +1224,12 @@ msgstr ""
 
 #: templates/allauth/account/messages/cannot_delete_primary_email.txt:2
 #, python-format
-msgid "You cannot remove your primary e-mail address (%(email)s)."
+msgid "You cannot remove your primary email address (%(email)s)."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmation_sent.txt:2
 #, python-format
-msgid "Confirmation e-mail sent to %(email)s."
+msgid "Confirmation email sent to %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmed.txt:2
@@ -1239,7 +1239,7 @@ msgstr ""
 
 #: templates/allauth/account/messages/email_deleted.txt:2
 #, python-format
-msgid "Removed e-mail address %(email)s."
+msgid "Removed email address %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/logged_in.txt:4
@@ -1260,11 +1260,11 @@ msgid "Password successfully set."
 msgstr ""
 
 #: templates/allauth/account/messages/primary_email_set.txt:2
-msgid "Primary e-mail address set."
+msgid "Primary email address set."
 msgstr ""
 
 #: templates/allauth/account/messages/unverified_primary_email.txt:2
-msgid "Your primary e-mail address must be verified."
+msgid "Your primary email address must be verified."
 msgstr ""
 
 #: templates/allauth/account/password_change.html:6
@@ -1307,7 +1307,7 @@ msgstr ""
 
 #: templates/allauth/account/password_reset_done.html:15
 msgid ""
-"We have sent you an e-mail. Please contact us if you do not receive it "
+"We have sent you an email. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
 
@@ -1365,12 +1365,12 @@ msgstr ""
 #: templates/allauth/account/verification_sent.html:8
 #: templates/allauth/account/verified_email_required.html:5
 #: templates/allauth/account/verified_email_required.html:8
-msgid "Verify Your E-mail Address"
+msgid "Verify Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/verification_sent.html:10
 msgid ""
-"We have sent an e-mail to you for verification. Follow the link provided to "
+"We have sent an email to you for verification. Follow the link provided to "
 "finalize the signup process. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
@@ -1379,13 +1379,13 @@ msgstr ""
 msgid ""
 "This part of the site requires us to verify that\n"
 "you are who you claim to be. For this purpose, we require that you\n"
-"verify ownership of your e-mail address. "
+"verify ownership of your email address. "
 msgstr ""
 
 #: templates/allauth/account/verified_email_required.html:16
 msgid ""
-"We have sent an e-mail to you for\n"
-"verification. Please click on the link inside this e-mail. Please\n"
+"We have sent an email to you for\n"
+"verification. Please click on the link inside this email. Please\n"
 "contact us if you do not receive it within a few minutes."
 msgstr ""
 
@@ -1393,7 +1393,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your "
-"e-mail address</a>."
+"email address</a>."
 msgstr ""
 
 #: templates/allauth/openid/login.html:9

--- a/cadasta/config/locale/en/LC_MESSAGES/django.po
+++ b/cadasta/config/locale/en/LC_MESSAGES/django.po
@@ -1077,11 +1077,11 @@ msgid "Account"
 msgstr ""
 
 #: templates/allauth/account/email.html:8
-msgid "E-mail Addresses"
+msgid "Email Addresses"
 msgstr ""
 
 #: templates/allauth/account/email.html:10
-msgid "The following e-mail addresses are associated with your account:"
+msgid "The following email addresses are associated with your account:"
 msgstr ""
 
 #: templates/allauth/account/email.html:24
@@ -1115,20 +1115,20 @@ msgstr ""
 
 #: templates/allauth/account/email.html:43
 msgid ""
-"You currently do not have any e-mail address set up. You should really add "
-"an e-mail address so you can receive notifications, reset your password, etc."
+"You currently do not have an email address set up. You should really add "
+"an email address so you can receive notifications, reset your password, etc."
 msgstr ""
 
 #: templates/allauth/account/email.html:48
-msgid "Add E-mail Address"
+msgid "Add Email Address"
 msgstr ""
 
 #: templates/allauth/account/email.html:53
-msgid "Add E-mail"
+msgid "Add Email"
 msgstr ""
 
 #: templates/allauth/account/email.html:62
-msgid "Do you really want to remove the selected e-mail address?"
+msgid "Do you really want to remove the selected email address?"
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_message.txt:1
@@ -1136,8 +1136,8 @@ msgstr ""
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because user %(user_display)s at Cadasta "
-"Platform has given yours as an e-mail address to connect their account.\n"
+"You're receiving this email because user %(user_display)s at Cadasta "
+"Platform has given yours as an email address to connect their account.\n"
 "\n"
 "To confirm this is correct, go to %(activate_url)s\n"
 msgstr ""
@@ -1147,14 +1147,14 @@ msgid "Thank you from Cadasta."
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_subject.txt:3
-msgid "Please Confirm Your E-mail Address"
+msgid "Please Confirm Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_message.txt:1
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because you or someone else has requested a "
+"You're receiving this email because you or someone else has requested a "
 "password for your user account at Cadasta Platform.\n"
 "It can be safely ignored if you did not request a password reset. Click the "
 "link below to reset your password."
@@ -1170,18 +1170,18 @@ msgid "Thank you for using Cadasta Platform!\n"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_subject.txt:3
-msgid "Password Reset E-mail"
+msgid "Password Reset Email"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:6
 #: templates/allauth/account/email_confirm.html:10
-msgid "Confirm E-mail Address"
+msgid "Confirm Email Address"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:16
 #, python-format
 msgid ""
-"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an e-mail "
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
 "address for user %(user_display)s."
 msgstr ""
 
@@ -1192,8 +1192,8 @@ msgstr ""
 #: templates/allauth/account/email_confirm.html:27
 #, python-format
 msgid ""
-"This e-mail confirmation link expired or is invalid. Please <a href="
-"\"%(email_url)s\">issue a new e-mail confirmation request</a>."
+"This email confirmation link expired or is invalid. Please <a href="
+"\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr ""
 
 #: templates/allauth/account/login.html:10
@@ -1221,12 +1221,12 @@ msgstr ""
 
 #: templates/allauth/account/messages/cannot_delete_primary_email.txt:2
 #, python-format
-msgid "You cannot remove your primary e-mail address (%(email)s)."
+msgid "You cannot remove your primary email address (%(email)s)."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmation_sent.txt:2
 #, python-format
-msgid "Confirmation e-mail sent to %(email)s."
+msgid "Confirmation email sent to %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmed.txt:2
@@ -1236,7 +1236,7 @@ msgstr ""
 
 #: templates/allauth/account/messages/email_deleted.txt:2
 #, python-format
-msgid "Removed e-mail address %(email)s."
+msgid "Removed email address %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/logged_in.txt:4
@@ -1257,11 +1257,11 @@ msgid "Password successfully set."
 msgstr ""
 
 #: templates/allauth/account/messages/primary_email_set.txt:2
-msgid "Primary e-mail address set."
+msgid "Primary email address set."
 msgstr ""
 
 #: templates/allauth/account/messages/unverified_primary_email.txt:2
-msgid "Your primary e-mail address must be verified."
+msgid "Your primary email address must be verified."
 msgstr ""
 
 #: templates/allauth/account/password_change.html:6
@@ -1304,7 +1304,7 @@ msgstr ""
 
 #: templates/allauth/account/password_reset_done.html:15
 msgid ""
-"We have sent you an e-mail. Please contact us if you do not receive it "
+"We have sent you an email. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
 
@@ -1362,12 +1362,12 @@ msgstr ""
 #: templates/allauth/account/verification_sent.html:8
 #: templates/allauth/account/verified_email_required.html:5
 #: templates/allauth/account/verified_email_required.html:8
-msgid "Verify Your E-mail Address"
+msgid "Verify Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/verification_sent.html:10
 msgid ""
-"We have sent an e-mail to you for verification. Follow the link provided to "
+"We have sent an email to you for verification. Follow the link provided to "
 "finalize the signup process. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
@@ -1376,13 +1376,13 @@ msgstr ""
 msgid ""
 "This part of the site requires us to verify that\n"
 "you are who you claim to be. For this purpose, we require that you\n"
-"verify ownership of your e-mail address. "
+"verify ownership of your email address. "
 msgstr ""
 
 #: templates/allauth/account/verified_email_required.html:16
 msgid ""
-"We have sent an e-mail to you for\n"
-"verification. Please click on the link inside this e-mail. Please\n"
+"We have sent an email to you for\n"
+"verification. Please click on the link inside this email. Please\n"
 "contact us if you do not receive it within a few minutes."
 msgstr ""
 

--- a/cadasta/config/locale/es/LC_MESSAGES/django.po
+++ b/cadasta/config/locale/es/LC_MESSAGES/django.po
@@ -1081,11 +1081,11 @@ msgid "Account"
 msgstr ""
 
 #: templates/allauth/account/email.html:8
-msgid "E-mail Addresses"
+msgid "Email Addresses"
 msgstr ""
 
 #: templates/allauth/account/email.html:10
-msgid "The following e-mail addresses are associated with your account:"
+msgid "The following email addresses are associated with your account:"
 msgstr ""
 
 #: templates/allauth/account/email.html:24
@@ -1119,21 +1119,21 @@ msgstr ""
 
 #: templates/allauth/account/email.html:43
 msgid ""
-"You currently do not have any e-mail address set up. You should really add "
-"an e-mail address so you can receive notifications, reset your password, "
+"You currently do not have an email address set up. You should really add "
+"an email address so you can receive notifications, reset your password, "
 "etc."
 msgstr ""
 
 #: templates/allauth/account/email.html:48
-msgid "Add E-mail Address"
+msgid "Add Email Address"
 msgstr ""
 
 #: templates/allauth/account/email.html:53
-msgid "Add E-mail"
+msgid "Add Email"
 msgstr ""
 
 #: templates/allauth/account/email.html:62
-msgid "Do you really want to remove the selected e-mail address?"
+msgid "Do you really want to remove the selected email address?"
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_message.txt:1
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because user %(user_display)s at Cadasta Platform has given yours as an e-mail address to connect their account.\n"
+"You're receiving this email because user %(user_display)s at Cadasta Platform has given yours as an email address to connect their account.\n"
 "\n"
 "To confirm this is correct, go to %(activate_url)s\n"
 msgstr ""
@@ -1151,14 +1151,14 @@ msgid "Thank you from Cadasta."
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_subject.txt:3
-msgid "Please Confirm Your E-mail Address"
+msgid "Please Confirm Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_message.txt:1
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because you or someone else has requested a password for your user account at Cadasta Platform.\n"
+"You're receiving this email because you or someone else has requested a password for your user account at Cadasta Platform.\n"
 "It can be safely ignored if you did not request a password reset. Click the link below to reset your password."
 msgstr ""
 
@@ -1172,18 +1172,18 @@ msgid "Thank you for using Cadasta Platform!\n"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_subject.txt:3
-msgid "Password Reset E-mail"
+msgid "Password Reset Email"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:6
 #: templates/allauth/account/email_confirm.html:10
-msgid "Confirm E-mail Address"
+msgid "Confirm Email Address"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:16
 #, python-format
 msgid ""
-"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an e-mail "
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
 "address for user %(user_display)s."
 msgstr ""
 
@@ -1194,8 +1194,8 @@ msgstr ""
 #: templates/allauth/account/email_confirm.html:27
 #, python-format
 msgid ""
-"This e-mail confirmation link expired or is invalid. Please <a "
-"href=\"%(email_url)s\">issue a new e-mail confirmation request</a>."
+"This email confirmation link expired or is invalid. Please <a "
+"href=\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr ""
 
 #: templates/allauth/account/login.html:10
@@ -1223,12 +1223,12 @@ msgstr ""
 
 #: templates/allauth/account/messages/cannot_delete_primary_email.txt:2
 #, python-format
-msgid "You cannot remove your primary e-mail address (%(email)s)."
+msgid "You cannot remove your primary email address (%(email)s)."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmation_sent.txt:2
 #, python-format
-msgid "Confirmation e-mail sent to %(email)s."
+msgid "Confirmation email sent to %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmed.txt:2
@@ -1238,7 +1238,7 @@ msgstr ""
 
 #: templates/allauth/account/messages/email_deleted.txt:2
 #, python-format
-msgid "Removed e-mail address %(email)s."
+msgid "Removed email address %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/logged_in.txt:4
@@ -1259,11 +1259,11 @@ msgid "Password successfully set."
 msgstr ""
 
 #: templates/allauth/account/messages/primary_email_set.txt:2
-msgid "Primary e-mail address set."
+msgid "Primary email address set."
 msgstr ""
 
 #: templates/allauth/account/messages/unverified_primary_email.txt:2
-msgid "Your primary e-mail address must be verified."
+msgid "Your primary email address must be verified."
 msgstr ""
 
 #: templates/allauth/account/password_change.html:6
@@ -1306,7 +1306,7 @@ msgstr ""
 
 #: templates/allauth/account/password_reset_done.html:15
 msgid ""
-"We have sent you an e-mail. Please contact us if you do not receive it "
+"We have sent you an email. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
 
@@ -1364,12 +1364,12 @@ msgstr ""
 #: templates/allauth/account/verification_sent.html:8
 #: templates/allauth/account/verified_email_required.html:5
 #: templates/allauth/account/verified_email_required.html:8
-msgid "Verify Your E-mail Address"
+msgid "Verify Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/verification_sent.html:10
 msgid ""
-"We have sent an e-mail to you for verification. Follow the link provided to "
+"We have sent an email to you for verification. Follow the link provided to "
 "finalize the signup process. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
@@ -1378,13 +1378,13 @@ msgstr ""
 msgid ""
 "This part of the site requires us to verify that\n"
 "you are who you claim to be. For this purpose, we require that you\n"
-"verify ownership of your e-mail address. "
+"verify ownership of your email address. "
 msgstr ""
 
 #: templates/allauth/account/verified_email_required.html:16
 msgid ""
-"We have sent an e-mail to you for\n"
-"verification. Please click on the link inside this e-mail. Please\n"
+"We have sent an email to you for\n"
+"verification. Please click on the link inside this email. Please\n"
 "contact us if you do not receive it within a few minutes."
 msgstr ""
 
@@ -1392,7 +1392,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your "
-"e-mail address</a>."
+"email address</a>."
 msgstr ""
 
 #: templates/allauth/openid/login.html:9

--- a/cadasta/config/locale/fr/LC_MESSAGES/django.po
+++ b/cadasta/config/locale/fr/LC_MESSAGES/django.po
@@ -1082,11 +1082,11 @@ msgid "Account"
 msgstr "Compte"
 
 #: templates/allauth/account/email.html:8
-msgid "E-mail Addresses"
+msgid "Email Addresses"
 msgstr ""
 
 #: templates/allauth/account/email.html:10
-msgid "The following e-mail addresses are associated with your account:"
+msgid "The following email addresses are associated with your account:"
 msgstr ""
 
 #: templates/allauth/account/email.html:24
@@ -1120,21 +1120,21 @@ msgstr ""
 
 #: templates/allauth/account/email.html:43
 msgid ""
-"You currently do not have any e-mail address set up. You should really add "
-"an e-mail address so you can receive notifications, reset your password, "
+"You currently do not have an email address set up. You should really add "
+"an email address so you can receive notifications, reset your password, "
 "etc."
 msgstr ""
 
 #: templates/allauth/account/email.html:48
-msgid "Add E-mail Address"
+msgid "Add Email Address"
 msgstr ""
 
 #: templates/allauth/account/email.html:53
-msgid "Add E-mail"
+msgid "Add Email"
 msgstr ""
 
 #: templates/allauth/account/email.html:62
-msgid "Do you really want to remove the selected e-mail address?"
+msgid "Do you really want to remove the selected email address?"
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_message.txt:1
@@ -1142,7 +1142,7 @@ msgstr ""
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because user %(user_display)s at Cadasta Platform has given yours as an e-mail address to connect their account.\n"
+"You're receiving this email because user %(user_display)s at Cadasta Platform has given yours as an email address to connect their account.\n"
 "\n"
 "To confirm this is correct, go to %(activate_url)s\n"
 msgstr ""
@@ -1152,14 +1152,14 @@ msgid "Thank you from Cadasta."
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_subject.txt:3
-msgid "Please Confirm Your E-mail Address"
+msgid "Please Confirm Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_message.txt:1
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because you or someone else has requested a password for your user account at Cadasta Platform.\n"
+"You're receiving this email because you or someone else has requested a password for your user account at Cadasta Platform.\n"
 "It can be safely ignored if you did not request a password reset. Click the link below to reset your password."
 msgstr ""
 
@@ -1173,18 +1173,18 @@ msgid "Thank you for using Cadasta Platform!\n"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_subject.txt:3
-msgid "Password Reset E-mail"
+msgid "Password Reset Email"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:6
 #: templates/allauth/account/email_confirm.html:10
-msgid "Confirm E-mail Address"
+msgid "Confirm Email Address"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:16
 #, python-format
 msgid ""
-"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an e-mail "
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
 "address for user %(user_display)s."
 msgstr ""
 
@@ -1195,8 +1195,8 @@ msgstr ""
 #: templates/allauth/account/email_confirm.html:27
 #, python-format
 msgid ""
-"This e-mail confirmation link expired or is invalid. Please <a "
-"href=\"%(email_url)s\">issue a new e-mail confirmation request</a>."
+"This email confirmation link expired or is invalid. Please <a "
+"href=\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr ""
 
 #: templates/allauth/account/login.html:10
@@ -1224,12 +1224,12 @@ msgstr ""
 
 #: templates/allauth/account/messages/cannot_delete_primary_email.txt:2
 #, python-format
-msgid "You cannot remove your primary e-mail address (%(email)s)."
+msgid "You cannot remove your primary email address (%(email)s)."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmation_sent.txt:2
 #, python-format
-msgid "Confirmation e-mail sent to %(email)s."
+msgid "Confirmation email sent to %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmed.txt:2
@@ -1239,7 +1239,7 @@ msgstr ""
 
 #: templates/allauth/account/messages/email_deleted.txt:2
 #, python-format
-msgid "Removed e-mail address %(email)s."
+msgid "Removed email address %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/logged_in.txt:4
@@ -1260,11 +1260,11 @@ msgid "Password successfully set."
 msgstr ""
 
 #: templates/allauth/account/messages/primary_email_set.txt:2
-msgid "Primary e-mail address set."
+msgid "Primary email address set."
 msgstr ""
 
 #: templates/allauth/account/messages/unverified_primary_email.txt:2
-msgid "Your primary e-mail address must be verified."
+msgid "Your primary email address must be verified."
 msgstr ""
 
 #: templates/allauth/account/password_change.html:6
@@ -1307,7 +1307,7 @@ msgstr ""
 
 #: templates/allauth/account/password_reset_done.html:15
 msgid ""
-"We have sent you an e-mail. Please contact us if you do not receive it "
+"We have sent you an email. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
 
@@ -1365,12 +1365,12 @@ msgstr ""
 #: templates/allauth/account/verification_sent.html:8
 #: templates/allauth/account/verified_email_required.html:5
 #: templates/allauth/account/verified_email_required.html:8
-msgid "Verify Your E-mail Address"
+msgid "Verify Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/verification_sent.html:10
 msgid ""
-"We have sent an e-mail to you for verification. Follow the link provided to "
+"We have sent an email to you for verification. Follow the link provided to "
 "finalize the signup process. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
@@ -1379,13 +1379,13 @@ msgstr ""
 msgid ""
 "This part of the site requires us to verify that\n"
 "you are who you claim to be. For this purpose, we require that you\n"
-"verify ownership of your e-mail address. "
+"verify ownership of your email address. "
 msgstr ""
 
 #: templates/allauth/account/verified_email_required.html:16
 msgid ""
-"We have sent an e-mail to you for\n"
-"verification. Please click on the link inside this e-mail. Please\n"
+"We have sent an email to you for\n"
+"verification. Please click on the link inside this email. Please\n"
 "contact us if you do not receive it within a few minutes."
 msgstr ""
 
@@ -1393,7 +1393,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your "
-"e-mail address</a>."
+"email address</a>."
 msgstr ""
 
 #: templates/allauth/openid/login.html:9

--- a/cadasta/config/locale/id/LC_MESSAGES/django.po
+++ b/cadasta/config/locale/id/LC_MESSAGES/django.po
@@ -1081,11 +1081,11 @@ msgid "Account"
 msgstr ""
 
 #: templates/allauth/account/email.html:8
-msgid "E-mail Addresses"
+msgid "Email Addresses"
 msgstr ""
 
 #: templates/allauth/account/email.html:10
-msgid "The following e-mail addresses are associated with your account:"
+msgid "The following email addresses are associated with your account:"
 msgstr ""
 
 #: templates/allauth/account/email.html:24
@@ -1119,21 +1119,21 @@ msgstr ""
 
 #: templates/allauth/account/email.html:43
 msgid ""
-"You currently do not have any e-mail address set up. You should really add "
-"an e-mail address so you can receive notifications, reset your password, "
+"You currently do not have an email address set up. You should really add "
+"an email address so you can receive notifications, reset your password, "
 "etc."
 msgstr ""
 
 #: templates/allauth/account/email.html:48
-msgid "Add E-mail Address"
+msgid "Add Email Address"
 msgstr ""
 
 #: templates/allauth/account/email.html:53
-msgid "Add E-mail"
+msgid "Add Email"
 msgstr ""
 
 #: templates/allauth/account/email.html:62
-msgid "Do you really want to remove the selected e-mail address?"
+msgid "Do you really want to remove the selected email address?"
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_message.txt:1
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because user %(user_display)s at Cadasta Platform has given yours as an e-mail address to connect their account.\n"
+"You're receiving this email because user %(user_display)s at Cadasta Platform has given yours as an email address to connect their account.\n"
 "\n"
 "To confirm this is correct, go to %(activate_url)s\n"
 msgstr ""
@@ -1151,14 +1151,14 @@ msgid "Thank you from Cadasta."
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_subject.txt:3
-msgid "Please Confirm Your E-mail Address"
+msgid "Please Confirm Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_message.txt:1
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because you or someone else has requested a password for your user account at Cadasta Platform.\n"
+"You're receiving this email because you or someone else has requested a password for your user account at Cadasta Platform.\n"
 "It can be safely ignored if you did not request a password reset. Click the link below to reset your password."
 msgstr ""
 
@@ -1172,18 +1172,18 @@ msgid "Thank you for using Cadasta Platform!\n"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_subject.txt:3
-msgid "Password Reset E-mail"
+msgid "Password Reset Email"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:6
 #: templates/allauth/account/email_confirm.html:10
-msgid "Confirm E-mail Address"
+msgid "Confirm Email Address"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:16
 #, python-format
 msgid ""
-"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an e-mail "
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
 "address for user %(user_display)s."
 msgstr ""
 
@@ -1194,8 +1194,8 @@ msgstr ""
 #: templates/allauth/account/email_confirm.html:27
 #, python-format
 msgid ""
-"This e-mail confirmation link expired or is invalid. Please <a "
-"href=\"%(email_url)s\">issue a new e-mail confirmation request</a>."
+"This email confirmation link expired or is invalid. Please <a "
+"href=\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr ""
 
 #: templates/allauth/account/login.html:10
@@ -1223,12 +1223,12 @@ msgstr ""
 
 #: templates/allauth/account/messages/cannot_delete_primary_email.txt:2
 #, python-format
-msgid "You cannot remove your primary e-mail address (%(email)s)."
+msgid "You cannot remove your primary email address (%(email)s)."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmation_sent.txt:2
 #, python-format
-msgid "Confirmation e-mail sent to %(email)s."
+msgid "Confirmation email sent to %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmed.txt:2
@@ -1238,7 +1238,7 @@ msgstr ""
 
 #: templates/allauth/account/messages/email_deleted.txt:2
 #, python-format
-msgid "Removed e-mail address %(email)s."
+msgid "Removed email address %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/logged_in.txt:4
@@ -1259,11 +1259,11 @@ msgid "Password successfully set."
 msgstr ""
 
 #: templates/allauth/account/messages/primary_email_set.txt:2
-msgid "Primary e-mail address set."
+msgid "Primary email address set."
 msgstr ""
 
 #: templates/allauth/account/messages/unverified_primary_email.txt:2
-msgid "Your primary e-mail address must be verified."
+msgid "Your primary email address must be verified."
 msgstr ""
 
 #: templates/allauth/account/password_change.html:6
@@ -1306,7 +1306,7 @@ msgstr ""
 
 #: templates/allauth/account/password_reset_done.html:15
 msgid ""
-"We have sent you an e-mail. Please contact us if you do not receive it "
+"We have sent you an email. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
 
@@ -1364,12 +1364,12 @@ msgstr ""
 #: templates/allauth/account/verification_sent.html:8
 #: templates/allauth/account/verified_email_required.html:5
 #: templates/allauth/account/verified_email_required.html:8
-msgid "Verify Your E-mail Address"
+msgid "Verify Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/verification_sent.html:10
 msgid ""
-"We have sent an e-mail to you for verification. Follow the link provided to "
+"We have sent an email to you for verification. Follow the link provided to "
 "finalize the signup process. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
@@ -1378,13 +1378,13 @@ msgstr ""
 msgid ""
 "This part of the site requires us to verify that\n"
 "you are who you claim to be. For this purpose, we require that you\n"
-"verify ownership of your e-mail address. "
+"verify ownership of your email address. "
 msgstr ""
 
 #: templates/allauth/account/verified_email_required.html:16
 msgid ""
-"We have sent an e-mail to you for\n"
-"verification. Please click on the link inside this e-mail. Please\n"
+"We have sent an email to you for\n"
+"verification. Please click on the link inside this email. Please\n"
 "contact us if you do not receive it within a few minutes."
 msgstr ""
 
@@ -1392,7 +1392,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your "
-"e-mail address</a>."
+"email address</a>."
 msgstr ""
 
 #: templates/allauth/openid/login.html:9

--- a/cadasta/config/locale/pt/LC_MESSAGES/django.po
+++ b/cadasta/config/locale/pt/LC_MESSAGES/django.po
@@ -1083,11 +1083,11 @@ msgid "Account"
 msgstr "Conta"
 
 #: templates/allauth/account/email.html:8
-msgid "E-mail Addresses"
+msgid "Email Addresses"
 msgstr "Endereços de e-mail"
 
 #: templates/allauth/account/email.html:10
-msgid "The following e-mail addresses are associated with your account:"
+msgid "The following email addresses are associated with your account:"
 msgstr "Os seguintes endereços de e-mail são associados à sua conta:"
 
 #: templates/allauth/account/email.html:24
@@ -1121,21 +1121,21 @@ msgstr "Atenção:"
 
 #: templates/allauth/account/email.html:43
 msgid ""
-"You currently do not have any e-mail address set up. You should really add "
-"an e-mail address so you can receive notifications, reset your password, "
+"You currently do not have an email address set up. You should really add "
+"an email address so you can receive notifications, reset your password, "
 "etc."
 msgstr "Actualmente não tem qualquer endereço de e-mail configurado. Devia adicionar um endereço de e-mail para que possa receber notificações, redefinir a sua senha, etc."
 
 #: templates/allauth/account/email.html:48
-msgid "Add E-mail Address"
+msgid "Add Email Address"
 msgstr "Adicionar endereço de e-mail"
 
 #: templates/allauth/account/email.html:53
-msgid "Add E-mail"
+msgid "Add Email"
 msgstr "Adicionar e-mail"
 
 #: templates/allauth/account/email.html:62
-msgid "Do you really want to remove the selected e-mail address?"
+msgid "Do you really want to remove the selected email address?"
 msgstr "Será que deseja remover o endereço de e-mail selecionado?"
 
 #: templates/allauth/account/email/email_confirmation_message.txt:1
@@ -1143,7 +1143,7 @@ msgstr "Será que deseja remover o endereço de e-mail selecionado?"
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because user %(user_display)s at Cadasta Platform has given yours as an e-mail address to connect their account.\n"
+"You're receiving this email because user %(user_display)s at Cadasta Platform has given yours as an email address to connect their account.\n"
 "\n"
 "To confirm this is correct, go to %(activate_url)s\n"
 msgstr "\nEstá a receber este e-mail porque o usuário %(user_display)s na Plataforma de Cadasta deu o seu como um endereço de e-mail para conectar a sua conta.\n\nPara confirmar que está correcto, vá para %(activate_url)s\n\n"
@@ -1153,14 +1153,14 @@ msgid "Thank you from Cadasta."
 msgstr "Obrigado de Cadasta."
 
 #: templates/allauth/account/email/email_confirmation_subject.txt:3
-msgid "Please Confirm Your E-mail Address"
+msgid "Please Confirm Your Email Address"
 msgstr "Por favor confirme o seu endereço de email"
 
 #: templates/allauth/account/email/password_reset_key_message.txt:1
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because you or someone else has requested a password for your user account at Cadasta Platform.\n"
+"You're receiving this email because you or someone else has requested a password for your user account at Cadasta Platform.\n"
 "It can be safely ignored if you did not request a password reset. Click the link below to reset your password."
 msgstr "\nEstá a receber este e-mail porque você, ou outra pessoa, tenha solicitado uma senha para a sua conta no Plataforma de Cadasta.\nPode ser ignorado se não solicitou uma nova senha. Clique no link abaixo para redefinir a sua senha."
 
@@ -1174,18 +1174,18 @@ msgid "Thank you for using Cadasta Platform!\n"
 msgstr "Obrigado por usar o Plataforma de Cadasta!\n\n"
 
 #: templates/allauth/account/email/password_reset_key_subject.txt:3
-msgid "Password Reset E-mail"
+msgid "Password Reset Email"
 msgstr "Endereço de e-mail reiniciar a senha"
 
 #: templates/allauth/account/email_confirm.html:6
 #: templates/allauth/account/email_confirm.html:10
-msgid "Confirm E-mail Address"
+msgid "Confirm Email Address"
 msgstr "Confirmar o endereço de e-mail"
 
 #: templates/allauth/account/email_confirm.html:16
 #, python-format
 msgid ""
-"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an e-mail "
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
 "address for user %(user_display)s."
 msgstr "Por favor, confirme que <a href=\"mailto:%(email)s\"> %(email)s</a> é um endereço de e-mail para o usuário %(user_display)s."
 
@@ -1196,8 +1196,8 @@ msgstr "Confirmar"
 #: templates/allauth/account/email_confirm.html:27
 #, python-format
 msgid ""
-"This e-mail confirmation link expired or is invalid. Please <a "
-"href=\"%(email_url)s\">issue a new e-mail confirmation request</a>."
+"This email confirmation link expired or is invalid. Please <a "
+"href=\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr "Este link de confirmação de e-mail expirou ou é inválido. Por favor <a Href=\"%(email_url)s\">emitir um novo pedido de confirmação de e-mail</a>."
 
 #: templates/allauth/account/login.html:10
@@ -1225,12 +1225,12 @@ msgstr "Tem certeza que deseja sair?"
 
 #: templates/allauth/account/messages/cannot_delete_primary_email.txt:2
 #, python-format
-msgid "You cannot remove your primary e-mail address (%(email)s)."
+msgid "You cannot remove your primary email address (%(email)s)."
 msgstr "Não pode remover o seu endereço de e-mail principal (%(email)s)."
 
 #: templates/allauth/account/messages/email_confirmation_sent.txt:2
 #, python-format
-msgid "Confirmation e-mail sent to %(email)s."
+msgid "Confirmation email sent to %(email)s."
 msgstr "Confirmação de e-mail enviado para %(email)s."
 
 #: templates/allauth/account/messages/email_confirmed.txt:2
@@ -1240,7 +1240,7 @@ msgstr "Confirmou %(email)s."
 
 #: templates/allauth/account/messages/email_deleted.txt:2
 #, python-format
-msgid "Removed e-mail address %(email)s."
+msgid "Removed email address %(email)s."
 msgstr "Removido endereço de e-mail %(email)s."
 
 #: templates/allauth/account/messages/logged_in.txt:4
@@ -1261,11 +1261,11 @@ msgid "Password successfully set."
 msgstr "Senha definida com sucesso."
 
 #: templates/allauth/account/messages/primary_email_set.txt:2
-msgid "Primary e-mail address set."
+msgid "Primary email address set."
 msgstr "Endereço de e-mail primário definido."
 
 #: templates/allauth/account/messages/unverified_primary_email.txt:2
-msgid "Your primary e-mail address must be verified."
+msgid "Your primary email address must be verified."
 msgstr "O seu endereço de e-mail principal deve ser verificado."
 
 #: templates/allauth/account/password_change.html:6
@@ -1308,7 +1308,7 @@ msgstr "Digitar endereço de e-mail"
 
 #: templates/allauth/account/password_reset_done.html:15
 msgid ""
-"We have sent you an e-mail. Please contact us if you do not receive it "
+"We have sent you an email. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr "Enviamos um e-mail. Por favor entrar em contacto connosco se não o receber dentro de alguns minutos."
 
@@ -1366,12 +1366,12 @@ msgstr "Está registado como <strong>%(user_display)s</ strong>."
 #: templates/allauth/account/verification_sent.html:8
 #: templates/allauth/account/verified_email_required.html:5
 #: templates/allauth/account/verified_email_required.html:8
-msgid "Verify Your E-mail Address"
+msgid "Verify Your Email Address"
 msgstr "Verificar o seu endereço de e-mail"
 
 #: templates/allauth/account/verification_sent.html:10
 msgid ""
-"We have sent an e-mail to you for verification. Follow the link provided to "
+"We have sent an email to you for verification. Follow the link provided to "
 "finalize the signup process. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr "Enviamos um e-mail para a sua verificação. Siga o link fornecido para finalizar o processo de registo. Por favor, entre em contacto connosco se não o receber dentro de alguns minutos."
@@ -1380,13 +1380,13 @@ msgstr "Enviamos um e-mail para a sua verificação. Siga o link fornecido para 
 msgid ""
 "This part of the site requires us to verify that\n"
 "you are who you claim to be. For this purpose, we require that you\n"
-"verify ownership of your e-mail address. "
+"verify ownership of your email address. "
 msgstr "Esta parte do site nos obriga a verificar que\nvocê é quem você diz ser. Para este efeito, é necessário que você\n verifica a propriedade do seu endereço de e-mail."
 
 #: templates/allauth/account/verified_email_required.html:16
 msgid ""
-"We have sent an e-mail to you for\n"
-"verification. Please click on the link inside this e-mail. Please\n"
+"We have sent an email to you for\n"
+"verification. Please click on the link inside this email. Please\n"
 "contact us if you do not receive it within a few minutes."
 msgstr "Enviamos um e-mail para a sua\n verificação. Por favor, clique no link dentro deste e-mail. Por favor\n entre em contacto connosco se não o receber dentro de alguns minutos."
 
@@ -1394,7 +1394,7 @@ msgstr "Enviamos um e-mail para a sua\n verificação. Por favor, clique no link
 #, python-format
 msgid ""
 "<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your "
-"e-mail address</a>."
+"email address</a>."
 msgstr "<Strong>Nota: </strong> Ainda pode <a href=\"%(email_url)s\">mudar o seu endereço de e-mail</a>."
 
 #: templates/allauth/openid/login.html:9

--- a/cadasta/config/locale/sw/LC_MESSAGES/django.po
+++ b/cadasta/config/locale/sw/LC_MESSAGES/django.po
@@ -1082,11 +1082,11 @@ msgid "Account"
 msgstr ""
 
 #: templates/allauth/account/email.html:8
-msgid "E-mail Addresses"
+msgid "Email Addresses"
 msgstr ""
 
 #: templates/allauth/account/email.html:10
-msgid "The following e-mail addresses are associated with your account:"
+msgid "The following email addresses are associated with your account:"
 msgstr ""
 
 #: templates/allauth/account/email.html:24
@@ -1120,21 +1120,21 @@ msgstr ""
 
 #: templates/allauth/account/email.html:43
 msgid ""
-"You currently do not have any e-mail address set up. You should really add "
-"an e-mail address so you can receive notifications, reset your password, "
+"You currently do not have an email address set up. You should really add "
+"an email address so you can receive notifications, reset your password, "
 "etc."
 msgstr ""
 
 #: templates/allauth/account/email.html:48
-msgid "Add E-mail Address"
+msgid "Add Email Address"
 msgstr ""
 
 #: templates/allauth/account/email.html:53
-msgid "Add E-mail"
+msgid "Add Email"
 msgstr ""
 
 #: templates/allauth/account/email.html:62
-msgid "Do you really want to remove the selected e-mail address?"
+msgid "Do you really want to remove the selected email address?"
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_message.txt:1
@@ -1142,7 +1142,7 @@ msgstr ""
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because user %(user_display)s at Cadasta Platform has given yours as an e-mail address to connect their account.\n"
+"You're receiving this email because user %(user_display)s at Cadasta Platform has given yours as an email address to connect their account.\n"
 "\n"
 "To confirm this is correct, go to %(activate_url)s\n"
 msgstr ""
@@ -1152,14 +1152,14 @@ msgid "Thank you from Cadasta."
 msgstr ""
 
 #: templates/allauth/account/email/email_confirmation_subject.txt:3
-msgid "Please Confirm Your E-mail Address"
+msgid "Please Confirm Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_message.txt:1
 msgid ""
 "\n"
 "\n"
-"You're receiving this e-mail because you or someone else has requested a password for your user account at Cadasta Platform.\n"
+"You're receiving this email because you or someone else has requested a password for your user account at Cadasta Platform.\n"
 "It can be safely ignored if you did not request a password reset. Click the link below to reset your password."
 msgstr ""
 
@@ -1173,18 +1173,18 @@ msgid "Thank you for using Cadasta Platform!\n"
 msgstr ""
 
 #: templates/allauth/account/email/password_reset_key_subject.txt:3
-msgid "Password Reset E-mail"
+msgid "Password Reset Email"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:6
 #: templates/allauth/account/email_confirm.html:10
-msgid "Confirm E-mail Address"
+msgid "Confirm Email Address"
 msgstr ""
 
 #: templates/allauth/account/email_confirm.html:16
 #, python-format
 msgid ""
-"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an e-mail "
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
 "address for user %(user_display)s."
 msgstr ""
 
@@ -1195,8 +1195,8 @@ msgstr ""
 #: templates/allauth/account/email_confirm.html:27
 #, python-format
 msgid ""
-"This e-mail confirmation link expired or is invalid. Please <a "
-"href=\"%(email_url)s\">issue a new e-mail confirmation request</a>."
+"This email confirmation link expired or is invalid. Please <a "
+"href=\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr ""
 
 #: templates/allauth/account/login.html:10
@@ -1224,12 +1224,12 @@ msgstr ""
 
 #: templates/allauth/account/messages/cannot_delete_primary_email.txt:2
 #, python-format
-msgid "You cannot remove your primary e-mail address (%(email)s)."
+msgid "You cannot remove your primary email address (%(email)s)."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmation_sent.txt:2
 #, python-format
-msgid "Confirmation e-mail sent to %(email)s."
+msgid "Confirmation email sent to %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/email_confirmed.txt:2
@@ -1239,7 +1239,7 @@ msgstr ""
 
 #: templates/allauth/account/messages/email_deleted.txt:2
 #, python-format
-msgid "Removed e-mail address %(email)s."
+msgid "Removed email address %(email)s."
 msgstr ""
 
 #: templates/allauth/account/messages/logged_in.txt:4
@@ -1260,11 +1260,11 @@ msgid "Password successfully set."
 msgstr ""
 
 #: templates/allauth/account/messages/primary_email_set.txt:2
-msgid "Primary e-mail address set."
+msgid "Primary email address set."
 msgstr ""
 
 #: templates/allauth/account/messages/unverified_primary_email.txt:2
-msgid "Your primary e-mail address must be verified."
+msgid "Your primary email address must be verified."
 msgstr ""
 
 #: templates/allauth/account/password_change.html:6
@@ -1307,7 +1307,7 @@ msgstr ""
 
 #: templates/allauth/account/password_reset_done.html:15
 msgid ""
-"We have sent you an e-mail. Please contact us if you do not receive it "
+"We have sent you an email. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
 
@@ -1365,12 +1365,12 @@ msgstr ""
 #: templates/allauth/account/verification_sent.html:8
 #: templates/allauth/account/verified_email_required.html:5
 #: templates/allauth/account/verified_email_required.html:8
-msgid "Verify Your E-mail Address"
+msgid "Verify Your Email Address"
 msgstr ""
 
 #: templates/allauth/account/verification_sent.html:10
 msgid ""
-"We have sent an e-mail to you for verification. Follow the link provided to "
+"We have sent an email to you for verification. Follow the link provided to "
 "finalize the signup process. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
@@ -1379,13 +1379,13 @@ msgstr ""
 msgid ""
 "This part of the site requires us to verify that\n"
 "you are who you claim to be. For this purpose, we require that you\n"
-"verify ownership of your e-mail address. "
+"verify ownership of your email address. "
 msgstr ""
 
 #: templates/allauth/account/verified_email_required.html:16
 msgid ""
-"We have sent an e-mail to you for\n"
-"verification. Please click on the link inside this e-mail. Please\n"
+"We have sent an email to you for\n"
+"verification. Please click on the link inside this email. Please\n"
 "contact us if you do not receive it within a few minutes."
 msgstr ""
 
@@ -1393,7 +1393,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your "
-"e-mail address</a>."
+"email address</a>."
 msgstr ""
 
 #: templates/allauth/openid/login.html:9

--- a/cadasta/templates/allauth/account/email.html
+++ b/cadasta/templates/allauth/account/email.html
@@ -5,9 +5,9 @@
 {% block head_title %}{% trans "Account" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "E-mail Addresses" %}</h1>
+    <h1>{% trans "Email Addresses" %}</h1>
 {% if user.emailaddress_set.all %}
-<p>{% trans 'The following e-mail addresses are associated with your account:' %}</p>
+<p>{% trans 'The following email addresses are associated with your account:' %}</p>
 
 <form action="{% url 'account_email' %}" class="email_list" method="post" novalidate>
 {% csrf_token %}
@@ -40,17 +40,17 @@
 </form>
 
 {% else %}
-<p><strong>{% trans 'Warning:'%}</strong> {% trans "You currently do not have any e-mail address set up. You should really add an e-mail address so you can receive notifications, reset your password, etc." %}</p>
+<p><strong>{% trans 'Warning:'%}</strong> {% trans "You currently do not have an email address set up. You should really add an email address so you can receive notifications, reset your password, etc." %}</p>
 
 {% endif %}
 
 
-    <h2>{% trans "Add E-mail Address" %}</h2>
+    <h2>{% trans "Add Email Address" %}</h2>
 
     <form method="post" action="{% url 'account_email' %}" class="add_email" novalidate>
         {% csrf_token %}
         {{ form.as_p}}
-        <button name="action_add" type="submit">{% trans "Add E-mail" %}</button>
+        <button name="action_add" type="submit">{% trans "Add Email" %}</button>
     </form>
 
 {% endblock %}
@@ -59,7 +59,7 @@
 {% block extra_body %}
 <script type="text/javascript">
 (function() {
-  var message = "{% trans 'Do you really want to remove the selected e-mail address?' %}";
+  var message = "{% trans 'Do you really want to remove the selected email address?' %}";
   var actions = document.getElementsByName('action_remove');
   if (actions.length) {
     actions[0].addEventListener("click", function(e) {

--- a/cadasta/templates/allauth/account/email/email_confirmation_message.txt
+++ b/cadasta/templates/allauth/account/email/email_confirmation_message.txt
@@ -1,6 +1,6 @@
 {% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans %}
 
-You're receiving this e-mail because user {{ user_display }} at Cadasta Platform has given yours as an e-mail address to connect their account.
+You're receiving this email because user {{ user_display }} at Cadasta Platform has given yours as an email address to connect their account.
 
 To confirm this is correct, go to {{ activate_url }}
 {% endblocktrans %}{% endautoescape %}

--- a/cadasta/templates/allauth/account/email/email_confirmation_subject.txt
+++ b/cadasta/templates/allauth/account/email/email_confirmation_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Please Confirm Your E-mail Address{% endblocktrans %}
+{% blocktrans %}Please Confirm Your Email Address{% endblocktrans %}
 {% endautoescape %}

--- a/cadasta/templates/allauth/account/email/password_reset_key_message.txt
+++ b/cadasta/templates/allauth/account/email/password_reset_key_message.txt
@@ -1,6 +1,6 @@
 {% load i18n %}{% blocktrans %}
 
-You're receiving this e-mail because you or someone else has requested a password for your user account at Cadasta Platform.
+You're receiving this email because you or someone else has requested a password for your user account at Cadasta Platform.
 It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
 
 {{ password_reset_url }}

--- a/cadasta/templates/allauth/account/email/password_reset_key_subject.txt
+++ b/cadasta/templates/allauth/account/email/password_reset_key_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Password Reset E-mail{% endblocktrans %}
+{% blocktrans %}Password Reset Email{% endblocktrans %}
 {% endautoescape %}

--- a/cadasta/templates/allauth/account/email_confirm.html
+++ b/cadasta/templates/allauth/account/email_confirm.html
@@ -3,17 +3,17 @@
 {% load i18n %}
 {% load account %}
 
-{% block head_title %}{% trans "Confirm E-mail Address" %}{% endblock %}
+{% block head_title %}{% trans "Confirm Email Address" %}{% endblock %}
 
 
 {% block content %}
-<h1>{% trans "Confirm E-mail Address" %}</h1>
+<h1>{% trans "Confirm Email Address" %}</h1>
 
 {% if confirmation %}
 
 {% user_display confirmation.email_address.user as user_display %}
 
-<p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+<p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an email address for user {{ user_display }}.{% endblocktrans %}</p>
 
 <form method="post" action="{% url 'account_confirm_email' confirmation.key %}" novalidate>
 {% csrf_token %}
@@ -24,7 +24,7 @@
 
 {% url 'account_email' as email_url %}
 
-<p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
+<p>{% blocktrans %}This email confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new email confirmation request</a>.{% endblocktrans %}</p>
 
 {% endif %}
 

--- a/cadasta/templates/allauth/account/messages/cannot_delete_primary_email.txt
+++ b/cadasta/templates/allauth/account/messages/cannot_delete_primary_email.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans %}You cannot remove your primary e-mail address ({{email}}).{% endblocktrans %}
+{% blocktrans %}You cannot remove your primary email address ({{email}}).{% endblocktrans %}

--- a/cadasta/templates/allauth/account/messages/email_confirmation_sent.txt
+++ b/cadasta/templates/allauth/account/messages/email_confirmation_sent.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans %}Confirmation e-mail sent to {{email}}.{% endblocktrans %}
+{% blocktrans %}Confirmation email sent to {{email}}.{% endblocktrans %}

--- a/cadasta/templates/allauth/account/messages/email_deleted.txt
+++ b/cadasta/templates/allauth/account/messages/email_deleted.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans %}Removed e-mail address {{email}}.{% endblocktrans %}
+{% blocktrans %}Removed email address {{email}}.{% endblocktrans %}

--- a/cadasta/templates/allauth/account/messages/primary_email_set.txt
+++ b/cadasta/templates/allauth/account/messages/primary_email_set.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans %}Primary e-mail address set.{% endblocktrans %}
+{% blocktrans %}Primary email address set.{% endblocktrans %}

--- a/cadasta/templates/allauth/account/messages/unverified_primary_email.txt
+++ b/cadasta/templates/allauth/account/messages/unverified_primary_email.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans %}Your primary e-mail address must be verified.{% endblocktrans %}
+{% blocktrans %}Your primary email address must be verified.{% endblocktrans %}

--- a/cadasta/templates/allauth/account/password_reset_done.html
+++ b/cadasta/templates/allauth/account/password_reset_done.html
@@ -12,5 +12,5 @@
     {% include "account/snippets/already_logged_in.html" %}
     {% endif %}
     
-    <p>{% blocktrans %}We have sent you an e-mail. Please <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
+    <p>{% blocktrans %}We have sent you an email. Please <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
 {% endblock %}

--- a/cadasta/templates/allauth/account/verification_sent.html
+++ b/cadasta/templates/allauth/account/verification_sent.html
@@ -2,11 +2,11 @@
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock %}
+{% block head_title %}{% trans "Verify Your Email Address" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Verify Your E-mail Address" %}</h1>
+    <h1>{% trans "Verify Your Email Address" %}</h1>
 
-    <p>{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. Please <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
+    <p>{% blocktrans %}We have sent an email to you for verification. Follow the link provided to finalize the signup process. Please <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
 
 {% endblock %}

--- a/cadasta/templates/allauth/account/verified_email_required.html
+++ b/cadasta/templates/allauth/account/verified_email_required.html
@@ -2,22 +2,22 @@
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock %}
+{% block head_title %}{% trans "Verify Your Email Address" %}{% endblock %}
 
 {% block content %}
-<h1>{% trans "Verify Your E-mail Address" %}</h1>
+<h1>{% trans "Verify Your Email Address" %}</h1>
 
 {% url 'account_email' as email_url %}
 
 <p>{% blocktrans %}This part of the site requires us to verify that
 you are who you claim to be. For this purpose, we require that you
-verify ownership of your e-mail address. {% endblocktrans %}</p>
+verify ownership of your email address. {% endblocktrans %}</p>
 
-<p>{% blocktrans %}We have sent an e-mail to you for
-verification. Please click on the link inside this e-mail. Please
+<p>{% blocktrans %}We have sent an email to you for
+verification. Please click on the link inside this email. Please
 <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
 
-<p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your e-mail address</a>.{% endblocktrans %}</p>
+<p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your email address</a>.{% endblocktrans %}</p>
 
 
 {% endblock %}


### PR DESCRIPTION
### Proposed changes in this pull request

- Standardized use of "email" in platform text (removed hyphen if one existed)

### When should this PR be merged

- For sprint 9

### Risks

- Low since just text updates

### Follow up actions

- None 

