### PR TITLE
Show member list only to an organization member : https://github.com/…

### DIFF
--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -201,7 +201,8 @@ class OrganizationDashboardTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(user=user)
         assert response.status_code == 200
         assert response.content == self.render_content(
-            projects=Project.objects.all())
+            projects=Project.objects.all(),
+            show_members=True)
 
     def test_get_org_with_new_org(self):
         new_org = OrganizationFactory.create()
@@ -223,6 +224,7 @@ class OrganizationDashboardTest(ViewTestCase, UserTestCase, TestCase):
             is_superuser=True,
             is_administrator=True,
             add_allowed=True,
+            show_members=True,
             projects=self.all_projects)
 
     def test_get_org_with_org_admin(self):
@@ -239,6 +241,7 @@ class OrganizationDashboardTest(ViewTestCase, UserTestCase, TestCase):
             is_superuser=False,
             is_administrator=True,
             add_allowed=True,
+            show_members=True,
             projects=self.all_projects)
 
     def test_get_archived_org_with_unauthorized_user(self):
@@ -273,6 +276,7 @@ class OrganizationDashboardTest(ViewTestCase, UserTestCase, TestCase):
             is_superuser=False,
             is_administrator=True,
             add_allowed=True,
+            show_members=True,
             projects=self.all_projects)
 
 

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -7,6 +7,7 @@ import core.views.generic as generic
 import django.views.generic as base_generic
 import formtools.wizard.views as wizard
 from accounts.models import User
+from django.contrib.auth.models import AnonymousUser
 from core.mixins import (LoginPermissionRequiredMixin, PermissionRequiredMixin,
                          update_permissions)
 from core.views.mixins import ArchiveMixin, SuperUserCheckMixin
@@ -73,6 +74,7 @@ class OrganizationDashboard(PermissionRequiredMixin,
         context = self.get_context_data()
         if self.is_superuser:
             projects = self.object.all_projects()
+            show_members = True
         else:
             projects = self.object.public_projects()
             if hasattr(self.request.user, 'organizations'):
@@ -84,7 +86,19 @@ class OrganizationDashboard(PermissionRequiredMixin,
                         else:
                             projects = self.object.all_projects().filter(
                                 archived=False)
+
+            if not isinstance(self.request.user, AnonymousUser):
+                try:
+                    show_members = isinstance(OrganizationRole.objects.get(
+                        user=self.request.user,
+                        organization=context['organization']),
+                                              OrganizationRole)
+                except(OrganizationRole.DoesNotExist):
+                    show_members = False
+            else:
+                show_members = False
         context['projects'] = projects
+        context['show_members'] = show_members
         return super(generic.DetailView, self).render_to_response(context)
 
 

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -7,7 +7,6 @@ import core.views.generic as generic
 import django.views.generic as base_generic
 import formtools.wizard.views as wizard
 from accounts.models import User
-from django.contrib.auth.models import AnonymousUser
 from core.mixins import (LoginPermissionRequiredMixin, PermissionRequiredMixin,
                          update_permissions)
 from core.views.mixins import ArchiveMixin, SuperUserCheckMixin
@@ -87,14 +86,10 @@ class OrganizationDashboard(PermissionRequiredMixin,
                             projects = self.object.all_projects().filter(
                                 archived=False)
 
-            if not isinstance(self.request.user, AnonymousUser):
-                try:
-                    show_members = isinstance(OrganizationRole.objects.get(
-                        user=self.request.user,
-                        organization=context['organization']),
-                                              OrganizationRole)
-                except(OrganizationRole.DoesNotExist):
-                    show_members = False
+            if not self.request.user.is_anonymous():
+                show_members = OrganizationRole.objects.get(
+                    user=self.request.user,
+                    organization=context['organization']).exists()
             else:
                 show_members = False
         context['projects'] = projects

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -87,7 +87,7 @@ class OrganizationDashboard(PermissionRequiredMixin,
                                 archived=False)
 
             if not self.request.user.is_anonymous():
-                show_members = OrganizationRole.objects.get(
+                show_members = OrganizationRole.objects.filter(
                     user=self.request.user,
                     organization=context['organization']).exists()
             else:

--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -94,6 +94,7 @@
             {% endfor %}
             </dl>
           {% endif %}
+          {% if show_members %}
           <div class="divider-thick"></div>
           <div class="hidden-xs hidden-sm">
             <!-- Members list -->
@@ -111,6 +112,7 @@
               </a>
             </div>
           </div>
+          {% endif %}
         </section>
       </div>
       <!-- /.detail -->


### PR DESCRIPTION
### Proposed changes in this pull request

Restricted showing the organization member list in organization dashboard only to the members of that organization.
Related issue : https://github.com/Cadasta/cadasta-platform/issues/609

### When should this PR be merged
Whenever possible

…Cadasta/cadasta-platform/issues/609