### PR TITLE
Fix #389: Fix weird multi-language attribute labels

### DIFF
--- a/cadasta/party/forms.py
+++ b/cadasta/party/forms.py
@@ -1,8 +1,8 @@
-from jsonattrs.forms import AttributeModelForm
+from questionnaires.forms import AttributeMultiLangModelForm
 from .models import Party, TenureRelationshipType, TenureRelationship
 
 
-class PartyForm(AttributeModelForm):
+class PartyForm(AttributeMultiLangModelForm):
     attributes_field = 'attributes'
 
     class Meta:
@@ -20,7 +20,7 @@ class PartyForm(AttributeModelForm):
         return instance
 
 
-class TenureRelationshipEditForm(AttributeModelForm):
+class TenureRelationshipEditForm(AttributeMultiLangModelForm):
     attributes_field = 'attributes'
 
     class Meta:

--- a/cadasta/party/views/default.py
+++ b/cadasta/party/views/default.py
@@ -1,10 +1,10 @@
 from core.views import generic
 import django.views.generic as base_generic
 from django.core.urlresolvers import reverse
-from jsonattrs.mixins import JsonAttrsMixin
 from core.mixins import LoginPermissionRequiredMixin, update_permissions
 
 from organization.views import mixins as organization_mixins
+from questionnaires.views.mixins import JsonAttrsMultiLangMixin
 from resources.forms import AddResourceFromLibraryForm
 from resources.views import mixins as resource_mixins
 from . import mixins
@@ -39,7 +39,7 @@ class PartiesAdd(LoginPermissionRequiredMixin,
 
 
 class PartiesDetail(LoginPermissionRequiredMixin,
-                    JsonAttrsMixin,
+                    JsonAttrsMultiLangMixin,
                     mixins.PartyObjectMixin,
                     organization_mixins.ProjectAdminCheckMixin,
                     resource_mixins.HasUnattachedResourcesMixin,
@@ -104,7 +104,7 @@ class PartyResourcesNew(LoginPermissionRequiredMixin,
 
 
 class PartyRelationshipDetail(LoginPermissionRequiredMixin,
-                              JsonAttrsMixin,
+                              JsonAttrsMultiLangMixin,
                               mixins.PartyRelationshipObjectMixin,
                               organization_mixins.ProjectAdminCheckMixin,
                               resource_mixins.HasUnattachedResourcesMixin,

--- a/cadasta/questionnaires/forms.py
+++ b/cadasta/questionnaires/forms.py
@@ -1,0 +1,12 @@
+from jsonattrs.forms import AttributeModelForm
+from .functions import select_multilang_field_label
+
+
+class AttributeMultiLangModelForm(AttributeModelForm):
+    def add_attribute_fields(self, schema_selectors):
+        """For each field label of the form, this method runs the
+        select_multilang_field_label() function to get the correct label."""
+        super().add_attribute_fields(schema_selectors)
+        for key, field in self.fields.items():
+            if field.label:
+                field.label = select_multilang_field_label(field.label)

--- a/cadasta/questionnaires/functions.py
+++ b/cadasta/questionnaires/functions.py
@@ -1,0 +1,24 @@
+import json
+
+from django.utils import translation
+
+
+def select_multilang_field_label(label):
+    """This function checks if the supplied label is a valid JSON string so it
+    can return the appropriate language label from the embedded JSON object.
+    Otherwise the label is returned as is."""
+    try:
+        label_data = json.loads(label)
+        lang_code = translation.get_language()
+        lang_info = translation.get_language_info(lang_code)
+        lang_name = lang_info['name']
+        lang_native_name = lang_info['name_local']
+        if lang_name in label_data:
+            return label_data[lang_name]
+        if lang_native_name in label_data:
+            return label_data[lang_native_name]
+        if lang_code in label_data:
+            return label_data[lang_code]
+        return label_data['default']
+    except json.decoder.JSONDecodeError:
+        return label

--- a/cadasta/questionnaires/migrations/0010_alter_multilanguage_labels_to_json.py
+++ b/cadasta/questionnaires/migrations/0010_alter_multilanguage_labels_to_json.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import ast
+import json
+from jsonattrs.models import Attribute
+from django.db import migrations
+
+
+def alter_multilanguage_labels_to_json(apps, schema_editor):
+    for attr in Attribute.objects.all():
+        label = attr.long_name
+        try:
+            dict_data = ast.literal_eval(label)
+            attr.long_name = json.dumps(dict_data)
+            attr.save()
+        except:
+            pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('questionnaires', '0009_set_question_option_index_field_properties'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            alter_multilanguage_labels_to_json,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/cadasta/questionnaires/tests/test_functions.py
+++ b/cadasta/questionnaires/tests/test_functions.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+from django.utils.translation import activate
+from ..functions import select_multilang_field_label
+
+
+class SelectMultilangFieldLabelTest(TestCase):
+    def test_normal_string_label(self):
+        assert select_multilang_field_label("Label") == "Label"
+
+    def test_default_from_multilanguage_label(self):
+        label = '{"default": "Label", "Deutsch": "Etikett"}'
+        assert select_multilang_field_label(label) == "Label"
+
+    def test_lang_code_from_multilanguage_label(self):
+        activate('de')
+        label = '{"default": "Label", "de": "Etikett"}'
+        assert select_multilang_field_label(label) == "Etikett"
+        activate('en-us')
+
+    def test_lang_name_from_multilanguage_label(self):
+        activate('de')
+        label = '{"default": "Label", "German": "Etikett"}'
+        assert select_multilang_field_label(label) == "Etikett"
+        activate('en-us')
+
+    def test_lang_native_name_from_multilanguage_label(self):
+        activate('de')
+        label = '{"default": "Label", "Deutsch": "Etikett"}'
+        assert select_multilang_field_label(label) == "Etikett"
+        activate('en-us')

--- a/cadasta/questionnaires/views/mixins.py
+++ b/cadasta/questionnaires/views/mixins.py
@@ -1,0 +1,12 @@
+from jsonattrs.mixins import JsonAttrsMixin
+from ..functions import select_multilang_field_label
+
+
+class JsonAttrsMultiLangMixin(JsonAttrsMixin):
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        attrs = context[self.attributes_field]
+        context[self.attributes_field] = [
+            (select_multilang_field_label(a[0]), a[1]) for a in attrs
+        ]
+        return context

--- a/cadasta/spatial/forms.py
+++ b/cadasta/spatial/forms.py
@@ -4,16 +4,18 @@ from django.utils.translation import ugettext as _
 from django.contrib.contenttypes.models import ContentType
 
 from jsonattrs.models import Schema, compose_schemas
-from jsonattrs.forms import form_field_from_name, AttributeModelForm
+from jsonattrs.forms import form_field_from_name
 
 from leaflet.forms.widgets import LeafletWidget
 from core.util import ID_FIELD_LENGTH
 from party.models import Party, TenureRelationship, TenureRelationshipType
+from questionnaires.forms import AttributeMultiLangModelForm
+from questionnaires.functions import select_multilang_field_label
 from .models import SpatialUnit, TYPE_CHOICES
 from .widgets import SelectPartyWidget, NewEntityWidget
 
 
-class LocationForm(AttributeModelForm):
+class LocationForm(AttributeMultiLangModelForm):
     geometry = gisforms.GeometryField(
         widget=LeafletWidget(),
         error_messages={
@@ -112,7 +114,7 @@ class TenureRelationshipForm(forms.Form):
             atype = attr.attr_type
             initial = self.data.get(fieldname, '')
             args = {
-                'label': attr.long_name,
+                'label': select_multilang_field_label(attr.long_name),
                 'required': False,
                 'initial': initial
             }

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -1,5 +1,4 @@
 import json
-from jsonattrs.mixins import JsonAttrsMixin
 import django.views.generic as base_generic
 from core.views import generic
 from django.core.urlresolvers import reverse
@@ -8,6 +7,7 @@ from core.mixins import LoginPermissionRequiredMixin, update_permissions
 
 from resources.forms import AddResourceFromLibraryForm
 from resources.views import mixins as resource_mixins
+from questionnaires.views.mixins import JsonAttrsMultiLangMixin
 from party.messages import TENURE_REL_CREATE
 from . import mixins
 from organization.views import mixins as organization_mixins
@@ -59,7 +59,7 @@ class LocationsAdd(LoginPermissionRequiredMixin,
 
 
 class LocationDetail(LoginPermissionRequiredMixin,
-                     JsonAttrsMixin,
+                     JsonAttrsMultiLangMixin,
                      mixins.SpatialUnitObjectMixin,
                      organization_mixins.ProjectAdminCheckMixin,
                      resource_mixins.HasUnattachedResourcesMixin,


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #389:
    - *Background:* The weird formatting seen is due to having multi-language labels in the XLSForm and what is seen is exactly how pyxform represents these labels (as a dictionary where the language is the key ("default" for the default label). Because django-jsonattrs is not structured to handle multi-language `long_name`s, these multi-language labels should be stored somehow since they are useful.
    - On the XLSForm ingestion side, store the multi-language structure as JSON instead of stringified Python. Using JSON allows us to easily distinguish between normal labels and JSON-structured multi-language labels via a JSON parsing attempt. Plus JSON is more secure than Python code.
    - Create a unit test for the above.
    - On the output side, create a function `select_multilang_field_label()` that takes either a normal label or the JSON multi-language labels and returns the appropriate language label depending on the current language based on either its language code, English name, or native name. This is because there is no specification for "otherLanguage" in XLSForm, so we try all reasonable language forms.
    - Create 5 unit tests for the above.
    - Create `JsonAttrsMultiLangMixin`, a wrapper for jsonattrs' `JsonAttrsMixin`, that runs all of the attribute labels through `select_multilang_field_label()`.
    - Use the above wrapper in place of `JsonAttrsMixin` in 3 views.
    - Create `AttributeMultiLangModelForm`, a wrapper for jsonattrs' `AttributeModelForm`, that runs all of the attribute field labels through `select_multilang_field_label()`.
    - Use the above wrapper in place of `AttributeModelForm` in 3 forms.
    - Directly use `select_multilang_field_label()` in `TenureRelationshipForm`.
    - Create a migration to convert to JSON any attribute `long_name`s that have been stored as stringified Python.

### When should this PR be merged
Anytime

### Risks
None foreseen.

### Follow up actions
`./manage.py migrate`
