### PR TITLE
Project resource view 'Attach' button hiding from users who doesn't have permission

### DIFF
--- a/cadasta/templates/resources/project_list.html
+++ b/cadasta/templates/resources/project_list.html
@@ -15,6 +15,7 @@
       </div>
       <div class="panel panel-default">
         <div class="panel-body">
+          {% if is_allowed_add_resource %}
           <div class="top-btn pull-right top-add">
             {% if has_unattached_resources %}
             <a class="btn btn-primary btn-sm" href="{% url 'resources:project_add_existing' project=object.slug organization=object.organization.slug %}">
@@ -23,6 +24,7 @@
             {% endif %}
               <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Attach" %}</a>
           </div>
+          {% endif %}
           {% include 'resources/table.html' %}
         </div>
       </div>

--- a/functional_tests/projects/test_project_resources.py
+++ b/functional_tests/projects/test_project_resources.py
@@ -1,0 +1,31 @@
+from base import FunctionalTest
+from fixtures import load_test_data
+from fixtures.common_test_data_2 import get_test_data
+from pages.Login import LoginPage
+from pages.Project import ProjectPage
+from core.tests.factories import PolicyFactory
+from selenium.common.exceptions import NoSuchElementException
+
+
+class ProjectResourceTest(FunctionalTest):
+    def setUp(self):
+        super().setUp()
+        PolicyFactory.load_policies()
+        test_objs = load_test_data(get_test_data())
+        self.org = test_objs['organizations'][0]
+        self.prj = test_objs['projects'][0]
+
+    def test_resource_attach_button_for_non_project_user(self):
+        """Attach button will be hidden from users who doesn't have
+            permission to add resource."""
+
+        LoginPage(self).login('testuser', 'password')
+        page = ProjectPage(self, self.org.slug, self.prj.slug)
+        page.go_to()
+
+        # Test resource tab
+        page.click_on_resources_tab()
+        try:
+            page.click_on_add_button('panel-body', success=False)
+        except NoSuchElementException:
+            assert True


### PR DESCRIPTION
### Proposed changes in this pull request

In the project resources view, hide the 'Attach' button if the user doesn't have the permission to add resource
Fix for https://github.com/Cadasta/cadasta-platform/issues/835

### When should this PR be merged
Whenever possible

