### PR TITLE
Fix #674: Fix resource count on project dashboard

### DIFF
--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -361,7 +361,7 @@ class ProjectDashboard(PermissionRequiredMixin,
         context = super(ProjectDashboard, self).get_context_data(**kwargs)
         num_locations = self.object.spatial_units.count()
         num_parties = self.object.parties.count()
-        num_resources = self.object.resource_set.count()
+        num_resources = self.object.resource_set.filter(archived=False).count()
         context['has_content'] = (
             num_locations > 0 or num_parties > 0 or num_resources > 0)
         context['num_locations'] = num_locations


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #674:
    - Filter the resource count queryset with `filter(archived=False)`.
    - Add a unit test for this, and update the `ProjectDashboardTest` unit test class to complete the template context.

### When should this PR be merged
Anytime.

### Risks
None foreseen.

### Follow up actions
None.
