### PR TITLE
Resolve #445: Add blank defaults for dropdowns

### DIFF
--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -580,9 +580,10 @@ class ProjectAddTest(UserTestCase, TestCase):
             reverse('project:add'), self.EXTENTS_POST_DATA
         )
         assert extents_response.status_code == 200
-        self.DETAILS_POST_DATA['wizard_goto_step'] = 'extents'
+        post_data = self.DETAILS_POST_DATA.copy()
+        post_data['wizard_goto_step'] = 'extents'
         details_response = self.client.post(
-            reverse('project:add'), self.DETAILS_POST_DATA
+            reverse('project:add'), post_data
         )
         assert details_response.status_code == 200
 
@@ -598,10 +599,15 @@ class ProjectAddTest(UserTestCase, TestCase):
             reverse('project:add'), self.EXTENTS_POST_DATA
         )
         assert extents_response.status_code == 200
-        with pytest.raises(KeyError):
-            self.client.post(
-                reverse('project:add'), self.DETAILS_POST_DATA
-            )
+        details_response = self.client.post(
+            reverse('project:add'), self.DETAILS_POST_DATA
+        )
+        assert details_response.status_code == 200
+        assert details_response.context_data['form'].is_valid() is False
+        assert details_response.context_data['form'].errors == {
+            'organization': ["Select a valid choice. test-org is "
+                             "not one of the available choices."],
+        }
 
     def test_full_flow_invalid_xlsform(self):
         self.client.force_login(self.users[0])
@@ -626,6 +632,42 @@ class ProjectAddTest(UserTestCase, TestCase):
             Project.objects.get(
                 organization=self.org, slug='test-project')
             assert e.message == 'Project matching query does not exist.'
+
+    def test_flow_with_org_is_chosen_function(self):
+        second_org = OrganizationFactory.create(name="Second Org")
+        OrganizationRole.objects.create(organization=second_org,
+                                        user=self.users[0],
+                                        admin=True)
+        self.client.force_login(self.users[0])
+        extents_response = self.client.post(
+            reverse('project:add'), self.EXTENTS_POST_DATA
+        )
+        assert extents_response.status_code == 200
+        form = extents_response.context_data['form']
+        print(str(form.fields))
+        assert len(form.fields['organization'].choices) == 3
+        assert form.fields['organization'].choices[0] == (
+            '', "Please select an organization")
+        assert form.fields['organization'].choices[1][1] == "Second Org"
+        assert form.fields['organization'].choices[2][1] == "Test Org"
+        details_response = self.client.post(
+            reverse('project:add'), self.DETAILS_POST_DATA
+        )
+        assert details_response.status_code == 200
+        post_data = self.PERMISSIONS_POST_DATA.copy()
+        post_data['wizard_goto_step'] = 'details'
+        permissions_response = self.client.post(
+            reverse('project:add'), post_data
+        )
+        assert permissions_response.status_code == 200
+        form = permissions_response.context_data['form']
+        assert len(form.fields['organization'].choices) == 2
+        assert form.fields['organization'].choices[0][1] == "Second Org"
+        assert form.fields['organization'].choices[1][1] == "Test Org"
+        details_response = self.client.post(
+            reverse('project:add'), self.DETAILS_POST_DATA
+        )
+        assert details_response.status_code == 200
 
     def test_full_flow_long_slug(self):
         project_name = (

--- a/cadasta/spatial/forms.py
+++ b/cadasta/spatial/forms.py
@@ -22,7 +22,10 @@ class LocationForm(AttributeModelForm):
                           'new location.')}
     )
     type = forms.ChoiceField(
-        choices=filter(lambda c: c[0] != 'PX', TYPE_CHOICES)
+        choices=filter(lambda c: c[0] != 'PX', (
+            [('', _('Please select a location type'))] +
+            list(TYPE_CHOICES)
+        ))
     )
     attributes_field = 'attributes'
 

--- a/cadasta/spatial/tests/test_forms.py
+++ b/cadasta/spatial/tests/test_forms.py
@@ -77,6 +77,23 @@ class LocationFormTest(UserTestCase, TestCase):
         unit = SpatialUnit.objects.filter(project=project).first()
         assert unit.attributes.get('fname') == 'test'
 
+    def test_create_location_with_blank_type(self):
+        data = {
+            'geometry': '{"type": "Polygon","coordinates":'
+                        '[[[0,51],[0,52],[1,52],[1,51]]]}',
+            'type': '',
+        }
+        project = ProjectFactory.create()
+        form = forms.LocationForm(project_id=project.id,
+                                  data=data,
+                                  schema_selectors=())
+        type_dict = dict(form.fields['type'].choices)
+        assert type_dict[''] == "Please select a location type"
+        assert not form.is_valid()
+        assert len(form.errors['type']) == 1
+        assert form.errors['type'][0] == "This field is required."
+        assert SpatialUnit.objects.filter(project=project).count() == 0
+
 
 class TenureRelationshipFormTest(UserTestCase, TestCase):
     def test_init(self):

--- a/cadasta/templates/organization/project_add_details.html
+++ b/cadasta/templates/organization/project_add_details.html
@@ -14,10 +14,10 @@
    var img = $('#org-logo');
    select.change(function() {
      if (logos[select[0].value]) {
-       img.removeClass('org-logo-hidden');
+       img.css('display', 'inline-block');
        img.attr('src', logos[select[0].value]);
      } else {
-       img.hadClass('org-logo-hidden');
+       img.css('display', 'none');
      }
    });
  });
@@ -62,11 +62,9 @@
                     </div>
                   </div>
                   <div class="col-sm-4 hidden-xs">
-                    {% if init_org_logo %}
                     <div id="org-wrapper">
-                      <img class="org-logo {{ init_org_hidden }}" id="org-logo" src="{{ init_org_logo }}" />
+                      <img class="org-logo" id="org-logo" style="display:none;" src="/" />
                     </div>
-                    {% endif %}
                   </div>
                 </div>
               </div>

--- a/functional_tests/pages/Organization.py
+++ b/functional_tests/pages/Organization.py
@@ -127,7 +127,9 @@ class OrganizationPage(Page):
             return self.get_archive_button().text
 
     def click_on_close_alert_button(self):
-        close = self.browser.find_element_by_xpath("//div[contains(@class, 'alert')]//button[contains(@class, 'close')]")
+        close = self.browser.find_element_by_xpath(
+            "//div[contains(@class, 'alert')]"
+            "//button[contains(@class, 'close')]")
         self.click_through_close(close, self.test.BY_ALERT)
 
     def get_add_project_button(self):
@@ -188,7 +190,7 @@ class OrganizationPage(Page):
         back_button = self.test.link('index-link')
         self.click_through(back_button, (By.CLASS_NAME, 'add-org'))
 
-    def get_archived_project_filter(self):
+    def get_archived_project_filter(self, xpath):
         return self.browser.find_element_by_xpath(
             "//select[contains(@id, 'archive-filter')]" + xpath)
 

--- a/functional_tests/projects/test_project.py
+++ b/functional_tests/projects/test_project.py
@@ -6,7 +6,6 @@ from django.contrib.gis.geos import GEOSGeometry
 from core.tests.factories import PolicyFactory
 from organization.models import OrganizationRole
 from accounts.tests.factories import UserFactory
-from organization.tests.factories import ProjectFactory
 from resources.tests.factories import ResourceFactory
 from spatial.tests.factories import SpatialUnitFactory
 from party.tests.factories import PartyFactory, TenureRelationshipFactory

--- a/functional_tests/projects/test_project_add.py
+++ b/functional_tests/projects/test_project_add.py
@@ -158,7 +158,7 @@ class ProjectAddTest(FunctionalTest):
         proj_add_page.submit_geometry()
 
         # Check that details are all blank/default
-        project['org'] = 'unesco'
+        project['org'] = ''
         project['name'] = ""
         project['access'] = 'public'
         project['description'] = ""
@@ -168,38 +168,65 @@ class ProjectAddTest(FunctionalTest):
         # TODO: Check that only valid orgs are provided
         # TODO: Vary org selection
 
-        # Check that an error occurs when no project name was set
+        # Check that errors occurs when no org was selected
+        # and no project name was set
         # Also toggle access and set description
         project['access'] = 'private'
         project['description'] = self.test_data['project_description']
         proj_add_page.set_access(project['access'])
         proj_add_page.set_description(project['description'])
         proj_add_page.try_submit_details()
+        proj_add_page.check_missing_org_error()
         proj_add_page.check_missing_name_error()
+        proj_add_page.check_no_duplicate_name_error()
+        proj_add_page.check_no_invalid_url_error()
         proj_add_page.check_details(project)
 
+        # Select the first valid org
         # Check that an error occurs when the project name is only whitespace
         # Also toggle access and set URL
+        project['org'] = 'unesco'
         project['name'] = "     "
         project['access'] = 'public'
         project['url'] = self.test_data['project_url']
+        proj_add_page.set_org(project['org'])
         proj_add_page.set_name(project['name'])
         proj_add_page.set_access(project['access'])
         proj_add_page.set_proj_url(project['url'])
         proj_add_page.try_submit_details()
+        proj_add_page.check_no_missing_org_error()
         proj_add_page.check_missing_name_error()
+        proj_add_page.check_no_duplicate_name_error()
+        proj_add_page.check_no_invalid_url_error()
         proj_add_page.check_details(project)
 
-        # Set project name, final access, and invalid URL
-        # Check that the page is not submitted due to the invalid URL
-        # (This is an HTML5 feature)
+        # Unset the org, and set a valid project name
+        # Check that an error occurs for the missing org
+        project['org'] = ''
         project['name'] = self.test_data['project_name']
+        proj_add_page.set_org(project['org'])
+        proj_add_page.set_name(project['name'])
+        proj_add_page.try_submit_details()
+        proj_add_page.check_missing_org_error()
+        proj_add_page.check_no_missing_name_error()
+        proj_add_page.check_no_duplicate_name_error()
+        proj_add_page.check_no_invalid_url_error()
+        proj_add_page.check_details(project)
+
+        # Set final org, final access, and invalid URL
+        # Check that the page is not submitted due to the invalid URL
+        project['org'] = 'unesco'
         project['access'] = access
         project['url'] = "DEADBEEF"
+        proj_add_page.set_org(project['org'])
         proj_add_page.set_name(project['name'])
         proj_add_page.set_access(project['access'])
         proj_add_page.set_proj_url(project['url'])
-        proj_add_page.click_submit_details()
+        proj_add_page.try_submit_details()
+        proj_add_page.check_no_missing_org_error()
+        proj_add_page.check_no_missing_name_error()
+        proj_add_page.check_no_duplicate_name_error()
+        proj_add_page.check_invalid_url_error()
         proj_add_page.check_details(project)
 
         # Correct the URL, press "Previous" then "Next" and ensure

--- a/functional_tests/projects/test_project_list_access.py
+++ b/functional_tests/projects/test_project_list_access.py
@@ -23,7 +23,7 @@ class ProjectListAccessTest(FunctionalTest):
                 'username': 'default' + str(uid),
                 'password': 'password1',
             })
-        self.test_data = { 'users': users }
+        self.test_data = {'users': users}
         self.superuser = users[0]
 
         # Define 2 orgs and their members

--- a/runtests.py
+++ b/runtests.py
@@ -19,7 +19,7 @@ PYTEST_ARGS_FUNCTIONAL = {
     'fast': BASE_PYTEST_ARGS_FUNCTIONAL + ['-q'],
 }
 
-FLAKE8_ARGS = ['cadasta', '--exclude=migrations']
+FLAKE8_ARGS = ['cadasta', 'functional_tests', '--exclude=migrations']
 
 
 sys.path.append(os.path.dirname(__file__))


### PR DESCRIPTION
### Proposed changes in this pull request
- Resolve #445:
    - Please refer to [this comment](https://github.com/Cadasta/cadasta-platform/issues/445#issuecomment-248228338) to see which dropdowns are proposed to be modified, are already modified before, and won't be modified in this PR.
    - Add a blank default choice for the organization selection form field when adding a new project, except when the number of orgs to be selected is just 1. In addition, if the user has already validly chosen an org by successfully going to step 3 of the add project wizard, going back to step 2 will no longer include the blank choice in the dropdown.
        - Update the `ProjectAddDetails` form initialization to add the blank choice.
        - Remove the now unnecessary `init_org_logo` and `init_org_hidden` wizard view context variables.
        - Achieve the going-back behavior by setting an `org_is_chosen` key in the wizard storage during step 2's `process_step()` in the wizard, which is eventually used during the `ProjectAddDetails` form initialization.
        - Update `clean_name()` in `ProjectAddDetails` to avoid a `KeyError` due to the blank org choice.
        - Add 4 unit tests and update 1.
        - Update/add functional tests to be able to select and check the selected org and to check for the required org error message function.
    - Add a blank default choice in the location type form field when adding a new location.
        - Modify `LocationForm` to add the blank choice.
        - Add a unit test.
- Other improvements:
    - Fix the [mentioned bug](https://github.com/Cadasta/cadasta-platform/issues/445#issuecomment-248242446) wherein the initial org logo does not match the initially selected org.
    - Fix the [mentioned bug](https://github.com/Cadasta/cadasta-platform/issues/445#issuecomment-248246366) wherein if the initially selected org has no logo, the `<img>` element for the logo is never rendered.
    - Fix the JavaScript bug wherein if the newly selected org has no logo the `<img>` element is not hidden.
    - Avoid an extra database call in the wizard view that compiles the org logo URLs by caching the list of orgs in the form creation.
    - Improve the wizard view by using the wizard view `step` property instead of `isinstance`-ing the form to determine the current step.
    - Resolve the [mentioned issue](https://github.com/Cadasta/cadasta-platform/commit/d5ae6a2c444bb01ac94cb658dde4de2f74d8814d#commitcomment-19095085) wherein superusers are still able to select archived orgs, and add 2 unit tests to check for the resolution.
    - Resolve the [mentioned issue](https://github.com/Cadasta/cadasta-platform/commit/d5ae6a2c444bb01ac94cb658dde4de2f74d8814d#commitcomment-19095059) wherein there is an extra `all()` call.
    - Include functional tests during lint check, and fix existing lint errors in functional tests.
    - Update the functional tests to check for the invalid project URL error message function, and to check that error messages that are not expected do not appear.

### When should this PR be merged
Anytime.

### Risks
No risks foreseen.

### Follow up actions
None.
