### PR TITLE
Enhancement/#354 Cron task to prune MEDIA_ROOT files

### DIFF
--- a/provision/roles/webserver/production/tasks/main.yml
+++ b/provision/roles/webserver/production/tasks/main.yml
@@ -92,6 +92,13 @@
         src="{{ application_path }}app/dist"
         state=link
 
+- name: Create cron job to prune MEDIA_ROOT files
+  become: yes
+  become_user: root
+  cron: name="prune django media files" minute=5 hour=0
+        user="root"
+        job="find {{ application_path }}cadasta/media/s3/* -type f -ctime +1  -exec rm {} \\; > /var/log/django/prune_media.log"
+
 - name: Copy uwsgi_params to base directory
   become: yes
   become_user: "{{ app_user }}"

--- a/provision/roles/webserver/production/templates/uwsgi.ini
+++ b/provision/roles/webserver/production/templates/uwsgi.ini
@@ -16,7 +16,7 @@ chmod-socket = 666
 vacuum = true
 
 pidfile = /tmp/cadasta-master.pid
-harakiri = 20
+harakiri = 60
 max-requests = 5000
 daemonize = /var/log/uwsgi/cadasta.log
 


### PR DESCRIPTION
### Proposed changes in this pull request

Updates the Ansible deployment template to create a cron job that runs daily at 12:05AM, prunes files in MEDIA_ROOT that are at least 1 day old, and logs the results to a file.

Also includes an update to the uwsgi.ini template to increase harakiri duration for the worker processes (this change was already rolled out and made in another template location; keeping things consistent).

### When should this PR be merged

Anytime

### Risks

Very low; Ansible deployment code changes only 

### Follow up actions

None