### PR TITLE
Fix #794: Avoid error when superuser views org member edit page

### DIFF
--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -667,6 +667,16 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert '/account/login/' in response.location
 
+    def test_get_with_superuser(self):
+        superuser = UserFactory.create()
+        superuser_role = Role.objects.get(name='superuser')
+        superuser.assign_policies(superuser_role)
+        response = self.request(user=superuser)
+        assert response.status_code == 200
+        assert response.content == self.render_content(is_superuser=True,
+                                                       is_administrator=True,
+                                                       add_allowed=True)
+
     def test_get_with_archived_organization(self):
         OrganizationRole.objects.create(organization=self.org, user=self.user)
         assign_policies(self.user)

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -239,15 +239,20 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+
         context['organization'] = self.get_organization()
         context['form'] = self.get_form()
+        try:
+            org_admin = OrganizationRole.objects.get(
+                user=self.request.user,
+                organization=context['organization']).admin
+            context['org_admin'] = (org_admin and
+                                    not self.is_superuser and
+                                    context['org_member'] == self.request.user)
+        except OrganizationRole.DoesNotExist:
+            # Viewing user is a superuser who is not an org member
+            pass
 
-        org_admin = OrganizationRole.objects.get(
-            user=self.request.user,
-            organization=context['organization']).admin
-        context['org_admin'] = (org_admin and
-                                not self.is_superuser and
-                                context['org_member'] == self.request.user)
         return context
 
     def post(self, request, *args, **kwargs):

--- a/cadasta/templates/organization/organization_members_edit.html
+++ b/cadasta/templates/organization/organization_members_edit.html
@@ -37,21 +37,21 @@
                     <div class="form-group member-role{% if form.org_role.errors %} has-error{% endif %}">
                       <label class="control-label" for="{{ form.org_role.id_for_label }}">{% trans "Role" %}</label>
                       {% if org_admin %}
-                        {% render_field form.org_role class+="form-control" data-parsley-required="true" %}
+                      {% render_field form.org_role class+="form-control" data-parsley-required="true" disabled="disabled" %}
                       {% else %}
-                        {% render_field form.org_role class+="form-control" data-parsley-required="true" %}
+                      {% render_field form.org_role class+="form-control" data-parsley-required="true" %}
                       {% endif %}
                       <div class="error-block">{{ form.org_role.errors }}</div>
                     </div>
                     <div class="btn-full">
                       <button type="button" class="btn btn-danger" name="remove" data-toggle="modal" data-target="#remove_confirm"{% if org_admin %} disabled{% endif %}>
                         <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> {% trans "Remove member" %}</button>
-                        {% if org_admin %}
-                          <div class="alert alert-full" role="alert">
-                            <div class="pull-left"><span class="glyphicon glyphicon-info-sign"></span></div>
-                            <div>{% trans "An organization administrator cannot remove themself." %}</div>
-                          </div>
-                        {% endif %}
+                      {% if org_admin %}
+                      <div class="alert alert-full" role="alert">
+                        <div class="pull-left"><span class="glyphicon glyphicon-info-sign"></span></div>
+                        <div>{% trans "An organization administrator cannot remove themself." %}</div>
+                      </div>
+                      {% endif %}
                     </div>
                   </div>
                 </div>

--- a/functional_tests/organizations/test_organization_member.py
+++ b/functional_tests/organizations/test_organization_member.py
@@ -75,18 +75,10 @@ class OrganizationMemberTest(FunctionalTest):
         OrganizationMemberListPage(self).go_to_member_list_page()
         page.go_to_admin_member_page()
 
+        role_select = page.get_member_role_select('')
+        assert role_select.get_attribute('disabled')
         roles = page.get_role_options()
         assert roles["admin"].text == roles["selected"].text
-
-        roles["member"].click()
-        page.click_submit_button()
-        self.get_screenshot()
-        # get error message
-        # assert you stayed on the same page.
-        roles = page.get_role_options()
-        errors = page.get_org_role_error()
-        assert errors.text == ("Organization administrators cannot change" +
-                               " their own role in the organization.")
 
     def test_removing_a_member_from_an_organization(self):
         """An admin member can remove a member from an organization."""


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #794:
    - Add exception handling to `OrganizationMembersEdit.get_context_data()` to avoid the error when the user is a superuser.
    - Add a unit test to catch this bug and to verify that it is fixed.
- Disable the org role select form field when the viewing user is an org admin viewing his/her own member page.
    - (Context: https://github.com/Cadasta/cadasta-platform/commit/1aac076acae061fa2c6e6ead305d4a68fef17e0c#commitcomment-19327831)
    - Update a functional test to reflect the disabled select state. 

### When should this PR be merged
Anytime.

### Risks
None foreseen.

### Follow up actions
None.
