### PR TITLE
fixing https://github.com/Cadasta/cadasta-platform/issues/758

### DIFF
--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -105,7 +105,11 @@
             <ul class="list-unstyled list-divider">
             {% for user in organization.users.all %}
               <li>
-                <strong>{{ user.full_name }}</strong><br />{% trans "Username" %}: {{ user.username }}
+                <strong>
+                    {{ user.get_display_name }}
+                </strong>
+                <br />
+                {% trans "Username" %}: {{ user.username }}
               </li>
             {% endfor %}
             </ul>

--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -105,11 +105,10 @@
             <ul class="list-unstyled list-divider">
             {% for user in organization.users.all %}
               <li>
-                <strong>
-                    {{ user.get_display_name }}
-                </strong>
-                <br />
-                {% trans "Username" %}: {{ user.username }}
+                <strong>{{ user.username }}</strong>
+                {% if user.full_name %}
+                  <br />{{ user.full_name }}
+                {% endif %}
               </li>
             {% endfor %}
             </ul>

--- a/functional_tests/organizations/test_organization.py
+++ b/functional_tests/organizations/test_organization.py
@@ -33,7 +33,7 @@ class OrganizationTest(FunctionalTest):
         info = page.get_org_description_and_members()
         assert "This is a test." in info
         assert "Test User" in info
-        assert "Username: testuser" in info
+        assert "testuser" in info
         self.logout()
 
         LoginPage(self).login('testuser', 'password')
@@ -44,7 +44,7 @@ class OrganizationTest(FunctionalTest):
         info = page.get_org_description_and_members()
         assert "This is a test." in info
         assert "Test User" in info
-        assert "Username: testuser" in info
+        assert "testuser" in info
 
     def test_edit_organization(self):
         """A registered admin user can edit an organization's information."""


### PR DESCRIPTION
### Proposed changes in this pull request

Fixing https://github.com/Cadasta/cadasta-platform/issues/758
Issue Description : When user has no full name empty space there on top of that users' username in organization member side menu

-
-
-

### When should this PR be merged

No preconditions


-
-
-

### Risks

No Risks

-
-
-

### Follow up actions

No follow up actions

-
-
-

