### PR TITLE
Map interaction performance improvements

### DIFF
--- a/cadasta/core/static/js/L.Map.Deflate.js
+++ b/cadasta/core/static/js/L.Map.Deflate.js
@@ -1,1 +1,131 @@
-L.Deflate=function(e,r){function o(r,o){var a=r.getBounds(),t=e.project(a.getNorthEast(),o),d=e.project(a.getSouthWest(),o),m=t.x-d.x,u=d.y-t.y;return n>u||n>m}function a(r){var a=null,t=e.getZoom();if(o(r,e.getZoom()))for(;!a;)t+=1,o(r,t)||(a=t-1);else for(;!a;)t-=1,o(r,t)&&(a=t);return a}var t=[],n=r.minSize||10,d=r.layerGroup||e;d.on("layeradd",function(r){var o=r.layer;if(!o._layers&&o.getBounds&&!o.zoomThreshold&&!o.marker){var n=a(o),m=L.marker(o.getBounds().getCenter());o._popupHandlersAdded&&m.bindPopup(o._popup._content),o.zoomThreshold=n,o.marker=m,e.getZoom()<=n&&(d.removeLayer(o),d.addLayer(o.marker),t.push(o))}}),e.on("zoomend",function(){d!==e&&e.removeLayer(d);var r=[];d.eachLayer(function(o){e.getZoom()<=o.zoomThreshold&&(d.removeLayer(o),d.addLayer(o.marker),r.push(o))});for(var o=0;o<t.length;o++){var a=t[o];e.getZoom()>a.zoomThreshold&&(d.removeLayer(a.marker),d.addLayer(a),t.splice(o,1),o-=1)}d!==e&&e.addLayer(d),t=t.concat(r)})};
+L.Deflate = function(options) {
+    var removedPaths = [];
+    var minSize = options.minSize || 10;
+    var layer, map;
+    var zoomBins = {};
+    var startZoom;
+    var markers = L.markerClusterGroup();
+
+    function isCollapsed(path, zoom) {
+        var bounds = path.getBounds();
+
+        var ne_px = map.project(bounds.getNorthEast(), zoom);
+        var sw_px = map.project(bounds.getSouthWest(), zoom);
+
+        var width = ne_px.x - sw_px.x;
+        var height = sw_px.y - ne_px.y;
+        return (height < minSize || width < minSize);
+    }
+
+    function getZoomThreshold(path) {
+        var zoomThreshold = null;
+        var zoom = map.getZoom();
+        if (isCollapsed(path, map.getZoom())) {
+            while (!zoomThreshold) {
+                zoom += 1;
+                if (!isCollapsed(path, zoom)) {
+                    zoomThreshold = zoom - 1;
+                }
+            }
+        } else {
+            while (!zoomThreshold) {
+                zoom -= 1;
+                if (isCollapsed(path, zoom)) {
+                    zoomThreshold = zoom;
+                }
+            }
+        }
+        return zoomThreshold;
+    }
+
+    function layeradd(event) {
+        var feature = event.layer;
+        if (feature instanceof L.Marker && layer !== markers) {
+            layer.removeLayer(feature);
+            markers.addLayer(feature);
+        } else if (!feature._layers && feature.getBounds && !feature.zoomThreshold && !feature.marker) {
+            var zoomThreshold = getZoomThreshold(feature);
+            var marker = L.marker(feature.getBounds().getCenter());
+
+            if (feature._popupHandlersAdded) {
+                marker.bindPopup(feature._popup._content)
+            }
+
+            var events = feature._events;
+            for (var event in events) {
+                if (events.hasOwnProperty(event)) {
+                    var listeners = events[event];
+                    for (var i = 0, len = listeners.length; i < len; i++) {
+                        marker.on(event, listeners[i].fn) 
+                    }
+                }
+            }
+
+            feature.zoomThreshold = zoomThreshold;
+            feature.marker = marker;
+            feature.zoomState = map.getZoom();
+            
+            layer.removeLayer(feature);
+            if (map.getZoom() <= zoomThreshold) {
+                markers.addLayer(feature.marker);
+            } else {
+                markers.addLayer(feature);
+            }
+
+            if (zoomBins[zoomThreshold]) {
+                zoomBins[zoomThreshold].push(feature);
+            } else {
+                zoomBins[zoomThreshold] = [feature];
+            }
+        }
+    }
+
+    function zoomstart() {
+        startZoom = map.getZoom();
+    }
+
+    function deflate() {
+        var bounds = map.getBounds();
+        var endZoom = map.getZoom();
+        var show = startZoom < endZoom;
+        var markersToAdd = []
+        var markersToRemove = [];
+
+        var start = (show ? startZoom : endZoom);
+        var end = (show ? endZoom : startZoom);
+
+        for (var i = start; i <= end; i++) {
+            if (zoomBins[i]) {
+                var features = zoomBins[i];
+
+                for (var j = 0, len = features.length; j < len; j++) {
+                    if (features[j].zoomState !== endZoom && features[j].getBounds().intersects(bounds)) {
+                        if (show) {
+                            layer.addLayer(features[j]);
+                            markersToRemove.push(features[j].marker);
+                        } else {
+                            layer.removeLayer(features[j]);
+                            markersToAdd.push(features[j].marker);
+                        }
+                        features[j].zoomState = endZoom;
+                    }
+                }
+            }
+        }
+        markers.removeLayers(markersToRemove);
+        markers.addLayers(markersToAdd);
+    }
+
+    function addTo(addToMap) {
+        layer = options.layerGroup || addToMap;
+        map = addToMap;
+
+        markers.addTo(map);
+        layer.on('layeradd', layeradd);
+        map.on('zoomstart', zoomstart);
+        map.on('zoomend', deflate);
+        map.on('dragend', deflate);
+    }
+
+    return { addTo: addTo }
+}

--- a/cadasta/core/static/js/map_utils.js
+++ b/cadasta/core/static/js/map_utils.js
@@ -65,7 +65,7 @@ function renderFeatures(map, projectExtent, spatialUnits, trans, fitBounds) {
     projectBounds = boundary.getBounds();
     if (fitBounds === 'project') {map.fitBounds(projectBounds);}
   }
-
+  
   var geoJson = L.geoJson(null, {
     style: { weight: 2 },
     onEachFeature: function(feature, layer) {
@@ -77,7 +77,8 @@ function renderFeatures(map, projectExtent, spatialUnits, trans, fitBounds) {
     }
   });
 
-  L.Deflate(map, {minSize: 20, layerGroup: geoJson});
+  L.Deflate({minSize: 20, layerGroup: geoJson}).addTo(map);
+  geoJson.addTo(map);
   geoJson.addData(spatialUnits);
 
   if (fitBounds === 'locations') {
@@ -87,11 +88,6 @@ function renderFeatures(map, projectExtent, spatialUnits, trans, fitBounds) {
       map.fitBounds(projectBounds);
     }
   }
-
-  var markerGroup = L.markerClusterGroup.layerSupport();
-  markerGroup.addTo(map);
-  markerGroup.checkIn(geoJson);
-  geoJson.addTo(map);
 }
 
 function switch_layer_controls(map, options){

--- a/cadasta/templates/core/dashboard.html
+++ b/cadasta/templates/core/dashboard.html
@@ -22,7 +22,6 @@
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>
 <script src="{% static 'js/map_utils.js' %}"></script>
-<script src="https://cdn.rawgit.com/ghybs/Leaflet.MarkerCluster.LayerSupport/3d4c4f24a008d6983a8f98b1c823f9a05ad62f80/leaflet.markercluster.layersupport-src.js"></script>
 <script>
   function project_map_init(map, options) {
     var data = {{ geojson|safe }};

--- a/cadasta/templates/organization/project_dashboard.html
+++ b/cadasta/templates/organization/project_dashboard.html
@@ -15,7 +15,6 @@
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>
 <script src="{% static 'js/map_utils.js' %}"></script>
-<script src="https://cdn.rawgit.com/ghybs/Leaflet.MarkerCluster.LayerSupport/3d4c4f24a008d6983a8f98b1c823f9a05ad62f80/leaflet.markercluster.layersupport-src.js"></script>
 <script>
   function project_map_init(map, options) {
     var trans = {
@@ -30,7 +29,6 @@
     var projectExtent = null;
     {% endif %}
     var spatialUnits = {{ geojson|safe }};
-
     renderFeatures(map, projectExtent, spatialUnits, trans, 'locations');
 
     var orgSlug = '{{ project.organization.slug }}';

--- a/cadasta/templates/spatial/location_add.html
+++ b/cadasta/templates/spatial/location_add.html
@@ -25,7 +25,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.js"></script>
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>
-<script src="https://cdn.rawgit.com/ghybs/Leaflet.MarkerCluster.LayerSupport/3d4c4f24a008d6983a8f98b1c823f9a05ad62f80/leaflet.markercluster.layersupport-src.js"></script>
 <script src="{% static 'js/jquery-ui.min.js' %}"></script>
 {% if get_current_language != "en-us" %}
 {% get_current_language as LANGUAGE_CODE %}

--- a/cadasta/templates/spatial/location_edit.html
+++ b/cadasta/templates/spatial/location_edit.html
@@ -22,7 +22,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.js"></script>
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>
-<script src="https://cdn.rawgit.com/ghybs/Leaflet.MarkerCluster.LayerSupport/3d4c4f24a008d6983a8f98b1c823f9a05ad62f80/leaflet.markercluster.layersupport-src.js"></script>
 <script src="{% static 'js/jquery-ui.min.js' %}"></script>
 {% if get_current_language != "en-us" %}
 {% get_current_language as LANGUAGE_CODE %}

--- a/cadasta/templates/spatial/location_map.html
+++ b/cadasta/templates/spatial/location_map.html
@@ -14,7 +14,6 @@
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>
 <script src="{% static 'js/map_utils.js' %}"></script>
-<script src="https://cdn.rawgit.com/ghybs/Leaflet.MarkerCluster.LayerSupport/3d4c4f24a008d6983a8f98b1c823f9a05ad62f80/leaflet.markercluster.layersupport-src.js"></script>
 <script>
   function locations_map_init(map, options) {
     // TODO: It seems Leaflet has a bug with L.geoJson()

--- a/cadasta/templates/spatial/location_wrapper.html
+++ b/cadasta/templates/spatial/location_wrapper.html
@@ -17,7 +17,6 @@
 {% leaflet_js plugins="groupedlayercontrol" %}
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>
-<script src="https://cdn.rawgit.com/ghybs/Leaflet.MarkerCluster.LayerSupport/3d4c4f24a008d6983a8f98b1c823f9a05ad62f80/leaflet.markercluster.layersupport-src.js"></script>
 <script src="{% static 'js/map_utils.js' %}"></script>
 <!-- Detail extra script-->
 <script>


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolves #932
- Switch to a customized version of Leaflet.Deflate to improve the performance of map interactions. (These changes will be added upstream to Leaflet.Deflate at some point). The customized approach includes the following changes:
    - Ignore point features when evaluation whether to show the original feature or the marker.
    - Group features into bins according to the zoom threshold and evaluate only features that were affected by the last zoom action.
    - When evaluating, features ignore everything that is outside the current map view. When the map is panned, the current map view is re-evaluated and updated accordingly. The reevaluation only includes features that have not be evaluated before.
- Removes Leaflet.MarkerCluster.LayerSupport as it is not needed any longer

I have tested this against a data set with 15,000 polygons of varying size and the Uttaran data set. 
Uttaran is almost exclusively points; the performance is increased tremendously. The performance of the polygons dataset is reasonable; for instance, takes roughly 350ms to replace ~4000 polygons when looking at an area approximately the size of Hamburg . 

### When should this PR be merged

For sprint 11

### Risks

None

### Follow up actions

None