### PR TITLE
Fix: #884 and #911 update original_file field and randomize filenames for imported resources

### DIFF
--- a/cadasta/organization/importers/csv.py
+++ b/cadasta/organization/importers/csv.py
@@ -22,12 +22,11 @@ TENURE_TYPE = 'tenure_type'
 
 class CSVImporter(base.Importer):
 
-    def __init__(self, project=None, path=None,
-                 delimiter=None, quotechar=None):
+    def __init__(self, project, path=None, delimiter=',', quotechar='"'):
         super(CSVImporter, self).__init__(project=project)
         self.path = path
-        self.delimiter = ',' if not delimiter else delimiter
-        self.quotechar = '"' if not quotechar else quotechar
+        self.delimiter = delimiter
+        self.quotechar = quotechar
 
     def get_headers(self):
         headers = []
@@ -154,25 +153,13 @@ class CSVImporter(base.Importer):
                 # handle select_multiple fields
                 if (attribute.attr_type.name == 'select_multiple'):
                     val = val.split(' ')
-                content_types[content_type][
-                    'attributes'][
-                        attribute.name] = val
-        party = Party.objects.create(
-            **content_types['party.party']
-        )
-        su = SpatialUnit.objects.create(
-            **content_types['spatial.spatialunit']
-        )
-        tt = TenureRelationshipType.objects.get(
-            id=tenure_type)
-        content_types[
-            'party.tenurerelationship']['party'] = party
-        content_types[
-            'party.tenurerelationship'][
-                'spatial_unit'] = su
-        content_types[
-            'party.tenurerelationship'][
-                'tenure_type'] = tt
+                content_types[content_type]['attributes'][attribute.name] = val
+        party = Party.objects.create(**content_types['party.party'])
+        su = SpatialUnit.objects.create(**content_types['spatial.spatialunit'])
+        tt = TenureRelationshipType.objects.get(id=tenure_type)
+        content_types['party.tenurerelationship']['party'] = party
+        content_types['party.tenurerelationship']['spatial_unit'] = su
+        content_types['party.tenurerelationship']['tenure_type'] = tt
         TenureRelationship.objects.create(
             **content_types['party.tenurerelationship']
         )

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -1055,4 +1055,5 @@ class SelectImportFormTest(UserTestCase, FileStorageTestCase, TestCase):
             files=file_dict, data=self.data,
             project=self.project, user=self.user)
         assert form.is_valid() is True
-        assert form.cleaned_data['mime_type'] == 'text/plain'
+        assert form.cleaned_data['mime_type'] == 'text/csv'
+        assert form.cleaned_data['original_file'] == 'test.csv'

--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -1506,7 +1506,11 @@ class ProjectDataImportTest(UserTestCase, FileStorageTestCase, TestCase):
                 assert type(su.geometry) is Point
 
         resource = Resource.objects.filter(project_id=proj.pk).first()
-        assert resource.file.url == '/media/s3/uploads/resources/test.csv'
+        assert resource.original_file == 'test.csv'
+        assert resource.mime_type == 'text/csv'
+        random_filename = resource.file.url[resource.file.url.rfind('/'):]
+        assert random_filename.endswith('.csv')
+        assert len(random_filename.split('.')[0].strip('/')) == 24
 
     def test_full_flow_invalid_value(self):
         self.client.force_login(self.user)

--- a/cadasta/resources/migrations/0006_randomize_imported_filenames.py
+++ b/cadasta/resources/migrations/0006_randomize_imported_filenames.py
@@ -1,0 +1,46 @@
+from __future__ import unicode_literals
+
+import os
+
+from core.util import random_id
+from django.db import migrations
+
+
+def fix_original_file_field(apps, schema_editor):
+    Resource = apps.get_model("resources", "Resource")
+    resources = Resource.objects.filter(mime_type='text/csv')
+    for resource in resources:
+        url = resource.file.url
+        if url.endswith('.csv'):
+            parts = list(os.path.split(url))
+            if not resource.original_file:
+                resource.original_file = parts[-1]
+                resource.save()
+
+
+def randomize_imported_resource_filenames(apps, schema_editor):
+    Resource = apps.get_model("resources", "Resource")
+    resources = Resource.objects.filter(mime_type='text/csv')
+    for resource in resources:
+        url = resource.file.url
+        if url.endswith('.csv'):
+            random_filename = '/' + random_id() + '.csv'
+            parts = list(os.path.split(url))
+            base_url = parts[:-1]
+            url = '/'.join(base_url) + random_filename
+            resource.file.url = url
+            resource.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0005_fix_import_resource_urls'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            fix_original_file_field, migrations.RunPython.noop),
+        migrations.RunPython(
+            randomize_imported_resource_filenames, migrations.RunPython.noop),
+    ]

--- a/cadasta/templates/organization/project_select_import.html
+++ b/cadasta/templates/organization/project_select_import.html
@@ -1,9 +1,9 @@
-{% extends "organization/project_import_wrapper.html" %} 
+{% extends "organization/project_import_wrapper.html" %}
 
 {% load i18n %}
 {% load widget_tweaks %}
 
-{% block extra_script %} {{ form.media }} {% endblock %} 
+{% block extra_script %} {{ form.media }} {% endblock %}
 
 {% block step_content %}
 
@@ -62,7 +62,6 @@
                 {% trans "Include import file in project resources" %}
               </label>
             </div>
-            {{ form.mime_type }}
           </div>
         </div>
       </div>
@@ -79,4 +78,3 @@
 {% endif %}
 
 {% endblock %}
-


### PR DESCRIPTION
### Proposed changes in this pull request

#### Fixes #884 original_file field not set correctly on imported resources
#### Fixes #911 Imported resource filenames should be randomized

- Adds a migration to update the `original_file` field on the `Resources` table for files with mime type `text/csv`
- Adds randomization to file names for imported `CSV` files
- The migration also rewrites the `file` field on the `Resource` table to reflect the randomized filename

### When should this PR be merged

Can be merged immediately. Should be included in the release for Sprint 10

### Risks

Relatively low risk. It includes a migration that has been unit tested but will need testing on staging before release.

### Follow up actions

14 CSV files in Staging, and 7 files in Demo S3 buckets will need to be renamed to reflect the randomized filenames in the `Resource` table. This can be done manually post-release.

