### PR TITLE
Provisioning for memcached support

### DIFF
--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -25,6 +25,16 @@ DATABASES = {
     }
 }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+        'LOCATION': [
+            os.environ['MEMCACHED_HOST'],
+        ],
+        'OPTIONS': {'distribution': 'consistent'}
+    }
+}
+
 DJOSER.update({  # NOQA
     'DOMAIN': os.environ['DOMAIN'],
 })

--- a/provision/roles/cadasta/application/tasks/main.yml
+++ b/provision/roles/cadasta/application/tasks/main.yml
@@ -22,6 +22,7 @@
       - libxml2-dev
       - libjpeg-dev
       - libgdal1-dev
+      - libmemcached-dev
 
 - name: dev locale
   become: yes

--- a/provision/roles/cadasta/install/tasks/main.yml
+++ b/provision/roles/cadasta/install/tasks/main.yml
@@ -32,6 +32,7 @@
       S3_ACCESS_KEY="{{ s3_access_key }}"
       S3_SECRET_KEY="{{ s3_secret_key }}"
       DJANGO_SETTINGS_MODULE="{{ django_settings }}"
+      MEMCACHED_HOST="{{ memcached_host }}"
 
 - name: Enable environment variables for SSH
   become: yes
@@ -52,6 +53,7 @@
       Defaults  env_keep += S3_BUCKET
       Defaults  env_keep += S3_ACCESS_KEY
       Defaults  env_keep += S3_SECRET_KEY
+      Defaults  env_keep += MEMCACHED_HOST
 
 # This is VERY ugly.  The problem is that Ansible keeps SSH
 # connections open across tasks, so the environment variable changes

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -28,3 +28,4 @@ openpyxl==2.3.5
 pytz==2016.4
 shapely==1.5.16
 gdal==1.11.2
+pylibmc==1.5.1


### PR DESCRIPTION
### Proposed changes in this pull request

Adds configuration for memcached support to provisioning files. Included changes:

- Installing libmemcached-dev and pylibcmc packages
- Adding env vars for memcached host
- Updated Django production settings file with cache configuation
- Consistent hashing option enabled for multi-node capability

### When should this PR be merged

Anytime. Provisioning only; no platform changes.

### Risks

None

### Follow up actions

None; changes are already in place on staging.