### PR TITLE
#586: Added support for select_multiple in xls forms

### DIFF
--- a/cadasta/party/tests/test_views_default.py
+++ b/cadasta/party/tests/test_views_default.py
@@ -218,13 +218,37 @@ class PartyDetailTest(ViewTestCase, UserTestCase, TestCase):
             attr_type=attr_type, index=0,
             required=False, omit=False
         )
+        Attribute.objects.create(
+            schema=schema,
+            name='fname_2', long_name='Test field 2',
+            attr_type=AttributeType.objects.get(name='select_one'),
+            choices=['-', 'one', 'two', 'three'],
+            choice_labels=['None', 'Choice 1', 'Choice 2', 'Choice 3'],
+            index=1,
+            required=False, omit=False
+        )
+        Attribute.objects.create(
+            schema=schema,
+            name='fname_3', long_name='Test field 3',
+            attr_type=AttributeType.objects.get(name='select_multiple'),
+            choices=['-', 'one', 'two', 'three'],
+            choice_labels=['None', 'Choice 1', 'Choice 2', 'Choice 3'],
+            index=2,
+            required=False, omit=False
+        )
         self.party = PartyFactory.create(project=self.project,
-                                         attributes={'fname': 'test'})
+                                         attributes={
+                                            'fname': 'test',
+                                            'fname_2': 'two',
+                                            'fname_3': ['one', 'three']
+                                         })
 
     def setup_template_context(self):
         return {'object': self.project,
                 'party': self.party,
-                'attributes': (('Test field', 'test', ), )}
+                'attributes': (('Test field', 'test', ),
+                               ('Test field 2', 'Choice 2', ),
+                               ('Test field 3', 'Choice 1, Choice 3', ))}
 
     def setup_url_kwargs(self):
         return {
@@ -773,15 +797,39 @@ class PartyRelationshipDetailTest(ViewTestCase, UserTestCase, TestCase):
             attr_type=attr_type, index=0,
             required=False, omit=False
         )
+        Attribute.objects.create(
+            schema=schema,
+            name='fname_2', long_name='Test field 2',
+            attr_type=AttributeType.objects.get(name='select_one'),
+            choices=['-', 'one', 'two', 'three'],
+            choice_labels=['None', 'Choice 1', 'Choice 2', 'Choice 3'],
+            index=1,
+            required=False, omit=False
+        )
+        Attribute.objects.create(
+            schema=schema,
+            name='fname_3', long_name='Test field 3',
+            attr_type=AttributeType.objects.get(name='select_multiple'),
+            choices=['-', 'one', 'two', 'three'],
+            choice_labels=['None', 'Choice 1', 'Choice 2', 'Choice 3'],
+            index=2,
+            required=False, omit=False
+        )
         self.relationship = TenureRelationshipFactory.create(
-            project=self.project, attributes={'fname': 'test'})
+            project=self.project, attributes={
+                'fname': 'test',
+                'fname_2': 'two',
+                'fname_3': ['one', 'three']
+            })
 
     def setup_template_context(self):
         return {'object': self.project,
                 'relationship': self.relationship,
                 'location': self.relationship.spatial_unit,
                 'geojson': '{"type": "FeatureCollection", "features": []}',
-                'attributes': (('Test field', 'test', ), )}
+                'attributes': (('Test field', 'test', ),
+                               ('Test field 2', 'Choice 2', ),
+                               ('Test field 3', 'Choice 1, Choice 3', ))}
 
     def setup_url_kwargs(self):
         return {

--- a/cadasta/questionnaires/managers.py
+++ b/cadasta/questionnaires/managers.py
@@ -101,8 +101,12 @@ def create_attrs_schema(project=None, dict=None, content_type=None, errors=[]):
         field = {}
         field['name'] = c.get('name')
         field['long_name'] = c.get('label')
-        # HACK: pyxform strips underscores from xform field names
-        field['attr_type'] = c.get('type').replace(' ', '_')
+        # HACK: pyxform renames select_multiple to select all that apply
+        if c.get('type') == 'select all that apply':
+            field['attr_type'] = 'select_multiple'
+        else:
+            # HACK: pyxform strips underscores from xform field names
+            field['attr_type'] = c.get('type').replace(' ', '_')
         if c.get('default'):
             field['default'] = c.get('default', '')
         if c.get('omit'):

--- a/cadasta/questionnaires/tests/attr_schemas.py
+++ b/cadasta/questionnaires/tests/attr_schemas.py
@@ -124,6 +124,25 @@ location_xform_group = {
             "type": "text",
             "omit": "yes",
             "hint": "Additional Notes"
+        },
+        {
+            "label": "Infrastructure",
+            "name": "infrastructure",
+            "type": "select all that apply",
+            "choices": [
+                {
+                    "name": "water",
+                    "label": "Water",
+                },
+                {
+                    "name": "food",
+                    "label": "Food",
+                },
+                {
+                    "name": "electricity",
+                    "label": "Electricity",
+                },
+            ]
         }
     ]
 }

--- a/cadasta/questionnaires/tests/test_attr_schemas.py
+++ b/cadasta/questionnaires/tests/test_attr_schemas.py
@@ -104,7 +104,8 @@ class CreateAttributeSchemaTest(UserTestCase, TestCase):
         spatial_unit = SpatialUnitFactory.create(
             project=project,
             attributes={
-                'quality': 'polygon_high'
+                'quality': 'polygon_high',
+                'infrastructure': ['water', 'food']
             }
         )
         assert 1 == Schema.objects.all().count()
@@ -114,6 +115,8 @@ class CreateAttributeSchemaTest(UserTestCase, TestCase):
             project.organization.pk, project.pk, project.current_questionnaire]
         assert 'quality' in spatial_unit.attributes.attributes
         assert 'polygon_high' == spatial_unit.attributes['quality']
+        assert 'infrastructure' in spatial_unit.attributes.attributes
+        assert 'water' in spatial_unit.attributes['infrastructure']
         # notes field is omitted in xform
         assert 'notes' not in spatial_unit.attributes.attributes
 

--- a/cadasta/spatial/tests/test_views_default.py
+++ b/cadasta/spatial/tests/test_views_default.py
@@ -259,15 +259,39 @@ class LocationDetailTest(ViewTestCase, UserTestCase, TestCase):
             attr_type=attr_type, index=0,
             required=False, omit=False
         )
+        Attribute.objects.create(
+            schema=schema,
+            name='fname_2', long_name='Test field 2',
+            attr_type=AttributeType.objects.get(name='select_one'),
+            choices=['-', 'one', 'two', 'three'],
+            choice_labels=['None', 'Choice 1', 'Choice 2', 'Choice 3'],
+            index=1,
+            required=False, omit=False
+        )
+        Attribute.objects.create(
+            schema=schema,
+            name='fname_3', long_name='Test field 3',
+            attr_type=AttributeType.objects.get(name='select_multiple'),
+            choices=['-', 'one', 'two', 'three'],
+            choice_labels=['None', 'Choice 1', 'Choice 2', 'Choice 3'],
+            index=2,
+            required=False, omit=False
+        )
         self.location = SpatialUnitFactory.create(
-            project=self.project, attributes={'fname': 'test'})
+            project=self.project, attributes={
+                'fname': 'test',
+                'fname_2': 'two',
+                'fname_3': ['one', 'three']
+            })
 
     def setup_template_context(self):
         return {
             'object': self.project,
             'location': self.location,
             'geojson': '{"type": "FeatureCollection", "features": []}',
-            'attributes': (('Test field', 'test', ), ),
+            'attributes': (('Test field', 'test', ),
+                           ('Test field 2', 'Choice 2', ),
+                           ('Test field 3', 'Choice 1, Choice 3', )),
             'is_allowed_add_location': True
         }
 

--- a/cadasta/xforms/mixins/model_helper.py
+++ b/cadasta/xforms/mixins/model_helper.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.core.files.storage import get_storage_class
 from django.db import transaction
 from django.utils.translation import ugettext as _
+from jsonattrs.models import Attribute, AttributeType
 from party.models import Party, TenureRelationship, TenureRelationshipType
 from pyxform.xform2json import XFormToDict
 from questionnaires.models import Questionnaire, Question
@@ -346,7 +347,14 @@ class ModelHelper():
         for attr_group in data:
             if '{model}_attributes'.format(model=model_type) in attr_group:
                 for item in data[attr_group]:
-                    attributes[item] = data[attr_group][item]
+                    if Attribute.objects.filter(
+                        name=item,
+                        attr_type=AttributeType.objects.get(
+                                    name='select_multiple')).exists():
+                        answers = data[attr_group][item].split(' ')
+                        attributes[item] = answers
+                    else:
+                        attributes[item] = data[attr_group][item]
         return attributes
 
     def _get_resource_files(self, data, model_type):

--- a/cadasta/xforms/tests/attr_schemas.py
+++ b/cadasta/xforms/tests/attr_schemas.py
@@ -94,6 +94,25 @@ location_xform_group = {
             "name": "name",
             "type": "text",
             "hint": "Name of the location"
+        },
+        {
+            "label": "Infrastructure",
+            "name": "infrastructure",
+            "type": "select all that apply",
+            "choices": [
+                {
+                    "name": "water",
+                    "label": "Water",
+                },
+                {
+                    "name": "food",
+                    "label": "Food",
+                },
+                {
+                    "name": "electricity",
+                    "label": "Electricity",
+                },
+            ]
         }
     ]
 }
@@ -105,7 +124,7 @@ location_relationship_xform_group = {
             "name": "notes",
             "label": "Notes",
             "type": "text"
-        }
+        },
     ],
     "label": "Location relationship attributes",
     "type": "group"

--- a/cadasta/xforms/tests/files/test_resources.py
+++ b/cadasta/xforms/tests/files/test_resources.py
@@ -19,6 +19,7 @@ STANDARD = '''<?xml version=\'1.0\' ?>
         <tenure_type>LH</tenure_type>
         <location_attributes>
             <name>Middle Earth</name>
+            <infrastructure>water food electricity</infrastructure>
         </location_attributes>
         <party_attributes_default>
             <notes>Party attribute default notes.</notes>

--- a/cadasta/xforms/tests/test_views_api.py
+++ b/cadasta/xforms/tests/test_views_api.py
@@ -249,7 +249,9 @@ class XFormSubmissionTest(APITestCase, UserTestCase, TestCase):
         assert response.status_code == 201
 
         party = Party.objects.get(name='Bilbo Baggins')
-        location = SpatialUnit.objects.get(attributes={'name': 'Middle Earth'})
+        location = SpatialUnit.objects.get(
+            attributes={'name': 'Middle Earth',
+                        'infrastructure': ['water', 'food', 'electricity']})
         tenure = TenureRelationship.objects.get(party=party)
         assert tenure.spatial_unit == location
         self._test_resource('test_image_one', location)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -23,7 +23,7 @@ django-buckets==0.1.16
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.2.0
-django-jsonattrs==0.1.13
+django-jsonattrs==0.1.15
 openpyxl==2.3.5
 pytz==2016.4
 shapely==1.5.16


### PR DESCRIPTION
### Proposed changes in this pull request
- Adds support for `select_multiple` in xls form uploads (#586)
- Adds support for `select_multiple` digestion through ODK
- Adds support for `select_multiple` in the platform UI
- Updated version of jsonattrs (1.1.15)
- Added tests for JsonAttrsMixin render
### When should this PR be merged
- So this is going to conflict with my other PR #738 , so once either this one or the other is pulled in, I'll need to rebase and clean some stuff up.

### Risks
- None

### Follow up actions
- Update documentation to indicate that select_multiple is now available.