### PR TITLE
Fix #858 -- Read map:init event details correctly

### DIFF
--- a/cadasta/templates/organization/project_add_extents.html
+++ b/cadasta/templates/organization/project_add_extents.html
@@ -19,8 +19,14 @@
 <script>
  $(document).ready(function () {
    $(window).on('map:init', function(e) {
-     map = add_map_controls(e.originalEvent.detail.map);
-     map.fitBounds([[-45.0, -180.0], [45.0, 180.0]]);
+      if (e.detail) {
+        var map = e.detail.map;
+      } else {
+        var map = e.originalEvent.detail.map;
+      }
+      
+      map = add_map_controls(map);
+      map.fitBounds([[-45.0, -180.0], [45.0, 180.0]]);
    });
  });
 </script>

--- a/cadasta/templates/organization/project_edit_geometry.html
+++ b/cadasta/templates/organization/project_edit_geometry.html
@@ -20,7 +20,12 @@
 <script>
  $(document).ready(function () {
    $(window).on('map:init', function(e) {
-      add_map_controls(e.originalEvent.detail.map);
+      if (e.detail) {
+        var map = e.detail.map;
+      } else {
+        var map = e.originalEvent.detail.map;
+      }
+      add_map_controls(map);
 
       // Enable edit mode on map load and save the geometry on page save
       setTimeout(enableMapEditMode, 500);

--- a/cadasta/templates/spatial/location_add.html
+++ b/cadasta/templates/spatial/location_add.html
@@ -35,11 +35,15 @@
 <script>
   $(document).ready(function () {
     $(window).on('map:init', function(e) {
-      var map = e.originalEvent.detail.map;
-      var options = e.originalEvent.detail.options;
-      add_map_controls(map);
+      if (e.detail) {
+        var detail = e.detail;
+      } else {
+        var detail = e.originalEvent.detail;
+      }
+      var options = detail.options;
+      add_map_controls(detail.map);
 
-      switch_layer_controls(map, options);
+      switch_layer_controls(detail.map, options);
 
       // TODO: It seems Leaflet has a bug with L.geoJson()
       // not returning the correct bounds (see #377 for details)
@@ -54,13 +58,13 @@
       {% endif %}
       var spatialUnits = {{ geojson|safe }};
 
-      renderFeatures(map, projectExtent, spatialUnits, trans, 'project');
+      renderFeatures(detail.map, projectExtent, spatialUnits, trans, 'project');
 
       var orgSlug = '{{ object.organization.slug }}';
       var projectSlug = '{{ object.slug }}';
       var url = '/api/v1/organizations/'
               + orgSlug + '/projects/' + projectSlug + '/spatialresources/';
-      add_spatial_resources(map, url);
+      add_spatial_resources(detail.map, url);
     });
 
     $('.datepicker').datepicker({

--- a/cadasta/templates/spatial/location_edit.html
+++ b/cadasta/templates/spatial/location_edit.html
@@ -32,8 +32,13 @@
 <script>
   $(document).ready(function () {
     $(window).on('map:init', function(e) {
-      var map = e.originalEvent.detail.map;
-      var options = e.originalEvent.detail.options;
+      if (e.detail) {
+        var detail = e.detail;
+      } else {
+        var detail = e.originalEvent.detail;
+      }
+      var map = detail.map;
+      var options = detail.options;
       switch_layer_controls(map, options);
 
       var orgSlug = '{{ object.organization.slug }}';


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #858 In Safari >10.x the `map:init` event object is structured differently. This PR adds the necessary checks when parsing the object before adding controls to the map. 

### When should this PR be merged

Anytime.

### Risks

None.

### Follow up actions

None. 