### PR TITLE
Remove postgis-2.1 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ python:
   - '3.5'
 addons:
   postgresql: '9.4'
-  apt:
-    packages:
-      - postgresql-9.4-postgis-2.1
 
 before_install:
   - export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Proposed changes in this pull request

- Removes postgis-2.1 from travis script, because it broke the builds and we overwrite it with postgis-2.2 anyway

### When should this PR be merged

ASAP

### Risks

None

### Follow up actions

- Everyone should rebase after this is merge, otherwise builds of feature branches will continue to fail