### PR TITLE
Caching for tutelary

### DIFF
--- a/cadasta/config/settings/dev.py
+++ b/cadasta/config/settings/dev.py
@@ -68,6 +68,12 @@ LEAFLET_CONFIG['TILES'][0] = (
     LEAFLET_CONFIG['TILES'][0][2]
 )
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
 # Debug logging...
 LOGGING = {
     'version': 1,

--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -58,12 +58,6 @@ STATIC_ROOT = '/opt/cadasta/cadasta-platform/cadasta/static/'
 MEDIA_URL = '/media/'
 MEDIA_ROOT = '/opt/cadasta/cadasta-platform/cadasta/media/'
 
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-    }
-}
-
 # Debug logging...
 LOGGING = {
     'version': 1,

--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -58,6 +58,12 @@ STATIC_ROOT = '/opt/cadasta/cadasta-platform/cadasta/static/'
 MEDIA_URL = '/media/'
 MEDIA_ROOT = '/opt/cadasta/cadasta-platform/cadasta/media/'
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
 # Debug logging...
 LOGGING = {
     'version': 1,

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -14,7 +14,7 @@ djangorestframework-gis==0.10.1
 jsonschema==2.5.1
 rfc3987==1.3.5
 drfdocs-cadasta==0.0.12
-django-tutelary==0.1.19
+django-tutelary==0.1.20
 django-audit-log==0.7.0
 django-simple-history==1.8.1
 simplejson==3.8.1


### PR DESCRIPTION
### Proposed changes in this pull request

- Bump django-tutelary version.
- Add cache configuration to development and production settings.

*The cache configuration in this PR at the moment is set up the same for development and production.  For development, this is the correct `DummyCache` backend.  For production, this needs to be updated to use `memcached` once `memcached` is included in the provisioning setup.*

### When should this PR be merged

**This PR should not be merged until @amplifi has modified it to include `memcached` setup in the production provisioning scripts.**

### Risks

There shouldn't be any risk to this.  It's just caching, and before these changes, django-tutelary wasn't doing any across-process cache invalidation of its internal caches, so this can only make things better!

### Follow up actions

I don't know how to do this, but it would be good to have some diagnostics to demonstrate that the cache is really working.