### PR TITLE
Organization admin role selection changed from disabled to readonly

### DIFF
--- a/cadasta/templates/organization/organization_members_edit.html
+++ b/cadasta/templates/organization/organization_members_edit.html
@@ -37,7 +37,7 @@
                     <div class="form-group member-role{% if form.org_role.errors %} has-error{% endif %}">
                       <label class="control-label" for="{{ form.org_role.id_for_label }}">{% trans "Role" %}</label>
                       {% if org_admin %}
-                      {% render_field form.org_role class+="form-control" data-parsley-required="true" disabled="disabled" %}
+                      {% render_field form.org_role class+="form-control" data-parsley-required="true" readonly="True" %}
                       {% else %}
                       {% render_field form.org_role class+="form-control" data-parsley-required="true" %}
                       {% endif %}

--- a/functional_tests/organizations/test_organization_member.py
+++ b/functional_tests/organizations/test_organization_member.py
@@ -76,7 +76,7 @@ class OrganizationMemberTest(FunctionalTest):
         page.go_to_admin_member_page()
 
         role_select = page.get_member_role_select('')
-        assert role_select.get_attribute('disabled')
+        assert role_select.get_attribute('readonly')
         roles = page.get_role_options()
         assert roles["admin"].text == roles["selected"].text
 


### PR DESCRIPTION
### Proposed changes in this pull request

In member role change view, changed the selection field for role as "readonly" if the currently logged user admin user is editing his member profile.
This is the fix for the issue https://github.com/Cadasta/cadasta-platform/issues/823
### When should this PR be merged

whenever possible
