### PR TITLE
Display user's full name on user list page

### DIFF
--- a/cadasta/templates/organization/user_list.html
+++ b/cadasta/templates/organization/user_list.html
@@ -43,7 +43,7 @@
   </thead>
   {% for user in object_list %}
   <tr class="{{ user.is_active|yesno:_("disabled,active") }}">
-    <td>{{ user.username }}</td>
+    <td><p>{{ user.username }}</p><p>{{ user.full_name }}</p></td>
     <td>{{ user.email }}</td>
     <td>{{ user.org_names|safe }}</td>
     <td>{{ user.last_login|default_if_none:"&mdash;" }}</td>

--- a/functional_tests/pages/Users.py
+++ b/functional_tests/pages/Users.py
@@ -10,7 +10,7 @@ class UsersPage(Page):
     # the user with the specified username
     row_xpath = (
         "//table[@id='DataTables_Table_0']/tbody" +
-        "/tr[./td[1][text()='{0}' and not(*[2])]]"
+        "/tr[./td[1]/p[1][text()='{0}']]"
     )
 
     # XPath to unambiguously search for the form that
@@ -98,9 +98,12 @@ class UsersPage(Page):
     def get_user_cell_value(self, username, cell_pos):
         formatted_xpath = self.row_xpath.format(username)
         user_row = self.browser.find_element_by_xpath(formatted_xpath)
-        cell_xpath = "td[{}][not(*[2])]".format(cell_pos)
+        cell_xpath = "./td[{}]".format(cell_pos)
         cell = user_row.find_element_by_xpath(cell_xpath)
         return cell.text
+
+    def get_user_name(self, username):
+        return self.get_user_cell_value(username, 1)
 
     def get_user_email(self, username):
         return self.get_user_cell_value(username, 2)

--- a/functional_tests/users/test_page_list.py
+++ b/functional_tests/users/test_page_list.py
@@ -20,6 +20,7 @@ class PageListTest(FunctionalTest):
         users.append({
             'username': 'superuser',
             'password': 'password3',
+            'full_name': 'Super User',
             'email': "superuser@example.com",
             'is_active': True,
             '_is_superuser': True,
@@ -85,6 +86,12 @@ class PageListTest(FunctionalTest):
         for user in users:
 
             username = user['username']
+
+            # Check full name is displayed correctly
+            full_name = user.get('full_name', '')
+            expected_name = '{}\n{}'.format(username, full_name).strip()
+            actual_name = users_page.get_user_name(username)
+            assert actual_name == expected_name
 
             # Check email is displayed correctly
             expected_email = user['email'] or '—'


### PR DESCRIPTION
### Proposed changes in this pull request

- Refactor functional tests user creation code
    
    Reuse user creation code whether user is a superuser or not.  Apply the
    superuser role if user is indeed supposed to be a superuser.

- Display user's full name on user list page

  Under the "member" column, it used to show only the user's username, now
  it's showing "username (full name)".

  Close #316

Screenshot from original user list page:
![user-list-old](https://cloud.githubusercontent.com/assets/153353/19415043/adaf50cc-935a-11e6-8336-8ef5b2cd69b8.png)

Screenshot after proposed changes:
![user-list-new](https://cloud.githubusercontent.com/assets/153353/19417437/f7791a72-93a4-11e6-9059-48c168db8ca3.png)

### When should this PR be merged

No preconditions

### Risks

There shouldn't be any.

### Follow up actions

None
