### PR TITLE
added pre_delete to detach resources from records

### DIFF
--- a/cadasta/party/models.py
+++ b/cadasta/party/models.py
@@ -14,7 +14,7 @@ from organization.models import Project
 from organization.validators import validate_contact
 from simple_history.models import HistoricalRecords
 
-from resources.mixins import ResourceModelMixin
+from resources.mixins import ResourceModelMixin, detach_object_resources
 from spatial.models import SpatialUnit
 from tutelary.decorators import permissioned_model
 
@@ -131,6 +131,9 @@ class Party(ResourceModelMixin, RandomIDModel):
                 'party': self.id,
             },
         )
+
+
+models.signals.pre_delete.connect(detach_object_resources, sender=Party)
 
 
 @fix_model_for_attributes
@@ -312,6 +315,10 @@ class TenureRelationship(ResourceModelMixin, RandomIDModel):
                 'relationship': self.id,
             },
         )
+
+
+models.signals.pre_delete.connect(
+    detach_object_resources, sender=TenureRelationship)
 
 
 class TenureRelationshipType(models.Model):

--- a/cadasta/party/tests/test_models.py
+++ b/cadasta/party/tests/test_models.py
@@ -151,17 +151,6 @@ class PartyRelationshipTest(UserTestCase, TestCase):
                 party2__project=project2
             )
 
-    # def test_detach_party_relationship_resources(self):
-    #     relationship = PartyRelationshipFactory()
-    #     resource = ResourceFactory.create()
-    #     ContentObject.objects.create(
-    #         object_id=relationship.id,
-    #         resource=resource,)
-
-    #     relationship.delete()
-    #     assert not ContentObject.objects.filter(
-    #         object_id=relationship.id, resource=resource).exists()
-
 
 class TenureRelationshipTest(UserTestCase, TestCase):
 

--- a/cadasta/party/tests/test_models.py
+++ b/cadasta/party/tests/test_models.py
@@ -7,6 +7,8 @@ from django.contrib.contenttypes.models import ContentType
 from jsonattrs.models import Attribute, AttributeType, Schema
 from core.tests.utils.cases import UserTestCase
 from organization.tests.factories import ProjectFactory
+from resources.tests.factories import ResourceFactory
+from resources.models import ContentObject
 from party.models import Party, TenureRelationshipType
 from party.tests.factories import (PartyFactory, PartyRelationshipFactory,
                                    TenureRelationshipFactory)
@@ -64,11 +66,26 @@ class PartyTest(UserTestCase, TestCase):
                 prj=party.project.slug,
                 id=party.id))
 
+    def test_detach_party_resources(self):
+        project = ProjectFactory.create()
+        party = PartyFactory.create(project=project)
+        resource = ResourceFactory.create(project=project)
+        resource.content_objects.create(
+            content_object=party)
+
+        assert ContentObject.objects.filter(
+            object_id=party.id, resource=resource).exists()
+        assert resource in party.resources
+
+        party.delete()
+        assert not ContentObject.objects.filter(
+            object_id=party.id, resource=resource).exists()
+
 
 class PartyRelationshipTest(UserTestCase, TestCase):
 
     def test_str(self):
-        project = ProjectFactory(name='TestProject')
+        project = ProjectFactory.create(name='TestProject')
         relationship = PartyRelationshipFactory(
             project=project,
             party1__project=project,
@@ -133,6 +150,17 @@ class PartyRelationshipTest(UserTestCase, TestCase):
                 party1__project=project1,
                 party2__project=project2
             )
+
+    # def test_detach_party_relationship_resources(self):
+    #     relationship = PartyRelationshipFactory()
+    #     resource = ResourceFactory.create()
+    #     ContentObject.objects.create(
+    #         object_id=relationship.id,
+    #         resource=resource,)
+
+    #     relationship.delete()
+    #     assert not ContentObject.objects.filter(
+    #         object_id=relationship.id, resource=resource).exists()
 
 
 class TenureRelationshipTest(UserTestCase, TestCase):
@@ -208,6 +236,21 @@ class TenureRelationshipTest(UserTestCase, TestCase):
                 org=tenurerel.project.organization.slug,
                 prj=tenurerel.project.slug,
                 id=tenurerel.id))
+
+    def test_detach_tenure_relationship_resources(self):
+        project = ProjectFactory.create()
+        tenure = TenureRelationshipFactory.create(project=project)
+        resource = ResourceFactory.create(project=project)
+        resource.content_objects.create(
+            content_object=tenure)
+        assert ContentObject.objects.filter(
+            object_id=tenure.id,
+            resource=resource,).exists()
+        assert resource in tenure.resources
+
+        tenure.delete()
+        assert not ContentObject.objects.filter(
+            object_id=tenure.id, resource=resource).exists()
 
 
 class TenureRelationshipTypeTest(UserTestCase, TestCase):

--- a/cadasta/resources/mixins.py
+++ b/cadasta/resources/mixins.py
@@ -22,3 +22,11 @@ class ResourceModelMixin:
     def reload_resources(self):
         if hasattr(self, '_resources'):
             del self._resources
+
+
+def detach_object_resources(sender, instance, **kwargs):
+    for resource in instance.resources:
+        content_object = resource.content_objects.get(
+            object_id=instance.id,
+            resource__project__slug=instance.project.slug)
+        content_object.delete()

--- a/cadasta/spatial/models.py
+++ b/cadasta/spatial/models.py
@@ -14,7 +14,7 @@ from shapely.wkt import dumps
 from . import messages
 from .choices import TYPE_CHOICES
 from .exceptions import SpatialRelationshipError
-from resources.mixins import ResourceModelMixin
+from resources.mixins import ResourceModelMixin, detach_object_resources
 from jsonattrs.fields import JSONAttributeField
 from jsonattrs.decorators import fix_model_for_attributes
 
@@ -144,6 +144,8 @@ def reassign_spatial_geometry(instance):
 def check_extent(sender, instance, **kwargs):
     if instance.geometry:
         reassign_spatial_geometry(instance)
+
+models.signals.pre_delete.connect(detach_object_resources, sender=SpatialUnit)
 
 
 class SpatialRelationshipManager(managers.BaseRelationshipManager):

--- a/cadasta/spatial/tests/test_models.py
+++ b/cadasta/spatial/tests/test_models.py
@@ -5,6 +5,8 @@ from django.test import TestCase
 from jsonattrs.models import Attribute, AttributeType, Schema
 from core.tests.utils.cases import UserTestCase
 from organization.tests.factories import ProjectFactory
+from resources.tests.factories import ResourceFactory
+from resources.models import ContentObject
 from party import exceptions
 from spatial.tests.factories import (SpatialUnitFactory,
                                      SpatialRelationshipFactory)
@@ -95,6 +97,21 @@ class SpatialUnitTest(UserTestCase, TestCase):
                 org=su.project.organization.slug,
                 prj=su.project.slug,
                 id=su.id))
+
+    def test_detach_spatial_unit_resources(self):
+        project = ProjectFactory.create()
+        su = SpatialUnitFactory.create(project=project)
+        resource = ResourceFactory.create(project=project)
+        resource.content_objects.create(
+          content_object=su)
+        assert ContentObject.objects.filter(
+            object_id=su.id,
+            resource=resource,).exists()
+        assert resource in su.resources
+
+        su.delete()
+        assert not ContentObject.objects.filter(
+            object_id=su.id, resource=resource).exists()
 
 
 class SpatialRelationshipTest(UserTestCase, TestCase):

--- a/functional_tests/pages/Project.py
+++ b/functional_tests/pages/Project.py
@@ -93,7 +93,7 @@ class ProjectPage(Page):
             self.click_through(button, self.test.BY_ALERT)
             self.click_on_close_alert_button()
 
-    def click_on_detatch_resource_button(self, location, success=True):
+    def click_on_detach_resource_button(self, location, success=True):
         button = self.test.page_content(
             "//div[contains(@class, '{}')]".format(location) +
             "//button[contains(@class, 'btn-danger')]")

--- a/functional_tests/projects/test_project.py
+++ b/functional_tests/projects/test_project.py
@@ -91,7 +91,7 @@ class ProjectTest(FunctionalTest):
         page.click_on_location_resource_tab()
         page.click_on_add_button('active', success=False)
         page.click_on_location_resource_tab()
-        page.click_on_detatch_resource_button('detail', success=False)
+        page.click_on_detach_resource_button('detail', success=False)
 
         # Test spatial unit relationship tab
         page.click_on_location_relationship_tab()
@@ -103,19 +103,19 @@ class ProjectTest(FunctionalTest):
         page.click_on_edit_button(success=False)
         page.click_on_delete_button(success=False)
         page.click_on_add_button('detail', success=False)
-        page.click_on_detatch_resource_button('detail', success=False)
+        page.click_on_detach_resource_button('detail', success=False)
 
         # Test party page
         page.click_on_party_in_table()
         page.click_on_edit_button(success=False)
         page.click_on_delete_button(success=False)
         page.click_on_add_button('panel-body', success=False)
-        page.click_on_detatch_resource_button('panel-body', success=False)
+        page.click_on_detach_resource_button('panel-body', success=False)
 
         # Test project resource page
         page.click_on_resources_tab()
         page.click_on_add_button('panel-body', success=False)
-        page.click_on_detatch_resource_button('panel-body', success=False)
+        page.click_on_detach_resource_button('panel-body', success=False)
 
         page.click_on_resource_in_table()
         page.click_on_edit_resource_button(success=False)


### PR DESCRIPTION
### Proposed changes in this pull request
- added detach resource methods to models with `ResourceObjectMixin`
- fixes issue #803 

### When should this PR be merged
Whenever

### Risks
None

### Follow up actions
There is commented out code for whenever we implement resources for `PartyRelationship` and `SpatialUnitRelationship`

