### PR TITLE
Bugfix/#582

### DIFF
--- a/cadasta/resources/models.py
+++ b/cadasta/resources/models.py
@@ -107,6 +107,10 @@ class Resource(RandomIDModel):
     def num_entities(self):
         return ContentObject.objects.filter(resource=self).count()
 
+    def save(self, *args, **kwargs):
+        create_thumbnails(self, (not self.id))
+        super().save(*args, **kwargs)
+
 
 @receiver(models.signals.pre_save, sender=Resource)
 def archive_file(sender, instance, **kwargs):
@@ -122,8 +126,7 @@ def archive_file(sender, instance, **kwargs):
         ContentObject.objects.filter(resource=instance).delete()
 
 
-@receiver(models.signals.post_save, sender=Resource)
-def create_thumbnails(sender, instance, created, **kwargs):
+def create_thumbnails(instance, created):
     if created or instance._original_url != instance.file.url:
         if 'image' in instance.mime_type:
             io.ensure_dirs()

--- a/cadasta/resources/tests/test_models.py
+++ b/cadasta/resources/tests/test_models.py
@@ -9,9 +9,9 @@ from django.conf import settings
 from django.test import TestCase
 from django.utils.translation import gettext as _
 
+from accounts.tests.factories import UserFactory
 from ..exceptions import InvalidGPXFile
-from ..models import (ContentObject, Resource, create_spatial_resource,
-                      create_thumbnails)
+from ..models import ContentObject, Resource, create_spatial_resource
 from .factories import ResourceFactory, SpatialResourceFactory
 from .utils import clear_temp  # noqa
 
@@ -174,10 +174,11 @@ class ResourceTest(UserTestCase, TestCase):
         storage = FakeS3Storage()
         file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
         file_name = storage.save('resources/thumb_test.jpg', file)
+        contributor = UserFactory.create()
         resource = ResourceFactory.build(file=file_name,
-                                         mime_type='image/jpeg')
-
-        create_thumbnails(Resource, resource, True)
+                                         mime_type='image/jpeg',
+                                         contributor=contributor)
+        resource.save()
         assert os.path.isfile(os.path.join(
             settings.MEDIA_ROOT, 's3/uploads/resources/thumb_test-128x128.jpg')
         )

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,7 +19,7 @@ django-audit-log==0.7.0
 django-simple-history==1.8.1
 simplejson==3.8.1
 django-widget-tweaks==1.4.1
-django-buckets==0.1.16
+django-buckets==0.1.18
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.2.0


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix #582 
  - Bump django-buckets to 0.1.18
  - Files are now removed from S3 when the resource is removed
- Fix a bug that prevented thumbnails from being created on resource update
  - Since we used a `post_save` hook the `instance._original_url != instance.file.url` never became false. I removed the `post_save` hook from `create_thumbnails` and call it from `Resource.save()` instead. 

### When should this PR be merged

Anytime

### Risks

None

### Follow up actions

N/A
