### PR TITLE
Fix GDAL install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ addons:
 
 before_install:
   - export DEBIAN_FRONTEND=noninteractive
-  - sudo add-apt-repository ppa:ubuntugis/ppa -y
   - sudo -E apt-get -yq update &>> ~/apt-get-update.log
   - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install postgresql-9.4-postgis-2.2 squid3
-  - sudo apt-get -yq install libgdal1-dev
+  - sudo apt-get -yq install libgdal-dev
   - gdal-config --version
   - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
   - export C_INCLUDE_PATH=/usr/include/gdal

--- a/provision/roles/cadasta/application/tasks/main.yml
+++ b/provision/roles/cadasta/application/tasks/main.yml
@@ -3,6 +3,11 @@
   become_user: root
   apt_repository: repo='ppa:fkrull/deadsnakes'
 
+- name: Remove ubuntugis repository
+  become: yes
+  become_user: root
+  apt_repository: repo='ppa:ubuntugis/ppa' state=absent
+
 - name: Install packages
   become: yes
   become_user: root

--- a/provision/roles/cadasta/application/tasks/main.yml
+++ b/provision/roles/cadasta/application/tasks/main.yml
@@ -3,11 +3,6 @@
   become_user: root
   apt_repository: repo='ppa:fkrull/deadsnakes'
 
-- name: Add ubuntugis repository
-  become: yes
-  become_user: root
-  apt_repository: repo='ppa:ubuntugis/ppa'
-
 - name: Install packages
   become: yes
   become_user: root
@@ -21,7 +16,7 @@
       - libxslt1-dev
       - libxml2-dev
       - libjpeg-dev
-      - libgdal1-dev
+      - libgdal-dev
       - libmemcached-dev
 
 - name: dev locale

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -28,5 +28,5 @@ django-jsonattrs==0.1.21
 openpyxl==2.3.5
 pytz==2016.4
 shapely==1.5.16
-gdal==1.11.2
+gdal==1.10.0
 pylibmc==1.5.1


### PR DESCRIPTION
### Proposed changes in this pull request

Downgrades GDAL to 1.10.0 because builds and provisioning broke with GDAL provided by ubuntu-gis PPA.

### When should this PR be merged

ASAP. 

### Risks

We need to test how the downgrade affects existing installations on staging. 

### Follow up actions

After merging, everyone should rebase their branches to make the build work again