### PR TITLE
API Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ htmlcov
 */dist/bundle.js
 node_modules/
 
+# Floobits
+.floo
+.flooignore
+
 .idea
 /.envrc
 /.virtualenv/

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -11,6 +11,7 @@ from core.serializers import DetailSerializer, FieldSelectorSerializer
 from accounts.models import User
 from accounts.serializers import UserSerializer
 from .models import Organization, Project, OrganizationRole, ProjectRole
+from .forms import create_update_or_delete_project_role
 
 
 class OrganizationSerializer(DetailSerializer, FieldSelectorSerializer,
@@ -91,7 +92,8 @@ class ProjectSerializer(DetailSerializer, serializers.ModelSerializer):
     class Meta:
         model = Project
         fields = ('id', 'organization', 'country', 'name', 'description',
-                  'archived', 'urls', 'contacts', 'users', 'access', 'slug')
+                  'archived', 'urls', 'contacts', 'users', 'access', 'slug',
+                  'extent',)
         read_only_fields = ('id', 'country', 'slug')
         detail_only_fields = ('users',)
 
@@ -106,19 +108,6 @@ class ProjectSerializer(DetailSerializer, serializers.ModelSerializer):
             organization_id=organization.id,
             **validated_data
         )
-
-
-class NestedProjectSerializer(DetailSerializer, FieldSelectorSerializer,
-                              serializers.ModelSerializer):
-    organization = OrganizationSerializer(
-        read_only=True, fields=('id', 'name', 'slug')
-    )
-
-    class Meta:
-        model = Project
-        fields = ('id', 'organization', 'name', 'slug')
-        read_only_fields = ('id', 'slug')
-        detail_only_fields = ('organization',)
 
 
 class ProjectGeometrySerializer(geo_serializers.GeoFeatureModelSerializer):
@@ -175,20 +164,10 @@ class EntityUserSerializer(serializers.Serializer):
 
             try:
                 self.get_roles_object(self.user)
-            except self.Meta.role_model.DoesNotExist:
-                pass
-            else:
                 raise serializers.ValidationError(
                     _("Not able to add member. The role already exists."))
-
-    def validate_admin(self, role_value):
-        if 'request' in self.context:
-            if self.context['request'].user == self.instance:
-                if role_value != self.get_roles_object(self.instance).admin:
-                    raise serializers.ValidationError(
-                        _("Organization administrators cannot change their "
-                          "own permissions within the organization"))
-        return role_value
+            except self.Meta.role_model.DoesNotExist:
+                pass
 
     def create(self, validated_data):
         obj = self.context[self.Meta.context_key]
@@ -216,12 +195,94 @@ class EntityUserSerializer(serializers.Serializer):
         return instance
 
 
+class ProjectUserSerializer(EntityUserSerializer):
+    class Meta:
+        role_model = ProjectRole
+        context_key = 'project'
+        role_key = 'role'
+    role = serializers.CharField()
+
+    def validate(self, data):
+        if self.org_role.admin:
+            raise serializers.ValidationError(
+                _("User {username} is an organization admin, the role cannot "
+                  "be updated.").format(username=self.instance.username))
+        return super().validate(data)
+
+    def validate_username(self, value):
+        try:
+            super(ProjectUserSerializer, self).validate_username(value)
+        except OrganizationRole.DoesNotExist:
+            raise serializers.ValidationError(
+                _("User {username} is not member of the project\'s "
+                  "organization").format(username=value))
+
+    def get_roles_object(self, instance):
+        project = self.context[self.Meta.context_key]
+        self.org_role = instance.organizationrole_set.get(
+            organization_id=project.organization_id)
+
+        if not self.org_role.admin:
+            role = ProjectRole.objects.get(
+                user=instance,
+                project=self.context['project'])
+
+            return role
+
+        return self.org_role
+
+    def get_role_json(self, instance):
+        try:
+            role = self.get_roles_object(instance)
+            if hasattr(role, 'role'):
+                return role.role
+            else:
+                return 'A' if role.admin else 'Pb'
+        except ProjectRole.DoesNotExist:
+            return 'Pb'
+
+    def set_roles(self, data):
+        user_role = 'Pb'
+
+        if self.instance:
+            try:
+                role = self.get_roles_object(self.instance)
+                if hasattr(role, 'role'):
+                    user_role = role.role
+                else:
+                    user_role = 'A' if role.admin else 'Pb'
+            except ProjectRole.DoesNotExist:
+                pass
+
+        if data:
+            user_role = data
+
+        return user_role
+
+    def update(self, instance, validated_data):
+        role = validated_data[self.Meta.role_key]
+        create_update_or_delete_project_role(self.context['project'].id,
+                                             instance,
+                                             role)
+
+        return instance
+
+
 class OrganizationUserSerializer(EntityUserSerializer):
     class Meta:
         role_model = OrganizationRole
         context_key = 'organization'
         role_key = 'admin'
     admin = serializers.BooleanField()
+
+    def validate_admin(self, role_value):
+        if 'request' in self.context:
+            if self.context['request'].user == self.instance:
+                if role_value != self.get_roles_object(self.instance).admin:
+                    raise serializers.ValidationError(
+                        _("Organization administrators cannot change their "
+                          "own permissions within the organization"))
+        return role_value
 
     def get_roles_object(self, instance):
         self.role = OrganizationRole.objects.get(
@@ -245,46 +306,6 @@ class OrganizationUserSerializer(EntityUserSerializer):
             admin = data
 
         return admin
-
-
-class ProjectUserSerializer(EntityUserSerializer):
-    class Meta:
-        role_model = ProjectRole
-        context_key = 'project'
-        role_key = 'role'
-    role = serializers.CharField()
-
-    def validate_username(self, value):
-        super(ProjectUserSerializer, self).validate_username(value)
-        project = self.context[self.Meta.context_key]
-
-        if self.user not in project.organization.users.all():
-            raise serializers.ValidationError(
-                _("User {username} is not member of the project\'s "
-                  "organization").format(username=value))
-
-    def get_roles_object(self, instance):
-        self.role = ProjectRole.objects.get(
-            user=instance,
-            project=self.context['project'])
-
-        return self.role
-
-    def get_role_json(self, instance):
-        role = self.get_roles_object(instance)
-        return role.role
-
-    def set_roles(self, data):
-        user_role = 'PU'
-
-        if self.instance:
-            role = self.get_roles_object(self.instance)
-            user_role = role.role
-
-        if data:
-            user_role = data
-
-        return user_role
 
 
 class UserAdminSerializer(UserSerializer):

--- a/cadasta/organization/tests/factories.py
+++ b/cadasta/organization/tests/factories.py
@@ -45,6 +45,8 @@ class ProjectFactory(ExtendedFactory):
 
         if users:
             for u in users:
+                OrganizationRole.objects.get_or_create(
+                    organization=self.organization, user=u)
                 ProjectRole.objects.create(project=self, user=u)
 
 

--- a/cadasta/party/serializers.py
+++ b/cadasta/party/serializers.py
@@ -4,20 +4,15 @@ from django.utils.translation import ugettext as _
 from rest_framework import serializers
 
 from .models import Party, PartyRelationship, TenureRelationship
-from core.serializers import DetailSerializer, FieldSelectorSerializer
-from organization.serializers import NestedProjectSerializer
+from core.serializers import FieldSelectorSerializer
 from spatial.serializers import SpatialUnitSerializer
 
 
-class PartySerializer(DetailSerializer, FieldSelectorSerializer,
-                      serializers.ModelSerializer):
-    project = NestedProjectSerializer(read_only=True)
-
+class PartySerializer(FieldSelectorSerializer, serializers.ModelSerializer):
     class Meta:
         model = Party
-        fields = ('id', 'name', 'type', 'contacts', 'attributes', 'project',)
-        read_only_fields = ('id', 'project',)
-        detail_only_fields = ('project',)
+        fields = ('id', 'name', 'type', 'attributes', )
+        read_only_fields = ('id', )
 
     def create(self, validated_data):
         project = self.context['project']

--- a/cadasta/party/tests/test_serializers.py
+++ b/cadasta/party/tests/test_serializers.py
@@ -19,11 +19,6 @@ class PartySerializerTest(UserTestCase, TestCase):
         assert serialized['name'] == party.name
         assert serialized['type'] == party.type
         assert 'attributes' in serialized
-        assert 'contacts' in serialized
-
-        assert serialized['project']['id'] == party.project.id
-        assert (serialized['project']['organization']['id'] ==
-                party.project.organization.id)
 
     def test_create_party(self,):
         project = ProjectFactory.create(name='Test Project')
@@ -37,4 +32,3 @@ class PartySerializerTest(UserTestCase, TestCase):
         serializer.save()
         party_instance = serializer.instance
         assert party_instance.name == 'Tea Party'
-        assert party_instance.project_id == project.id

--- a/cadasta/questionnaires/serializers.py
+++ b/cadasta/questionnaires/serializers.py
@@ -53,7 +53,7 @@ class QuestionnaireSerializer(serializers.ModelSerializer):
         model = models.Questionnaire
         fields = (
             'id', 'filename', 'title', 'id_string', 'xls_form', 'xml_form',
-            'version', 'questions', 'question_groups', 'md5_hash'
+            'version', 'questions', 'question_groups',
         )
         read_only_fields = (
             'id', 'filename', 'title', 'id_string', 'version',

--- a/cadasta/spatial/serializers.py
+++ b/cadasta/spatial/serializers.py
@@ -4,22 +4,19 @@ from rest_framework import serializers
 from rest_framework_gis import serializers as geo_serializers
 
 from .models import SpatialUnit, SpatialRelationship
-from core.serializers import DetailSerializer, FieldSelectorSerializer
-from organization.serializers import NestedProjectSerializer
+from core.serializers import FieldSelectorSerializer
 
 
-class SpatialUnitSerializer(DetailSerializer, FieldSelectorSerializer,
+class SpatialUnitSerializer(FieldSelectorSerializer,
                             geo_serializers.GeoFeatureModelSerializer):
-    project = NestedProjectSerializer(read_only=True)
 
     class Meta:
         model = SpatialUnit
         context_key = 'project'
         geo_field = 'geometry'
         id_field = False
-        fields = ('id', 'geometry', 'type', 'attributes', 'project',)
-        read_only_fields = ('id', 'project',)
-        detail_only_fields = ('project',)
+        fields = ('id', 'geometry', 'type', 'attributes', )
+        read_only_fields = ('id', )
 
     def create(self, validated_data):
         project = self.context['project']

--- a/cadasta/spatial/tests/test_serializers.py
+++ b/cadasta/spatial/tests/test_serializers.py
@@ -34,12 +34,6 @@ class SpatialUnitSerializerTest(TestCase):
         spatial_instance = serializer.instance
         assert spatial_instance.project == project
 
-    def test_project_detail_not_serialized(self):
-        project = ProjectFactory.create()
-        spatial_data = SpatialUnitFactory.create(project=project)
-        serializer = serializers.SpatialUnitSerializer(spatial_data)
-        assert 'description' not in serializer.data['properties']['project']
-
     def test_update_spatial_unit(self):
         project = ProjectFactory.create()
         su = SpatialUnitFactory.create(type='BU',
@@ -85,10 +79,10 @@ class SpatialUnitSerializerTest(TestCase):
     def test_update_spatial_unit_project_fails(self):
         project = ProjectFactory.create(name='Original Project')
         su = SpatialUnitFactory.create(project=project)
-        ProjectFactory.create(name='New Project')
+        new_project = ProjectFactory.create(name='New Project')
         spatial_data = {
             'properties': {
-                'project': 'something'
+                'project': new_project
             }
         }
         serializer = serializers.SpatialUnitSerializer(
@@ -100,8 +94,9 @@ class SpatialUnitSerializerTest(TestCase):
 
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        data = serializer.data['properties']
-        assert data['project']['name'] != 'New Project'
+
+        su.refresh_from_db()
+        assert su.project == project
 
 
 class SpatialUnitGeoJsonSerializerTest(TestCase):

--- a/cadasta/xforms/tests/test_serializers.py
+++ b/cadasta/xforms/tests/test_serializers.py
@@ -48,7 +48,7 @@ class XFormListSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         assert (serializer.data['downloadUrl'] ==
                 protocol + '://localhost:8000' +
                 questionnaire.data['xml_form'])
-        assert serializer.data['hash'] == questionnaire.data['md5_hash']
+        assert serializer.data['hash'] == form.md5_hash
 
     def test_serialize(self):
         self._test_serialize()


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolves #880 
- Extent `ProjectUserSerializer` to list organization users
- Removes `md5_hash` from questionnaire serialization
- Removes `contacts` field from party serialization
- Removes serialization of `project` from party and spatial unit
- Adds `extent` field field to `ProjectSerializer`

### When should this PR be merged

For sprint 11

### Risks

Nothing I'm aware of

None

### Follow up actions

None

