### PR TITLE
Upgrade to Django 1.9.10

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-Django==1.9.6
+Django==1.9.10
 djangorestframework==3.3.3
 psycopg2==2.6.1
 djoser==0.4.3


### PR DESCRIPTION
### Proposed changes in this pull request

Updates requirements to django 1.9.10

### When should this PR be merged

Very soon

### Risks

Low

### Follow up actions

Support for Django 1.9 will stop when Django 1.11 will be released, which is currently scheduled for April 2017. We should upgrade to 1.10.x before.

