### PR TITLE
Fix 502 errors on resources list page

### DIFF
--- a/cadasta/resources/views/default.py
+++ b/cadasta/resources/views/default.py
@@ -36,6 +36,11 @@ class ProjectResources(LoginPermissionRequiredMixin,
     def get_resource_list(self):
         return self.get_queryset()
 
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context['success_url'] = None
+        return context
+
 
 class ProjectResourcesAdd(LoginPermissionRequiredMixin,
                           mixins.ProjectResourceMixin,
@@ -102,6 +107,7 @@ class ProjectResourcesDetail(LoginPermissionRequiredMixin,
         ]
 
         context['attachment_list'] = attachment_list
+        context['success_url'] = None
         return context
 
 


### PR DESCRIPTION
### Proposed changes in this pull request
Fix the HTTP 502 errors that are encountered on the resources list page by adding the `success_url` = `None` context variable to views that include the `modal_archive` or `modal_unarchive` modals.

### When should this PR be merged
As soon as possible would be good.

### Risks
No risks foreseen.

### Follow up actions
Check that no 502 errors are encountered on staging (because this error doesn't seem to happen on the dev VM or Travis).
