### PR TITLE
Add separate cache settings for jsonattrs

### DIFF
--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -40,6 +40,13 @@ CACHES = {
             os.environ['MEMCACHED_HOST'],
         ],
         'OPTIONS': {'distribution': 'consistent'}
+    },
+    'jsonattrs': {
+        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+        'LOCATION': [
+            os.environ['MEMCACHED_HOST'],
+        ],
+        'OPTIONS': {'distribution': 'consistent'}
     }
 }
 


### PR DESCRIPTION
### Proposed changes in this pull request

Adds a separate cache for jsonattrs, as distinct from the 'default' cache used by tutelary. This facilitates flushing of the jsonattrs cache without disturbing the tutelary cache.

### When should this PR be merged

Anytime; changes are already in place on staging.

### Risks

None; provisioning-only change.

### Follow up actions

None