### PR TITLE
Display username first then full name on projects permissions page

### DIFF
--- a/cadasta/organization/tests/test_widgets.py
+++ b/cadasta/organization/tests/test_widgets.py
@@ -25,8 +25,8 @@ class ProjectRoleWidgetTest(TestCase):
         expected = (
             '<tr>'
             '  <td>'
-            '    <p>Bob Smith</p>'
             '    <p>bob</p>'
+            '    <p>Bob Smith</p>'
             '  </td>'
             '  <td class="hidden-xs hidden-sm">me@example.com</td>'
             '  <td>'
@@ -49,8 +49,8 @@ class ProjectRoleWidgetTest(TestCase):
         expected = (
             '<tr>'
             '  <td>'
-            '    <p>Bob Smith</p>'
             '    <p>bob</p>'
+            '    <p>Bob Smith</p>'
             '  </td>'
             '  <td class="hidden-xs hidden-sm">me@example.com</td>'
             '  <td>'
@@ -71,8 +71,8 @@ class ProjectRoleWidgetTest(TestCase):
         expected = (
             '<tr>'
             '  <td>'
-            '    <p>Bob Smith</p>'
             '    <p>bob</p>'
+            '    <p>Bob Smith</p>'
             '  </td>'
             '  <td class="hidden-xs hidden-sm">me@example.com</td>'
             '  <td>'

--- a/cadasta/organization/widgets.py
+++ b/cadasta/organization/widgets.py
@@ -6,8 +6,8 @@ class ProjectRoleWidget(Select):
     html = (
         '<tr>'
         '  <td>'
-        '    <p>{full_name}</p>'
         '    <p>{username}</p>'
+        '    <p>{full_name}</p>'
         '  </td>'
         '  <td class="hidden-xs hidden-sm">{email}</td>'
         '  <td>'


### PR DESCRIPTION
### Proposed changes in this pull request

- Display username first then full name on projects permissions page

  It was displaying full name first then username, reverse them to be
  consistent with the new pattern.

  Close #818


### When should this PR be merged

No preconditions.

### Risks

None.

### Follow up actions

None.