### PR TITLE
Fix None for translated labels

### DIFF
--- a/cadasta/questionnaires/managers.py
+++ b/cadasta/questionnaires/managers.py
@@ -61,7 +61,7 @@ def create_options(options, question, errors=[]):
 
             QuestionOption.objects.create(
                 question=question, index=idx+1, name=o['name'],
-                label_xlat=o.get('label_xlat', o.get('label', None))
+                label_xlat=o.get('label_xlat', o.get('label', {}))
             )
     else:
         errors.append(_("Please provide at least one option for field"


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix #869 
- One line: default for a `get` should be `{}` instead of `None`.

### When should this PR be merged

Any time.

### Risks

None.

### Follow up actions

None.
