### PR TITLE
Only active projects appear on member permissions page

### DIFF
--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -210,7 +210,8 @@ class EditOrganizationMemberForm(forms.Form):
             project__organization=org).values('project__id', 'role')
         project_roles = {r['project__id']: r['role'] for r in project_roles}
 
-        for p in self.organization.projects.values_list('id', 'name'):
+        active_projects = self.organization.projects.filter(archived=False)
+        for p in active_projects.values_list('id', 'name'):
             role = project_roles.get(p[0], 'Pb')
 
             self.fields[p[0]] = forms.ChoiceField(

--- a/functional_tests/organizations/test_organization_member.py
+++ b/functional_tests/organizations/test_organization_member.py
@@ -132,9 +132,11 @@ class OrganizationMemberTest(FunctionalTest):
         OrganizationMemberListPage(self).go_to_member_list_page()
         page.go_to_testuser_member_page()
 
+        first_project = page.get_project_title_in_table()
+        assert first_project == 'Test Project'
         options = page.get_permission_options()
         assert options['selected'].text == options['pb'].text
-        options["pm"].click()
+        options['pm'].click()
 
         page.click_submit_button()
         page.go_to_testuser_member_page()

--- a/functional_tests/pages/OrganizationMember.py
+++ b/functional_tests/pages/OrganizationMember.py
@@ -106,6 +106,13 @@ class OrganizationMemberPage(Page):
             self.click_remove_button
         )
 
+    def get_table_data(self, xpath, row):
+        return self.test.table_body(
+            "projects-permissions", "//tr{}//td".format(row) + xpath)
+
+    def get_project_title_in_table(self, row="[1]"):
+        return self.get_table_data("//label", row).text
+
     def get_project_permission(self, xpath):
         return self.test.table_body("projects-permissions", '//select' + xpath)
 


### PR DESCRIPTION
### Proposed changes in this pull request
- Add filter for archived projects in org member edit form
- Doesn't cause conflicts because default permissions are added to all projects, and then changed by the user
- Fixes #763 and #779 

### When should this PR be merged
Whenever, I think it's minor enough that this week would be nice.

### Risks
None

### Follow up actions
None