### PR TITLE
Make pseudo-links behave more traditionally #615

### DIFF
--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -34,11 +34,14 @@
                   {% else %}
                     <td class="unarchived"><div>False</div></td>
                   {% endif %}
-                  <td>{{ prj.name }}{% if prj.archived %}
-                  <span class="label label-danger">
-                    Archived
-                  </span>
-                  {% endif %}</td>
+                  <td>
+                      <a href="{% url 'organization:project-dashboard' organization=organization.slug project=prj.slug %}">{{ prj.name }}</a>
+                      {% if prj.archived %}
+                      <span class="label label-danger">
+                        Archived
+                      </span>
+                      {% endif %}
+                  </td>
                   <td>{{ prj.country }}</td>
                   <td>{{ prj.last_updated }}</td>
                 </tr>

--- a/cadasta/templates/organization/organization_list.html
+++ b/cadasta/templates/organization/organization_list.html
@@ -52,7 +52,7 @@
       </div>
       {% endif %}
       <div class="org-text">
-        <h4>{{ org.name }}
+        <h4><a href="{% url 'organization:dashboard' slug=org.slug %}">{{ org.name }}</a>
         {% if org.archived %}
           <span class="label label-danger">Archived</span>
         {% endif %}

--- a/cadasta/templates/organization/organization_members.html
+++ b/cadasta/templates/organization/organization_members.html
@@ -34,7 +34,8 @@
             <tbody>
             {% for user in organization.users.all %}
               <tr class="linked" onclick="window.document.location='{% url 'organization:members_edit' slug=organization.slug username=user.username %}';">
-                <td>{{ user.get_display_name }}
+                <td>
+                  <a href="{% url 'organization:members_edit' slug=organization.slug username=user.username %}">{{ user.get_display_name }}</a>
                   <div class="hidden-sm hidden-md hidden-lg">
                     {{ user.username }}<br />
                     {{ user.email }}

--- a/cadasta/templates/organization/project_list.html
+++ b/cadasta/templates/organization/project_list.html
@@ -48,10 +48,11 @@
       <td class="unarchived"><div>False</div></td>
     {% endif %}
     <td>
-      <h4>{{ proj.name }}
-      {% if proj.archived %}
+      <h4>
+          <a href="{% url 'organization:project-dashboard' organization=proj.organization.slug project=proj.slug %}">{{ proj.name }}</a>
+          {% if proj.archived %}
           <span class="label label-danger">{% trans "Archived" %}</span>
-        {% endif %}
+          {% endif %}
         </h4>
       </h4>
       <p>{{ proj.description }}</p>

--- a/cadasta/templates/resources/table.html
+++ b/cadasta/templates/resources/table.html
@@ -20,7 +20,7 @@
           <img src="{{ resource.thumbnail }}" class="thumb-60">
         </div>
         <div class="resource-text">
-          <p><strong>{{ resource.name }}</strong>
+          <p><strong><a href="{% url 'resources:project_detail' project=object.slug organization=object.organization.slug resource=resource.id %}">{{ resource.name }}</a></strong>
             {% if resource.archived %}
               <span class="label label-danger">{% trans "Deleted" %}</span>
             {% endif %}


### PR DESCRIPTION
### Proposed changes in this pull request

Enhancement mentioned in the issue https://github.com/Cadasta/cadasta-platform/issues/615

I've added this enhancement to the following pages (tables)

- Organizations
- Projects
- Project resources
- Organization overview -> Projects table
- Organization members table

Here is a screenshot of Projects page table

![screenshot from 2016-09-25 19 55 16](https://cloud.githubusercontent.com/assets/10743861/18815906/3ca3f5d6-835b-11e6-9814-0c9399c3160d.png)


### When should this PR be merged

Whenever possible

