### PR TITLE
Fix #732: "Users" menu on password views

### DIFF
--- a/cadasta/accounts/urls/default.py
+++ b/cadasta/accounts/urls/default.py
@@ -7,4 +7,8 @@ urlpatterns = [
     url(r'^login/$', default.AccountLogin.as_view(), name='login'),
     url(r'^confirm-email/(?P<key>[-:\w]+)/$', default.ConfirmEmail.as_view(),
         name='verify_email'),
+    url(r'^password/change/$', default.PasswordChangeView.as_view(),
+        name="account_change_password"),
+    url(r'^password/reset/$', default.PasswordResetView.as_view(),
+        name="account_reset_password"),
 ]

--- a/cadasta/accounts/views/default.py
+++ b/cadasta/accounts/views/default.py
@@ -5,12 +5,26 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.utils import timezone
 
 from core.views.generic import UpdateView
+from core.views.mixins import SuperUserCheckMixin
 
+import allauth.account.views as allauth_views
 from allauth.account.views import ConfirmEmailView, LoginView
 from allauth.account.utils import send_email_confirmation
 
 from ..models import User
 from ..forms import ProfileForm
+
+
+class PasswordChangeView(LoginRequiredMixin,
+                         SuperUserCheckMixin,
+                         allauth_views.PasswordChangeView):
+    pass
+
+
+class PasswordResetView(LoginRequiredMixin,
+                        SuperUserCheckMixin,
+                        allauth_views.PasswordResetView):
+    pass
 
 
 class AccountProfile(LoginRequiredMixin, UpdateView):


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix #732
- Override `allauth` views used for password change and password reset to include `SuperUserCheckMixin` to ensure that "Users" menu appears where required.

### When should this PR be merged

Any time.

### Risks

None.

### Follow up actions

None.
