### PR TITLE
Fixed Issue #820, Already archived projects get unarchived when org is unarchived

### DIFF
--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -430,7 +430,6 @@ class OrganizationArchiveTest(ViewTestCase, UserTestCase, TestCase):
         assert ('/organizations/{}/'.format(self.org.slug)
                 in response.location)
         assert self.org.archived is True
-        assert project.archived is True
 
 
 class OrganizationUnarchiveTest(ViewTestCase, UserTestCase, TestCase):
@@ -486,7 +485,6 @@ class OrganizationUnarchiveTest(ViewTestCase, UserTestCase, TestCase):
         assert ('/organizations/{}/'.format(self.org.slug)
                 in response.location)
         assert self.org.archived is False
-        assert project.archived is False
 
 
 class OrganizationMembersTest(ViewTestCase, UserTestCase, TestCase):

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -140,9 +140,6 @@ class OrgArchiveView(LoginPermissionRequiredMixin,
         self.object = self.get_object()
         self.object.archived = self.do_archive
         self.object.save()
-        for project in self.object.projects.all():
-            project.archived = self.do_archive
-            project.save()
         return redirect(self.get_success_url())
 
 
@@ -366,6 +363,10 @@ class ProjectList(PermissionRequiredMixin,
                                                         ).admin is True:
                             projects.extend(
                                 org.projects.filter(archived=True))
+            for project in projects:
+                if project.organization.archived:
+                    project.archived = True
+
         self.object_list = sorted(
             projects, key=lambda p: p.organization.slug + ':' + p.slug)
         context = self.get_context_data()


### PR DESCRIPTION
###### This is my first Pull Request for OpenSource
### Proposed changes in this pull request
-  Already archived projects get unarchived when org is unarchived
- Working on the possible solution mentioned in the issue -
  
  When the organisation is archived, the projects are archived such that their status is not updated in the database.So, they behave as archived but their status is the same as their original archived status. 
  Now, when the organisation is unarchived, the original archived status is restored. 
  So, the archived projects remain archived.   
-  Change in the tests, where it asserts the status of the project as archived if the status of the organisation is archived ( same for unarchived). 
### When should this PR be merged

No preconditions
### Risks

None
### Follow up actions

None
