### PR TITLE
Resolve #556: Improve geometry editing UI

### DIFF
--- a/cadasta/core/static/js/map_utils.js
+++ b/cadasta/core/static/js/map_utils.js
@@ -49,16 +49,15 @@ function renderFeatures(map, projectExtent, spatialUnits, trans, fitBounds) {
 
   if (projectExtent) {
     var boundary = L.geoJson(
-      projectExtent,
-      {
+      projectExtent, {
         style: {
-            stroke: true,
-            color: "#0e305e",
-            weight: 2,
-            dashArray: "5, 5",
-            opacity: 1,
-            fill: false,
-            clickable: false,
+          stroke: true,
+          color: "#0e305e",
+          weight: 2,
+          dashArray: "5, 5",
+          opacity: 1,
+          fill: false,
+          clickable: false,
         }
       }
     );
@@ -96,45 +95,63 @@ function renderFeatures(map, projectExtent, spatialUnits, trans, fitBounds) {
 }
 
 function switch_layer_controls(map, options){
-    // swap out default layer switcher
-    var layers = options.djoptions.layers;
-    var baseLayers = {};
-    for (var l in layers){
-        var layer = layers[l];
-        var baseLayer = L.tileLayer(layer[1], layer[2]);
-        baseLayers[layer[0]] = baseLayer;
-    }
-    // select first layer by default
-    for (var l in baseLayers){
-        map.addLayer(baseLayers[l]);
-        break;
-    }
-    var groupedOptions = {
-      groupCheckboxes: false
-    };
-    map.removeControl(map.layerscontrol);
-    map.layerscontrol = L.control.groupedLayers(
-        baseLayers, groupedOptions).addTo(map);
+  // swap out default layer switcher
+  var layers = options.djoptions.layers;
+  var baseLayers = {};
+  for (var l in layers){
+    var layer = layers[l];
+    var baseLayer = L.tileLayer(layer[1], layer[2]);
+    baseLayers[layer[0]] = baseLayer;
+  }
+  // select first layer by default
+  for (var l in baseLayers){
+    map.addLayer(baseLayers[l]);
+    break;
+  }
+  var groupedOptions = {
+    groupCheckboxes: false
+  };
+  map.removeControl(map.layerscontrol);
+  map.layerscontrol = L.control.groupedLayers(
+    baseLayers, groupedOptions).addTo(map);
 }
 
 function add_spatial_resources(map, url){
-    $.ajax(url).done(function(data){
-        if (data.length == 0) return;
-        var spatialResources = {};
-        $.each(data, function(idx, resource){
-            var name = resource.name;
-            var layers = {};
-            var group = new L.LayerGroup();
-            $.each(resource.spatial_resources, function(i, spatial_resource){
-                var layer = L.geoJson(spatial_resource.geom).addTo(group);
-                layers['name'] = spatial_resource.name;
-                layers['group'] = group;
-            });
-            spatialResources[name] = layers;
-        });
-        $.each(spatialResources, function(sr){
-            var layer = spatialResources[sr];
-            map.layerscontrol.addOverlay(layer['group'], layer['name'], sr);
-        })
+  $.ajax(url).done(function(data){
+    if (data.length == 0) return;
+    var spatialResources = {};
+    $.each(data, function(idx, resource){
+      var name = resource.name;
+      var layers = {};
+      var group = new L.LayerGroup();
+      $.each(resource.spatial_resources, function(i, spatial_resource){
+        var layer = L.geoJson(spatial_resource.geom).addTo(group);
+        layers['name'] = spatial_resource.name;
+        layers['group'] = group;
+      });
+      spatialResources[name] = layers;
     });
+    $.each(spatialResources, function(sr){
+      var layer = spatialResources[sr];
+      map.layerscontrol.addOverlay(layer['group'], layer['name'], sr);
+    })
+  });
+}
+
+function enableMapEditMode() {
+  var editButton = $('.leaflet-draw-edit-edit')[0];
+  if (!editButton) {
+    setTimeout(enableMapEditMode, 500);
+  } else {
+    var clickEvent = new MouseEvent('click');
+    editButton.dispatchEvent(clickEvent);
+  }
+}
+
+function saveOnMapEditMode() {
+  var saveButton = $('.leaflet-draw-actions-top li:first-child a')[0];
+  if (saveButton) {
+    var clickEvent = new MouseEvent('click');
+    saveButton.dispatchEvent(clickEvent);
+  }
 }

--- a/cadasta/templates/organization/project_edit_geometry.html
+++ b/cadasta/templates/organization/project_edit_geometry.html
@@ -21,6 +21,10 @@
  $(document).ready(function () {
    $(window).on('map:init', function(e) {
       add_map_controls(e.originalEvent.detail.map);
+
+      // Enable edit mode on map load and save the geometry on page save
+      setTimeout(enableMapEditMode, 500);
+      $('button.btn-primary[type=submit]')[0].addEventListener('click', saveOnMapEditMode);
    });
  });
 </script>

--- a/cadasta/templates/spatial/location_add.html
+++ b/cadasta/templates/spatial/location_add.html
@@ -59,5 +59,5 @@
 {% endblock %}
 
 {% block content %}
-  {% include "spatial/location_form.html" with title="Add new location" %}
+  {% include "spatial/location_form.html" with title="Add new location" cancel_url=request.META.HTTP_REFERER %}
 {% endblock %}

--- a/cadasta/templates/spatial/location_edit.html
+++ b/cadasta/templates/spatial/location_edit.html
@@ -55,11 +55,16 @@
       markerGroup.addTo(map);
       markerGroup.checkIn(geoJson);
       geoJson.addTo(map);
+
+      // Enable edit mode on map load and save the geometry on page save
+      setTimeout(enableMapEditMode, 500);
+      $('input.btn-primary')[0].addEventListener('click', saveOnMapEditMode);
     });
   });
 </script>
 {% endblock %}
 
 {% block content %}
+  {% url 'locations:detail' object.organization.slug object.slug location.id as cancel_url %}
   {% include "spatial/location_form.html" with title="Edit location" %}
 {% endblock %}

--- a/cadasta/templates/spatial/location_form.html
+++ b/cadasta/templates/spatial/location_form.html
@@ -37,7 +37,7 @@
         </div>
         <div class="panel-footer panel-buttons">
           <input class="btn btn-primary" type="submit" value="{% trans 'Save' %}"/>
-          <a class="btn btn-default cancel" href="{{ request.META.HTTP_REFERER }}">{% trans "Cancel" %}</a>
+          <a class="btn btn-default cancel" href="{{ cancel_url }}">{% trans "Cancel" %}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Proposed changes in this pull request
- Resolve #556:
    - *Overview:* Editing project boundaries and location geometries will be made simpler because the user does not have to click as much:
        - When the geometry edit page loads, the Leaflet.draw editing mode will be enabled automatically so that the geometry is immediately editable. This will be done by dispatching the "click" event on the "Edit" button on the map toolbar.
        - When the user clicks the big "Save" button on the page, any changes to the geometry will be automatically saved as well. This will be done by dispatching the "click" event on the small "Save" button on the map toolbar if it is still visible.
    - Add `enableMapEditMode` and `saveOnMapEditMode` functions to **core/static/js/map_utils.js**. These take care of two behaviors described above respectively.
    - Add JavaScript code/event listeners to call the two functions above to the **project_edit_geometry.html** and **location_edit.html** templates.
- *Partially* resolve #719:
    - Fix the non-working cancel button during location editing by providing the location detail page as the cancel button's URL instead of the HTTP referrer.
    - Note: the cancel button during location creation is still *not* fixed as this requires a decision on the best cancel URL: it can be the referrer, but this must be preserved somehow, or just use the project dashboard URL.
- Other improvements:
    - Make the indentation of **core/static/js/map_utils.js** consistent to 2 spaces.

### When should this PR be merged
Anytime.

### Risks
No risks foreseen.

### Follow up actions
Since a static JavaScript file was modified, people need to clear their browser cache.
