### PR TITLE
Make SASS compilation work in dev VM again

### DIFF
--- a/cadasta/config/settings/dev.py
+++ b/cadasta/config/settings/dev.py
@@ -58,6 +58,7 @@ ROOT_URLCONF = 'config.urls.dev'
 DEFAULT_FILE_STORAGE = 'buckets.test.storage.FakeS3Storage'
 MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'core/media')
 MEDIA_URL = '/media/'
+SASS_PROCESSOR_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'core/static')
 
 # Use HTTP for OSM for testing only, to make caching tiles for
 # functional tests a bit simpler.


### PR DESCRIPTION
### Proposed changes in this pull request

- Add `SASS_PROCESSOR_ROOT` setting to development VM settings.
- This fixes a problem introduced by removing the spurious `STATIC_ROOT` setting we used to have in the development settings.  The Django package we're using for SASS processing was looking for its output files (to check whether they were out of date) either in `SASS_PROCESSOR_ROOT` or, if that wasn't set, in `STATIC_ROOT`.  Taking out the `STATIC_ROOT` setting broke the SASS compilation. 

### When should this PR be merged

Any time.

### Risks

None.

### Follow up actions

None.