### PR TITLE
Fix #881 -- Assign user instance when updating role via API

### DIFF
--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -157,7 +157,9 @@ class EntityUserSerializer(serializers.Serializer):
 
     def validate_username(self, value):
         error = ""
-        if not self.instance:
+        if self.instance:
+            self.user = self.instance
+        else:
             users = User.objects.filter(Q(username=value) | Q(email=value))
             users_count = len(users)
 

--- a/cadasta/organization/tests/test_serializers.py
+++ b/cadasta/organization/tests/test_serializers.py
@@ -554,6 +554,23 @@ class ProjectUserSerializerTest(UserTestCase, TestCase):
         role = ProjectRole.objects.get(user=user, project=project)
         assert role.role == data['role']
 
+    def test_update_roles_for_user_with_additional_payload(self):
+        user = UserFactory.create()
+        org = OrganizationFactory(add_users=[user])
+        project = ProjectFactory.create(add_users=[user], organization=org)
+        data = {'username': user.username, 'role': 'PM'}
+        serializer = serializers.ProjectUserSerializer(
+            user,
+            partial=True,
+            data=data,
+            context={'project': project}
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        role = ProjectRole.objects.get(user=user, project=project)
+        assert role.role == data['role']
+
 
 class UserAdminSerializerTest(UserTestCase, TestCase):
     def test_user_fields_are_set(self):


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix #881: When updating the user roles, assign the user object to `self.user`

### When should this PR be merged

Anytime

### Risks

Low

### Follow up actions

None