### PR TITLE
Fix #719: Fix URL for canceling adding locations

### DIFF
--- a/cadasta/templates/spatial/location_add.html
+++ b/cadasta/templates/spatial/location_add.html
@@ -73,5 +73,5 @@
 {% endblock %}
 
 {% block content %}
-  {% include "spatial/location_form.html" with title=_("Add new location") cancel_url=request.META.HTTP_REFERER %}
+  {% include "spatial/location_form.html" with title=_("Add new location") %}
 {% endblock %}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,4 +8,4 @@ django-compressor==2.0
 tox==2.3.1
 flake8==2.5.4
 django-debug-toolbar==1.5
-django-skivvy==0.1.0
+django-skivvy==0.1.3


### PR DESCRIPTION
### Proposed changes in this pull request
- Fully fix #719:
    - **Overall bugfix idea:** When the user first loads the add location page (via HTTP GET), the platform checks the HTTP referrer URL and if it exists and it is not the same add location page (the user could click the "Add location" button while on the add location page), then it stores this URL as the `cancel_add_location_url` session variable. Otherwise, the project dashboard URL is stored in that session variable. Later, when the view is rendered, the `cancel_url` context variable is copied from the `cancel_add_location_url` session variable if it exists, otherwise the project dashboard URL is used. This `cancel_url` context variable is used as the URL of the cancel button in the template.
    - Update the `LocationsAdd` view to perform the behavior described above.
    - Update the **spatial/location_add.html** template to remove the reference to the HTTP referrer.
    - Update django-skivvy from 0.1.0 to 0.1.3.
    - Update an existing view unit test and add 3 new view unit tests.
        - Two of the new unit tests uses the new `request_meta` feature of django-skivvy.
        - The remaining new test doesn't fully follow the django-skivvy coding guidelines because it tests the session variable functionality. It loads the view twice (the first sets the session variable, the second checks that the session variable is used). Since django-skivvy creates a brand new `HttpRequest` object everytime `request()` is called, the session is lost. So the test creates and reuses its own `HttpRequest` object. I appreciate any ideas on better ways that this unit test can be implemented.

### When should this PR be merged
This should be merged as part of Sprint 10 (so after Sprint 9 code freeze). But of course, the code can be reviewed now.

### Risks
No risks foreseen.

### Follow up actions
None.
