### PR TITLE
Allow accounts loadpolicies command to be run on its own

### DIFF
--- a/cadasta/accounts/management/commands/loadpolicies.py
+++ b/cadasta/accounts/management/commands/loadpolicies.py
@@ -6,5 +6,18 @@ from accounts import load
 class Command(BaseCommand):
     help = """Loads policy data."""
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--force',
+            action='store_true',
+            dest='force',
+            default=False)
+
+        parser.add_argument(
+            '--update',
+            action='store_true',
+            dest='update',
+            default=False)
+
     def handle(self, *args, **options):
         load.run(force=options['force'], update=options['update'])

--- a/cadasta/accounts/tests/test_management_commands_loadpolicies.py
+++ b/cadasta/accounts/tests/test_management_commands_loadpolicies.py
@@ -1,0 +1,34 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+import accounts.load
+
+
+class FakeAccountsLoadRun:
+    args = None
+    kwargs = None
+    call_count = 0
+
+    def __call__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.call_count += 1
+
+
+class LoadPoliciesTest(TestCase):
+    def setUp(self):
+        self.load_run = accounts.load.run
+        accounts.load.run = FakeAccountsLoadRun()
+        self.addCleanup(setattr, accounts.load, 'run', self.load_run)
+
+    def test_command_no_args(self):
+        call_command('loadpolicies')
+        assert accounts.load.run.call_count == 1
+        assert accounts.load.run.args == ()
+        assert accounts.load.run.kwargs == {'force': False, 'update': False}
+
+    def test_command_with_args(self):
+        call_command('loadpolicies', force=True, update=True)
+        assert accounts.load.run.call_count == 1
+        assert accounts.load.run.args == ()
+        assert accounts.load.run.kwargs == {'force': True, 'update': True}


### PR DESCRIPTION
### Proposed changes in this pull request

- Add arguments for accounts loadpolicies command

  Without the arguments, when running `python manage.py loadpolicies`, you
  get a `KeyError`:

  ```
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/karen/cadasta/env/lib/python3.5/site-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
    utility.execute()
  File "/home/karen/cadasta/env/lib/python3.5/site-packages/django/core/management/__init__.py", line 345, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/karen/cadasta/env/lib/python3.5/site-packages/django/core/management/base.py", line 348, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/karen/cadasta/env/lib/python3.5/site-packages/django/core/management/base.py", line 399, in execute
    output = self.handle(*args, **options)
  File "/home/karen/cadasta-platform/cadasta/accounts/management/commands/loadpolicies.py", line 10, in handle
    load.run(force=options['force'], update=options['update'])
KeyError: 'force'
  ```

  Close #836

### When should this PR be merged

When review is complete.

### Risks

There shouldn't be any.

### Follow up actions

If this pull request is accepted, we should look at other `management/commands` directories for other commands that have the same problem.