### PR TITLE
API Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ htmlcov
 */dist/bundle.js
 node_modules/
 
+# Floobits
+.floo
+.flooignore
+
 .idea
 /.envrc
 /.virtualenv/

--- a/cadasta/organization/tests/factories.py
+++ b/cadasta/organization/tests/factories.py
@@ -45,6 +45,8 @@ class ProjectFactory(ExtendedFactory):
 
         if users:
             for u in users:
+                OrganizationRole.objects.get_or_create(
+                    organization=self.organization, user=u)
                 ProjectRole.objects.create(project=self, user=u)
 
 

--- a/cadasta/organization/tests/test_serializers.py
+++ b/cadasta/organization/tests/test_serializers.py
@@ -1,6 +1,8 @@
+import json
 import random
 import pytest
 from datetime import datetime
+from tutelary.models import Role
 from core.util import slugify
 from django.test import TestCase
 from django.utils.translation import gettext as _
@@ -151,7 +153,12 @@ class ProjectSerializerTest(TestCase):
         organization = OrganizationFactory.create()
         project_data = {
             'name': "Project",
-            'organization': organization
+            'organization': organization,
+            'extent': {
+                'coordinates': [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0],
+                                 [0., 1.0], [0.0, 0.0]]],
+                'type': 'Polygon'
+            }
         }
         serializer = serializers.ProjectSerializer(
             data=project_data,
@@ -162,6 +169,8 @@ class ProjectSerializerTest(TestCase):
 
         project_instance = serializer.instance
         assert project_instance.organization == organization
+        assert (json.loads(project_instance.extent.json) ==
+                project_data['extent'])
 
     def test_project_public_visibility(self):
         organization = OrganizationFactory.create()
@@ -348,7 +357,6 @@ class OrganizationUserSerializerTest(UserTestCase, TestCase):
 
         assert len(serializer.data) == 3
 
-        print(serializer.data)
         for u in serializer.data:
             if u['username'] == org_admin.username:
                 assert u['admin'] is True
@@ -462,21 +470,39 @@ class ProjectUserSerializerTest(UserTestCase, TestCase):
     def test_list_to_representation(self):
         users = UserFactory.create_batch(2)
         prj_admin = UserFactory.create()
-        project = ProjectFactory.create(add_users=users)
+        org_admin = UserFactory.create()
+        public_user = UserFactory.create()
+
+        superuser = UserFactory.create()
+        superuser_role = Role.objects.get(name='superuser')
+        superuser.assign_policies(superuser_role)
+
+        org = OrganizationFactory.create(
+            add_users=[superuser, prj_admin, public_user])
+        project = ProjectFactory.create(add_users=users, organization=org)
+
+        OrganizationRole.objects.create(
+            organization=org, user=org_admin, admin=True)
         ProjectRole.objects.create(
-            user=prj_admin, project=project, role='PM'
-        )
+            project=project, user=prj_admin, role='PM')
+
         serializer = serializers.ProjectUserSerializer(
-            project.users.all(),
+            org.users.all(),
             many=True,
             context={'project': project}
         )
 
-        assert len(serializer.data) == 3
+        assert len(serializer.data) == 6
 
         for u in serializer.data:
-            if u['username'] == prj_admin.username:
+            if u['username'] == superuser.username:
+                assert u['role'] == 'A'
+            elif u['username'] == org_admin.username:
+                assert u['role'] == 'A'
+            elif u['username'] == prj_admin.username:
                 assert u['role'] == 'PM'
+            elif u['username'] == public_user.username:
+                assert u['role'] == 'Pb'
             else:
                 assert u['role'] == 'PU'
 
@@ -556,8 +582,7 @@ class ProjectUserSerializerTest(UserTestCase, TestCase):
 
     def test_update_roles_for_user_with_additional_payload(self):
         user = UserFactory.create()
-        org = OrganizationFactory(add_users=[user])
-        project = ProjectFactory.create(add_users=[user], organization=org)
+        project = ProjectFactory.create(add_users=[user])
         data = {'username': user.username, 'role': 'PM'}
         serializer = serializers.ProjectUserSerializer(
             user,
@@ -570,6 +595,81 @@ class ProjectUserSerializerTest(UserTestCase, TestCase):
 
         role = ProjectRole.objects.get(user=user, project=project)
         assert role.role == data['role']
+
+    def test_update_roles_for_organization_user(self):
+        user = UserFactory.create()
+        org = OrganizationFactory.create(add_users=[user])
+        project = ProjectFactory.create(organization=org)
+        data = {'role': 'PM'}
+        serializer = serializers.ProjectUserSerializer(
+            user,
+            partial=True,
+            data=data,
+            context={'project': project}
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        role = ProjectRole.objects.get(user=user, project=project)
+        assert role.role == data['role']
+
+    def test_update_roles_for_org_admin(self):
+        user = UserFactory.create(username='some-user')
+        project = ProjectFactory.create()
+        OrganizationRole.objects.create(organization=project.organization,
+                                        user=user,
+                                        admin=True)
+        data = {'role': 'DC'}
+        serializer = serializers.ProjectUserSerializer(
+            user,
+            partial=True,
+            data=data,
+            context={'project': project}
+        )
+
+        with pytest.raises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+        assert (('User some-user is an organization admin, the role cannot be'
+                 ' updated.') in serializer.errors['non_field_errors'])
+
+    def test_update_roles_for_superuser(self):
+        user = UserFactory.create(username='some-user')
+        superuser_role = Role.objects.get(name='superuser')
+        user.assign_policies(superuser_role)
+
+        project = ProjectFactory.create()
+        OrganizationRole.objects.create(organization=project.organization,
+                                        user=user,
+                                        admin=True)
+        data = {'role': 'DC'}
+        serializer = serializers.ProjectUserSerializer(
+            user,
+            partial=True,
+            data=data,
+            context={'project': project}
+        )
+
+        with pytest.raises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+        assert (('User some-user is an organization admin, the role cannot be'
+                 ' updated.') in serializer.errors['non_field_errors'])
+
+    def test_update_roles_to_public_user(self):
+        user = UserFactory.create(username='some-user')
+        project = ProjectFactory.create(add_users=[user])
+        assert (ProjectRole.objects.filter(project=project, user=user).exists()
+                is True)
+        data = {'role': 'Pb'}
+        serializer = serializers.ProjectUserSerializer(
+            user,
+            partial=True,
+            data=data,
+            context={'project': project}
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        assert (ProjectRole.objects.filter(project=project, user=user).exists()
+                is False)
 
 
 class UserAdminSerializerTest(UserTestCase, TestCase):

--- a/cadasta/party/serializers.py
+++ b/cadasta/party/serializers.py
@@ -4,20 +4,15 @@ from django.utils.translation import ugettext as _
 from rest_framework import serializers
 
 from .models import Party, PartyRelationship, TenureRelationship
-from core.serializers import DetailSerializer, FieldSelectorSerializer
-from organization.serializers import NestedProjectSerializer
+from core.serializers import FieldSelectorSerializer
 from spatial.serializers import SpatialUnitSerializer
 
 
-class PartySerializer(DetailSerializer, FieldSelectorSerializer,
-                      serializers.ModelSerializer):
-    project = NestedProjectSerializer(read_only=True)
-
+class PartySerializer(FieldSelectorSerializer, serializers.ModelSerializer):
     class Meta:
         model = Party
-        fields = ('id', 'name', 'type', 'contacts', 'attributes', 'project',)
-        read_only_fields = ('id', 'project',)
-        detail_only_fields = ('project',)
+        fields = ('id', 'name', 'type', 'attributes', )
+        read_only_fields = ('id', )
 
     def create(self, validated_data):
         project = self.context['project']

--- a/cadasta/party/tests/test_serializers.py
+++ b/cadasta/party/tests/test_serializers.py
@@ -19,11 +19,6 @@ class PartySerializerTest(UserTestCase, TestCase):
         assert serialized['name'] == party.name
         assert serialized['type'] == party.type
         assert 'attributes' in serialized
-        assert 'contacts' in serialized
-
-        assert serialized['project']['id'] == party.project.id
-        assert (serialized['project']['organization']['id'] ==
-                party.project.organization.id)
 
     def test_create_party(self,):
         project = ProjectFactory.create(name='Test Project')
@@ -37,4 +32,3 @@ class PartySerializerTest(UserTestCase, TestCase):
         serializer.save()
         party_instance = serializer.instance
         assert party_instance.name == 'Tea Party'
-        assert party_instance.project_id == project.id

--- a/cadasta/questionnaires/serializers.py
+++ b/cadasta/questionnaires/serializers.py
@@ -53,7 +53,7 @@ class QuestionnaireSerializer(serializers.ModelSerializer):
         model = models.Questionnaire
         fields = (
             'id', 'filename', 'title', 'id_string', 'xls_form', 'xml_form',
-            'version', 'questions', 'question_groups', 'md5_hash'
+            'version', 'questions', 'question_groups',
         )
         read_only_fields = (
             'id', 'filename', 'title', 'id_string', 'version',

--- a/cadasta/spatial/serializers.py
+++ b/cadasta/spatial/serializers.py
@@ -4,22 +4,19 @@ from rest_framework import serializers
 from rest_framework_gis import serializers as geo_serializers
 
 from .models import SpatialUnit, SpatialRelationship
-from core.serializers import DetailSerializer, FieldSelectorSerializer
-from organization.serializers import NestedProjectSerializer
+from core.serializers import FieldSelectorSerializer
 
 
-class SpatialUnitSerializer(DetailSerializer, FieldSelectorSerializer,
+class SpatialUnitSerializer(FieldSelectorSerializer,
                             geo_serializers.GeoFeatureModelSerializer):
-    project = NestedProjectSerializer(read_only=True)
 
     class Meta:
         model = SpatialUnit
         context_key = 'project'
         geo_field = 'geometry'
         id_field = False
-        fields = ('id', 'geometry', 'type', 'attributes', 'project',)
-        read_only_fields = ('id', 'project',)
-        detail_only_fields = ('project',)
+        fields = ('id', 'geometry', 'type', 'attributes', )
+        read_only_fields = ('id', )
 
     def create(self, validated_data):
         project = self.context['project']

--- a/cadasta/spatial/tests/test_serializers.py
+++ b/cadasta/spatial/tests/test_serializers.py
@@ -34,12 +34,6 @@ class SpatialUnitSerializerTest(TestCase):
         spatial_instance = serializer.instance
         assert spatial_instance.project == project
 
-    def test_project_detail_not_serialized(self):
-        project = ProjectFactory.create()
-        spatial_data = SpatialUnitFactory.create(project=project)
-        serializer = serializers.SpatialUnitSerializer(spatial_data)
-        assert 'description' not in serializer.data['properties']['project']
-
     def test_update_spatial_unit(self):
         project = ProjectFactory.create()
         su = SpatialUnitFactory.create(type='BU',
@@ -85,10 +79,10 @@ class SpatialUnitSerializerTest(TestCase):
     def test_update_spatial_unit_project_fails(self):
         project = ProjectFactory.create(name='Original Project')
         su = SpatialUnitFactory.create(project=project)
-        ProjectFactory.create(name='New Project')
+        new_project = ProjectFactory.create(name='New Project')
         spatial_data = {
             'properties': {
-                'project': 'something'
+                'project': new_project
             }
         }
         serializer = serializers.SpatialUnitSerializer(
@@ -100,8 +94,9 @@ class SpatialUnitSerializerTest(TestCase):
 
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        data = serializer.data['properties']
-        assert data['project']['name'] != 'New Project'
+
+        su.refresh_from_db()
+        assert su.project == project
 
 
 class SpatialUnitGeoJsonSerializerTest(TestCase):

--- a/cadasta/xforms/tests/test_serializers.py
+++ b/cadasta/xforms/tests/test_serializers.py
@@ -48,7 +48,7 @@ class XFormListSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         assert (serializer.data['downloadUrl'] ==
                 protocol + '://localhost:8000' +
                 questionnaire.data['xml_form'])
-        assert serializer.data['hash'] == questionnaire.data['md5_hash']
+        assert serializer.data['hash'] == form.md5_hash
 
     def test_serialize(self):
         self._test_serialize()


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolves #880 
- Extent `ProjectUserSerializer` to list organization users
- Removes `md5_hash` from questionnaire serialization
- Removes `contacts` field from party serialization
- Removes serialization of `project` from party and spatial unit
- Adds `extent` field field to `ProjectSerializer`

### When should this PR be merged

For sprint 11

### Risks

Nothing I'm aware of

### Follow up actions

None