### PR TITLE
Updating pages needing css, fixed long form name overflow, removed hy…

### DIFF
--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -3793,7 +3793,7 @@ body.tinted-bg {
   -o-background-size: cover;
   -webkit-background-size: cover; }
 
-.form-narrow {
+.form-narrow, .narrow {
   margin: 0 auto;
   max-width: 500px;
   background: #fff;
@@ -3808,16 +3808,27 @@ body.tinted-bg {
   -moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
   -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05); }
-  .form-narrow h1 {
+  .form-narrow h1, .narrow h1 {
     text-align: center;
     margin: 4px auto 24px; }
-  .form-narrow h5 {
+  .form-narrow h5, .narrow h5 {
     border-top: 1px dashed #ddd;
     padding-top: 20px; }
-  .form-narrow .btn-block {
+  .form-narrow .btn-block, .narrow .btn-block {
     margin-bottom: 20px; }
-  .form-narrow .checkbox.pull-left {
+  .form-narrow .checkbox.pull-left, .narrow .checkbox.pull-left {
     margin-top: 0; }
+  .form-narrow .btn-full, .narrow .btn-full {
+    background: transparent;
+    border-top: 1px solid #e7e8ea;
+    text-align: center;
+    padding: 20px;
+    clear: both;
+    margin: 20px 0; }
+    .form-narrow .btn-full .btn, .narrow .btn-full .btn {
+      min-width: 100px; }
+    .form-narrow .btn-full .btn-group .btn, .narrow .btn-full .btn-group .btn {
+      margin: 0; }
 
 @media (max-width: 1199px) {
   .form-narrow {
@@ -4417,7 +4428,7 @@ label {
   font-weight: 400; }
 
 a {
-  color: #337ab7; }
+  color: #2e51a3; }
   a:hover, a:focus {
     color: #0e305e;
     outline: none; }
@@ -4815,6 +4826,7 @@ header {
   border-radius: 0;
   min-width: 224px;
   min-width: 160px;
+  max-width: 300px;
   height: 70px;
   border: none;
   font-size: 13px;
@@ -4853,6 +4865,14 @@ header {
   .reg-links .btn-user .badge {
     color: transparent;
     background-color: #eeeeee; }
+  .reg-links .btn-user .username {
+    display: inline-block !important;
+    position: relative;
+    top: 5px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px; }
   .reg-links .btn-user:hover, .reg-links .btn-user:focus {
     color: #fff;
     background-color: #28478f;
@@ -5031,6 +5051,8 @@ header {
     margin-left: 4px; }
   .reg-links .btn-user {
     min-width: 90px; }
+    .reg-links .btn-user .username {
+      display: none !important; }
     .reg-links .btn-user .thumbnail {
       margin-right: 4px; }
   .reg-links .btn-reg {
@@ -5830,7 +5852,10 @@ div.org-logo {
   clear: both;
   margin: 30px 0; }
 
-#projects-permissions .form-control {
+#projects-permissions .form-group, .form-inline .form-group {
+  display: block; }
+
+#projects-permissions .form-control, .form-inline .form-control {
   min-width: 70%; }
 
 /* =Dashboard map
@@ -5913,7 +5938,7 @@ img.org-logo, img#org-logo {
   clear: both;
   margin: 20px 0; }
   .btn-full .btn {
-    min-width: 200px; }
+    min-width: 160px; }
   .btn-full .btn-group .btn {
     margin: 0; }
 
@@ -5977,6 +6002,9 @@ div.add-btn-btm {
     display: table-cell;
     vertical-align: top;
     padding: 4px; }
+
+.form-narrow .alert-full, .narrow .alert-full {
+  margin-bottom: 20px; }
 
 .translation-wrapper {
   background-color: fuchsia; }

--- a/cadasta/core/static/css/main.scss
+++ b/cadasta/core/static/css/main.scss
@@ -104,7 +104,7 @@ label {
 }
 
 a {
-  color: #337ab7;
+  color: $link-color;
   &:hover, 
   &:focus {
    color: $brand-darkblue;
@@ -297,10 +297,20 @@ header {
     border-radius: 0;
     min-width: 224px;
     min-width: 160px; // beta
+    max-width: 300px;
     height: $header-height;
     border: none;
     font-size: 13px;
     @include button-variant($gray-lighter, transparent, $btn-blue-bg);
+    .username {
+      display: inline-block !important;
+      position: relative;
+      top: 5px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 200px;
+    }
     &:hover,
     &:focus {
       @include button-variant(#fff, darken($btn-blue-bg, 5%), $btn-blue-bg);
@@ -346,6 +356,9 @@ header {
     }
     .btn-user { // user profile links
       min-width: 90px;
+      .username {
+        display: none !important;
+      }
       .thumbnail {
         margin-right: 4px;
       }
@@ -1152,8 +1165,13 @@ div.org-logo {
   margin: 30px 0;
 }
 
-#projects-permissions .form-control {
-  min-width: 70%;
+#projects-permissions, .form-inline {
+  .form-group {
+    display: block;
+  }
+  .form-control {
+    min-width: 70%;
+  }
 }
 
 /* =Dashboard map
@@ -1256,7 +1274,7 @@ img.org-logo, img#org-logo {
   clear: both;
   margin: 20px 0;
   .btn {
-    min-width: 200px;
+    min-width: 160px;
   }
   .btn-group .btn {
     margin: 0;
@@ -1339,6 +1357,12 @@ div.add-btn-btm { // add party link at bottom of table
     display: table-cell;
     vertical-align: top;
     padding: 4px;
+  }
+}
+
+.form-narrow, .narrow {
+  .alert-full {
+    margin-bottom: 20px;
   }
 }
 

--- a/cadasta/core/static/css/reg.scss
+++ b/cadasta/core/static/css/reg.scss
@@ -9,7 +9,7 @@ body.tinted-bg { // photo for login and register forms
   -webkit-background-size: cover;
 }
 
-.form-narrow {
+.form-narrow, .narrow {
   margin: 0 auto;
   max-width: 500px;
   background: #fff;
@@ -37,6 +37,20 @@ body.tinted-bg { // photo for login and register forms
   }
   .checkbox.pull-left {
     margin-top: 0;
+  }
+  .btn-full {
+    background: transparent;
+    border-top: 1px solid $table-border-color;
+    text-align: center;
+    padding: 20px;
+    clear: both;
+    margin: 20px 0;
+    .btn {
+      min-width: 100px;
+    }
+    .btn-group .btn {
+      margin: 0;
+    }
   }
 }
 

--- a/cadasta/templates/allauth/account/account_inactive.html
+++ b/cadasta/templates/allauth/account/account_inactive.html
@@ -5,7 +5,10 @@
 {% block head_title %}{% trans "Account Inactive" %}{% endblock %}
 
 {% block content %}
-<h1>{% trans "Account Inactive" %}</h1>
 
-<p>{% trans "This account is inactive." %}</p>
+<div class="narrow">
+	<h1>{% trans "Account inactive" %}</h1>
+	<p>{% blocktrans %}This account is inactive. Please <a href="mailto:support@cadasta.org">contact us</a> if you need assistance.{% endblocktrans %}</p>
+</div>
+
 {% endblock %}

--- a/cadasta/templates/allauth/account/email.html
+++ b/cadasta/templates/allauth/account/email.html
@@ -1,57 +1,69 @@
 {% extends "account/base.html" %}
 
 {% load i18n %}
+{% load widget_tweaks %}
 
 {% block head_title %}{% trans "Account" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "E-mail Addresses" %}</h1>
-{% if user.emailaddress_set.all %}
-<p>{% trans 'The following e-mail addresses are associated with your account:' %}</p>
 
-<form action="{% url 'account_email' %}" class="email_list" method="post" novalidate>
+<form action="{% url 'account_email' %}" class="email_list form-narrow" method="post" data-parsley-validate>
 {% csrf_token %}
-<fieldset class="blockLabels">
 
-  {% for emailaddress in user.emailaddress_set.all %}
-<div class="ctrlHolder">
-      <label for="email_radio_{{forloop.counter}}" class="{% if emailaddress.primary %}primary_email{%endif%}">
+   <h1>{% trans "Email addresses" %}</h1>
 
-      <input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary or user.emailaddress_set.count == 1 %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
+  {% if user.emailaddress_set.all %} 
 
-{{ emailaddress.email }}
-    {% if emailaddress.verified %}
-    <span class="verified">{% trans "Verified" %}</span>
-    {% else %}
-    <span class="unverified">{% trans "Unverified" %}</span>
-    {% endif %}
-      {% if emailaddress.primary %}<span class="primary">{% trans "Primary" %}</span>{% endif %}
-</label>
-</div>
-  {% endfor %}
+    <div class="form-group">
+      <p>{% trans 'The following email addresses are associated with your account:' %}</p>
 
-<div class="buttonHolder">
-      <button class="secondaryAction" type="submit" name="action_primary" >{% trans 'Make Primary' %}</button>
-      <button class="secondaryAction" type="submit" name="action_send" >{% trans 'Re-send Verification' %}</button>
-      <button class="primaryAction" type="submit" name="action_remove" >{% trans 'Remove' %}</button>
-</div>
+      {% for emailaddress in user.emailaddress_set.all %}
+        <ul class="list-unstyled spacing-lg">
+          <li class="radio">
+            <label class="control-label" for="email_radio_{{forloop.counter}}" class="{% if emailaddress.primary %}primary_email{% endif %}">
+              <input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary or user.emailaddress_set.count == 1 %}checked="checked"{% endif %} value="{{ emailaddress.email }}"/>
+              {{ emailaddress.email }}
+                {% if emailaddress.verified %}
+                  <span class="label label-success small verified">{% trans "Verified" %}</span>
+                {% else %}
+                  <span class="label label-warning small unverified">{% trans "Unverified" %}</span>
+                {% endif %}
+                {% if emailaddress.primary %}<small>{% trans "Primary" %}</small>{% endif %}
+            </label>
+          </li>
+        </ul>
+      {% endfor %}
 
-</fieldset>
+      <div class="btn-full">
+        <button class="btn btn-primary secondaryAction" type="submit" name="action_primary" >{% trans 'Make Primary' %}</button>
+        <button class="btn btn-default secondaryAction" type="submit" name="action_send" >{% trans 'Re-send Verification' %}</button>
+        <button class="btn btn-default primaryAction" type="submit" name="action_remove" ><span class="glyphicon glyphicon-remove" aria-hidden="true"></span> {% trans 'Remove' %}</button>
+      </div>
+
+    </div>
+ 
+  {% else %}
+
+    <div class="alert alert-danger"><p><strong>{% trans 'Warning:'%}</strong> {% trans "You currently do not have any email address set up. You should really add an email address so you can receive notifications, reset your password, etc." %}</p></div>
+
+  {% endif %}
+
 </form>
 
-{% else %}
-<p><strong>{% trans 'Warning:'%}</strong> {% trans "You currently do not have any e-mail address set up. You should really add an e-mail address so you can receive notifications, reset your password, etc." %}</p>
+<form method="post" action="{% url 'account_email' %}" class="add_email form-narrow" data-parsley-validate>
+{% csrf_token %}
+    
+  <h2>{% trans "Add email address" %}</h2>
+  <p>{% trans 'To associate another email address to your account, complete the form below.' %}</p>
+  <div class="form-group{% if form.email.errors %} has-error{% endif %}">
+    <label class="control-label" for="{{ form.email.id_for_label }}">{% trans "Email" %}</label>
+    {% render_field form.email class+="form-control input-lg" placeholder="" data-parsley-required="true" %}
+    <div class="error-block">{{ form.email.errors }}</div>
+  </div>
 
-{% endif %}
+  <button class="btn btn-primary btn-lg btn-block text-uppercase" name="action_add" type="submit">{% trans "Add Email" %}</button>
 
-
-    <h2>{% trans "Add E-mail Address" %}</h2>
-
-    <form method="post" action="{% url 'account_email' %}" class="add_email" novalidate>
-        {% csrf_token %}
-        {{ form.as_p}}
-        <button name="action_add" type="submit">{% trans "Add E-mail" %}</button>
-    </form>
+</form>
 
 {% endblock %}
 
@@ -59,7 +71,7 @@
 {% block extra_body %}
 <script type="text/javascript">
 (function() {
-  var message = "{% trans 'Do you really want to remove the selected e-mail address?' %}";
+  var message = "{% trans 'Do you really want to remove the selected email address?' %}";
   var actions = document.getElementsByName('action_remove');
   if (actions.length) {
     actions[0].addEventListener("click", function(e) {

--- a/cadasta/templates/allauth/account/email/email_confirmation_message.txt
+++ b/cadasta/templates/allauth/account/email/email_confirmation_message.txt
@@ -1,7 +1,8 @@
 {% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans %}
 
-You're receiving this e-mail because user {{ user_display }} at Cadasta Platform has given yours as an e-mail address to connect their account.
+You're receiving this email because user {{ user_display }} at Cadasta Platform has given yours as an email address to connect their account.
 
 To confirm this is correct, go to {{ activate_url }}
 {% endblocktrans %}{% endautoescape %}
+
 {% blocktrans %}Thank you from Cadasta.{% endblocktrans %}

--- a/cadasta/templates/allauth/account/email/email_confirmation_subject.txt
+++ b/cadasta/templates/allauth/account/email/email_confirmation_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Please Confirm Your E-mail Address{% endblocktrans %}
+{% blocktrans %}Please Confirm Your Email Address{% endblocktrans %}
 {% endautoescape %}

--- a/cadasta/templates/allauth/account/email/password_reset_key_message.txt
+++ b/cadasta/templates/allauth/account/email/password_reset_key_message.txt
@@ -1,6 +1,7 @@
 {% load i18n %}{% blocktrans %}
 
-You're receiving this e-mail because you or someone else has requested a password for your user account at Cadasta Platform.
+You're receiving this email because you or someone else has requested a password for your user account at Cadasta Platform.
+
 It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
 
 {{ password_reset_url }}

--- a/cadasta/templates/allauth/account/email/password_reset_key_subject.txt
+++ b/cadasta/templates/allauth/account/email/password_reset_key_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Password Reset E-mail{% endblocktrans %}
+{% blocktrans %}Password Reset Email{% endblocktrans %}
 {% endautoescape %}

--- a/cadasta/templates/allauth/account/email_confirm.html
+++ b/cadasta/templates/allauth/account/email_confirm.html
@@ -3,29 +3,34 @@
 {% load i18n %}
 {% load account %}
 
-{% block head_title %}{% trans "Confirm E-mail Address" %}{% endblock %}
+{% block head_title %}{% trans "Confirm Email Address" %}{% endblock %}
 
 
 {% block content %}
-<h1>{% trans "Confirm E-mail Address" %}</h1>
 
-{% if confirmation %}
+<div class="narrow">
 
-{% user_display confirmation.email_address.user as user_display %}
+	<h1>{% trans "Confirm email address" %}</h1>
 
-<p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+	{% if confirmation %}
 
-<form method="post" action="{% url 'account_confirm_email' confirmation.key %}" novalidate>
-{% csrf_token %}
-    <button type="submit">{% trans 'Confirm' %}</button>
-</form>
+		{% user_display confirmation.email_address.user as user_display %}
 
-{% else %}
+		<p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an email address for user {{ user_display }}.{% endblocktrans %}</p>
 
-{% url 'account_email' as email_url %}
+		<form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+		{% csrf_token %}
+	    	<button class="btn btn-primary btn-block" type="submit">{% trans 'Confirm' %}</button>
+		</form>
 
-<p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
+	{% else %}
 
-{% endif %}
+		{% url 'account_email' as email_url %}
+
+		<p>{% blocktrans %}This email confirmation link expired or is invalid. Please issue a new <a href="{{ email_url }}">email confirmation request</a>.{% endblocktrans %}</p>
+
+	{% endif %}
+
+</div>
 
 {% endblock %}

--- a/cadasta/templates/allauth/account/logout.html
+++ b/cadasta/templates/allauth/account/logout.html
@@ -7,17 +7,19 @@
 {% block head_title %}{% trans "Sign Out" %}{% endblock %}
 
 {% block content %}
-<h1>{% trans "Sign Out" %}</h1>
 
-<p>{% trans 'Are you sure you want to sign out?' %}</p>
+<form class="narrow" method="post" action="{% url 'account_logout' %}">
+{% csrf_token %}
 
-<form method="post" action="{% url 'account_logout' %}">
-  {% csrf_token %}
+  <h1>{% trans "Sign out" %}</h1>
+
+  <p>{% trans 'Are you sure you want to sign out?' %}</p>
+
   {% if redirect_field_value %}
-  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+  	<input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
   {% endif %}
-  <button type="submit">{% trans 'Sign Out' %}</button>
+  
+  <button class="btn btn-primary btn-block" type="submit">{% trans 'Sign Out' %}</button>
 </form>
-
 
 {% endblock %}

--- a/cadasta/templates/allauth/account/messages/cannot_delete_primary_email.txt
+++ b/cadasta/templates/allauth/account/messages/cannot_delete_primary_email.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans %}You cannot remove your primary e-mail address ({{email}}).{% endblocktrans %}
+{% blocktrans %}You cannot remove your primary email address ({{email}}).{% endblocktrans %}

--- a/cadasta/templates/allauth/account/messages/email_confirmation_sent.txt
+++ b/cadasta/templates/allauth/account/messages/email_confirmation_sent.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans %}Confirmation e-mail sent to {{email}}.{% endblocktrans %}
+{% blocktrans %}Confirmation email sent to {{email}}.{% endblocktrans %}

--- a/cadasta/templates/allauth/account/messages/email_deleted.txt
+++ b/cadasta/templates/allauth/account/messages/email_deleted.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans %}Removed e-mail address {{email}}.{% endblocktrans %}
+{% blocktrans %}Removed email address {{email}}.{% endblocktrans %}

--- a/cadasta/templates/allauth/account/messages/primary_email_set.txt
+++ b/cadasta/templates/allauth/account/messages/primary_email_set.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans %}Primary e-mail address set.{% endblocktrans %}
+{% blocktrans %}Primary email address set.{% endblocktrans %}

--- a/cadasta/templates/allauth/account/messages/unverified_primary_email.txt
+++ b/cadasta/templates/allauth/account/messages/unverified_primary_email.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans %}Your primary e-mail address must be verified.{% endblocktrans %}
+{% blocktrans %}Your primary email address must be verified.{% endblocktrans %}

--- a/cadasta/templates/allauth/account/password_change.html
+++ b/cadasta/templates/allauth/account/password_change.html
@@ -8,28 +8,28 @@
 {% block content %}
 
 <form method="POST" action="{% url 'account_change_password' %}"
-      class="login-form form-narrow" novalidate>
+      class="login-form form-narrow" data-parsley-validate>
 
   <h1>{% trans "Change your password" %}</h1>
 
   {% csrf_token %}
 
   <div class="form-group{% if form.oldpassword.errors %} has-error{% endif %}">
-    <label for="id_oldpassword">{% trans "Current password" %}</label>
-    <label class="pull-right control-label">{{ form.oldpassword.errors }}</label>
-    {% render_field form.oldpassword class+="form-control input-lg" placeholder="" %}
+    <label class="control-label" for="id_oldpassword">{% trans "Current password" %}</label>
+    {% render_field form.oldpassword class+="form-control input-lg" placeholder="" data-parsley-required="true" %}
+     <div class="error-block">{{ form.oldpassword.errors }}</div>
   </div>
 
   <div class="form-group{% if form.password1.errors %} has-error{% endif %}">
-    <label for="id_password1">{% trans "Enter a new password" %}</label>
-    <label class="pull-right control-label">{{ form.password1.errors }}</label>
-    {% render_field form.password1 class+="form-control input-lg" placeholder="" %}
+    <label class="control-label" for="id_password1">{% trans "Enter a new password" %}</label>
+    {% render_field form.password1 class+="form-control input-lg" placeholder="" data-parsley-required="true" %}
+    <div class="error-block">{{ form.password1.errors }}</div>
   </div>
 
   <div class="form-group{% if form.password2.errors %} has-error{% endif %}">
-    <label for="id_password2">{% trans "Confirm the new password" %}</label>
-    <label class="pull-right control-label">{{ form.password2.errors }}</label>
-    {% render_field form.password2 class+="form-control input-lg" placeholder="" %}
+    <label class="control-label" for="id_password2">{% trans "Confirm the new password" %}</label>
+    {% render_field form.password2 class+="form-control input-lg" placeholder="" data-parsley-required="true" data-parsley-equalto="#id_password1" %}
+    <div class="error-block">{{ form.password2.errors }}</div>
   </div>
 
   <button type="submit" name="action"

--- a/cadasta/templates/allauth/account/password_reset_done.html
+++ b/cadasta/templates/allauth/account/password_reset_done.html
@@ -6,11 +6,17 @@
 {% block head_title %}{% trans "Password Reset" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Password Reset" %}</h1>
+
+<div class="narrow">
+
+    <h1>{% trans "Password reset" %}</h1>
     
     {% if user.is_authenticated %}
     {% include "account/snippets/already_logged_in.html" %}
     {% endif %}
     
-    <p>{% blocktrans %}We have sent you an e-mail. Please <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
+    <p>{% blocktrans %}We have sent you an email. Please <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
+
+</div>
+
 {% endblock %}

--- a/cadasta/templates/allauth/account/password_reset_from_key.html
+++ b/cadasta/templates/allauth/account/password_reset_from_key.html
@@ -1,12 +1,13 @@
 {% extends "account/base.html" %}
 
+{% load widget_tweaks %}
 {% load i18n %}
 {% block head_title %}{% trans "Change Password" %}{% endblock %}
 
 {% block content %}
 
 <div class="narrow">
-    <h1>{% if token_fail %}{% trans "Bad token" %}{% else %}{% trans "Change password" %}{% endif %}</h1>
+    <h1>{% if token_fail %}{% trans "Bad token" %}{% else %}{% trans "Change your password" %}{% endif %}</h1>
 
     {% if token_fail %}
         {% url 'account_reset_password' as passwd_reset_url %}
@@ -15,8 +16,21 @@
         {% if form %}
             <form method="POST" action="." data-parsley-validate>
                 {% csrf_token %}
-                {{ form.as_p }}
-                <input type="submit" name="action" value="{% trans 'change password' %}"/>
+
+                <div class="form-group{% if form.password1.errors %} has-error{% endif %}">
+                    <label class="control-label" for="id_password1">{% trans "Enter a new password" %}</label>
+                    {% render_field form.password1 class+="form-control input-lg" placeholder="" data-parsley-required="true" %}
+                    <div class="error-block">{{ form.password1.errors }}</div>
+                </div>
+
+                <div class="form-group{% if form.password2.errors %} has-error{% endif %}">
+                    <label class="control-label" for="id_password2">{% trans "Confirm the new password" %}</label>
+                    {% render_field form.password2 class+="form-control input-lg" placeholder="" data-parsley-required="true" data-parsley-equalto="#id_password1" %}
+                    <div class="error-block">{{ form.password2.errors }}</div>
+                </div>
+
+                <input class="btn btn-primary btn-lg btn-block text-uppercase" type="submit" name="action" value="{% trans 'Change password' %}"/>
+
             </form>
         {% else %}
             <p>{% trans 'Your password is now changed.' %}</p>

--- a/cadasta/templates/allauth/account/password_reset_from_key.html
+++ b/cadasta/templates/allauth/account/password_reset_from_key.html
@@ -4,14 +4,16 @@
 {% block head_title %}{% trans "Change Password" %}{% endblock %}
 
 {% block content %}
-    <h1>{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
+
+<div class="narrow">
+    <h1>{% if token_fail %}{% trans "Bad token" %}{% else %}{% trans "Change password" %}{% endif %}</h1>
 
     {% if token_fail %}
         {% url 'account_reset_password' as passwd_reset_url %}
         <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
     {% else %}
         {% if form %}
-            <form method="POST" action="." novalidate>
+            <form method="POST" action="." data-parsley-validate>
                 {% csrf_token %}
                 {{ form.as_p }}
                 <input type="submit" name="action" value="{% trans 'change password' %}"/>
@@ -20,4 +22,6 @@
             <p>{% trans 'Your password is now changed.' %}</p>
         {% endif %}
     {% endif %}
+</div>
+
 {% endblock %}

--- a/cadasta/templates/allauth/account/password_reset_from_key_done.html
+++ b/cadasta/templates/allauth/account/password_reset_from_key_done.html
@@ -4,6 +4,10 @@
 {% block head_title %}{% trans "Change Password" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Change Password" %}</h1>
+
+<div class="narrow">
+    <h1>{% trans "Change password" %}</h1>
     <p>{% trans 'Your password is now changed.' %}</p>
+</div>
+
 {% endblock %}

--- a/cadasta/templates/allauth/account/password_set.html
+++ b/cadasta/templates/allauth/account/password_set.html
@@ -5,11 +5,12 @@
 {% block head_title %}{% trans "Set Password" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Set Password" %}</h1>
 
-    <form method="POST" action="{% url 'account_set_password' %}" class="password_set" novalidate>
-        {% csrf_token %}
-        {{ form.as_p }}
-        <input type="submit" name="action" value="{% trans 'Set Password' %}"/>
+    <form method="POST" action="{% url 'account_set_password' %}" class="password_set form-narrow">
+    {% csrf_token %}
+        <h1>{% trans "Set password" %}</h1>
+		{{ form.as_p }}
+        <input class="btn btn-block btn-primary btn-lg text-uppercase" type="submit" name="action" value="{% trans 'Set Password' %}"/>
     </form>
+
 {% endblock %}

--- a/cadasta/templates/allauth/account/signup_closed.html
+++ b/cadasta/templates/allauth/account/signup_closed.html
@@ -5,7 +5,10 @@
 {% block head_title %}{% trans "Sign Up Closed" %}{% endblock %}
 
 {% block content %}
-<h1>{% trans "Sign Up Closed" %}</h1>
 
-<p>{% trans "We are sorry, but the sign up is currently closed." %}</p>
+<div class="narrow">
+	<h1>{% trans "Sign up closed" %}</h1>
+	<p>{% trans "We are sorry, but the sign up is currently closed." %}</p>
+</div>
+
 {% endblock %}

--- a/cadasta/templates/allauth/account/snippets/already_logged_in.html
+++ b/cadasta/templates/allauth/account/snippets/already_logged_in.html
@@ -2,4 +2,6 @@
 {% load account %}
 
 {% user_display user as user_display %}
-<p class="alert alert-info">{% blocktrans %}You are currently logged in as <strong>{{ user_display }}</strong>.{% endblocktrans %}</p>
+<p class="alert alert-info alert-full">
+	{% blocktrans %}You are currently logged in as <strong>{{ user_display }}</strong>.{% endblocktrans %}
+</p>

--- a/cadasta/templates/allauth/account/verification_sent.html
+++ b/cadasta/templates/allauth/account/verification_sent.html
@@ -2,11 +2,16 @@
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock %}
+{% block head_title %}{% trans "Verify Your Email Address" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Verify Your E-mail Address" %}</h1>
 
-    <p>{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. Please <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
+<div class="narrow">
+
+	<h1>{% trans "Verify your email address" %}</h1>
+
+	<p>{% blocktrans %}We have sent an email to you for verification. Follow the link provided to finalize the signup process. Please <a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
+
+</div>
 
 {% endblock %}

--- a/cadasta/templates/allauth/account/verified_email_required.html
+++ b/cadasta/templates/allauth/account/verified_email_required.html
@@ -2,22 +2,26 @@
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock %}
+{% block head_title %}{% trans "Verify Your Email Address" %}{% endblock %}
 
 {% block content %}
-<h1>{% trans "Verify Your E-mail Address" %}</h1>
 
-{% url 'account_email' as email_url %}
+<div class="narrow">
 
-<p>{% blocktrans %}This part of the site requires us to verify that
-you are who you claim to be. For this purpose, we require that you
-verify ownership of your e-mail address. {% endblocktrans %}</p>
+	<h1>{% trans "Verify your email address" %}</h1>
 
-<p>{% blocktrans %}We have sent an e-mail to you for
-verification. Please click on the link inside this e-mail. Please
-<a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
+	{% url 'account_email' as email_url %}
 
-<p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your e-mail address</a>.{% endblocktrans %}</p>
+	<p>{% blocktrans %}This part of the site requires us to verify that
+	you are who you claim to be. For this purpose, we require that you
+	verify ownership of your email address. {% endblocktrans %}</p>
 
+	<p>{% blocktrans %}We have sent an email to you for
+	verification. Please click on the link inside this email. Please
+	<a href="mailto:support@cadasta.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
+
+	<p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your email address</a>.{% endblocktrans %}</p>
+
+</div>
 
 {% endblock %}

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -38,7 +38,7 @@
               aria-haspopup="true" aria-expanded="false">
                 <img src="/static/img/avatar.jpg" class="avatar thumbnail">
                 <span class="visible-xs-inline glyphicon glyphicon-user"></span>
-                <span class="visible-sm-inline visible-md-inline visible-lg-inline">
+                <span class="username visible-sm-inline visible-md-inline visible-lg-inline">
                   {% if user.full_name %}
                   {{ user.full_name }}
                   {% else %}


### PR DESCRIPTION
### Proposed changes in this pull request

- Removed hyphenated "email" from email message text and html pages
- Updated css on misc. account pages to bring into fold
- Added fix so long user names don't break header format

### When should this PR be merged

- When convenient

### Risks

- Don't foresee any

### Follow up actions

----------------------------------------------------------------------------

Completes #709 and #591.

Remove hyphen from email

CSS changes

Updated title on confirm email

Password reset form