### PR TITLE
Fix #896

### DIFF
--- a/cadasta/party/tests/test_views_api_relationship_list.py
+++ b/cadasta/party/tests/test_views_api_relationship_list.py
@@ -83,7 +83,7 @@ class SpatialUnitsRelationshipListAPITest(APITestCase, UserTestCase, TestCase):
         self.TR.create(project=self.prj, party=party2, spatial_unit=su1)
 
         response = self.request(user=self.user,
-                                url_kwargs={'party_id': party1.id})
+                                url_kwargs={'party': party1.id})
         assert response.status_code == 200
         assert len(response.content) == 3
         valid_ids = (pr1.id, pr2.id, tr1.id)
@@ -93,7 +93,7 @@ class SpatialUnitsRelationshipListAPITest(APITestCase, UserTestCase, TestCase):
     def test_get_invalid_relationship_class(self):
         party = party_factories.PartyFactory.create(project=self.prj)
         response = self.request(user=self.user,
-                                url_kwargs={'party_id': party.id},
+                                url_kwargs={'party': party.id},
                                 get_data={'class': 'nonsense'})
 
         assert response.status_code == 400

--- a/cadasta/party/views/api.py
+++ b/cadasta/party/views/api.py
@@ -119,31 +119,20 @@ class RelationshipList(APIPermissionRequiredMixin,
             return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
         spatial_rels = []
-        if (
-            'location' in kwargs and
-            (rel_class is None or rel_class == 'spatial')
-        ):
+        if ('location' in kwargs and
+                (rel_class is None or rel_class == 'spatial')):
             manager = SpatialRelationship.objects
-            spatial_rels = (
-                manager.filter(
-                    Q(su1=kwargs['location']) |
-                    Q(su2=kwargs['location'])
-                )
+            spatial_rels = manager.filter(
+                Q(su1=kwargs['location']) | Q(su2=kwargs['location'])
             )
         serialized_spatial_rels = SpatialRelationshipReadSerializer(
             spatial_rels, many=True).data
 
         party_rels = []
-        if (
-            'party_id' in kwargs and
-            (rel_class is None or rel_class == 'party')
-        ):
+        if 'party' in kwargs and (rel_class is None or rel_class == 'party'):
             manager = PartyRelationship.objects
-            party_rels = (
-                manager.filter(
-                    Q(party1=kwargs['party_id']) |
-                    Q(party2=kwargs['party_id'])
-                )
+            party_rels = manager.filter(
+                Q(party1=kwargs['party']) | Q(party2=kwargs['party'])
             )
         serialized_party_rels = serializers.PartyRelationshipReadSerializer(
             party_rels, many=True).data
@@ -152,13 +141,9 @@ class RelationshipList(APIPermissionRequiredMixin,
         if rel_class is None or rel_class == 'tenure':
             manager = TenureRelationship.objects
             if 'location' in kwargs:
-                tenure_rels = (
-                    manager.filter(spatial_unit=kwargs['location'])
-                )
-            elif 'party_id' in kwargs:
-                tenure_rels = (
-                    manager.filter(party=kwargs['party_id'])
-                )
+                tenure_rels = manager.filter(spatial_unit=kwargs['location'])
+            elif 'party' in kwargs:
+                tenure_rels = (manager.filter(party=kwargs['party']))
         serialized_tenure_rels = serializers.TenureRelationshipReadSerializer(
             tenure_rels, many=True).data
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix #896 
- URL for party relationship list had `party` as a keyword argument, but both the corresponding view and its related unit tests used `party_id`.  Replaced `party_id` with `party` in the relevant places: `party_id` is not used in any of our URL patterns.
 
### When should this PR be merged

Any time.

### Risks

None.

### Follow up actions

None.
