### PR TITLE
Fix handling of L.Deflate for location edit page

### DIFF
--- a/cadasta/core/static/js/L.Map.Deflate.js
+++ b/cadasta/core/static/js/L.Map.Deflate.js
@@ -82,12 +82,8 @@ L.Deflate = function(options) {
     function deflate() {
         var bounds = map.getBounds();
         var endZoom = map.getZoom();
-        var show = startZoom < endZoom;
         var markersToAdd = []
         var markersToRemove = [];
-
-        var start = (show ? startZoom : endZoom);
-        var end = (show ? endZoom : startZoom);
 
         for (var i = 0, len = layers.length; i < len; i++) {
             if (layers[i].zoomState !== endZoom && layers[i].getBounds().intersects(bounds)) {

--- a/cadasta/templates/spatial/location_edit.html
+++ b/cadasta/templates/spatial/location_edit.html
@@ -50,23 +50,8 @@
 
       var data = {{ geojson|safe }};
 
-      var geoJson = L.geoJson(null, {
-        onEachFeature: function(feature, layer) {
-          layer.bindPopup("<div class=\"text-wrap\">" +
-                         "<h2><span>Location</span>" +
-                         feature.properties.type + "</h2></div>" +
-                         "<div class=\"btn-wrap\"><a href='" + feature.properties.url + "' class=\"btn btn-primary btn-sm btn-block\">{% trans 'Open location' %}</a>"  +
-                         "</div>");
-        }
-      });
-
-      L.Deflate(map, {minSize: 20, layerGroup: geoJson});
-      geoJson.addData(data);
-
-      var markerGroup = L.markerClusterGroup.layerSupport()
-      markerGroup.addTo(map);
-      markerGroup.checkIn(geoJson);
-      geoJson.addTo(map);
+      var trans = {open: "{% trans 'Open location' %}"}
+      renderFeatures(detail.map, null, data, trans);
 
       // Enable edit mode on map load and save the geometry on page save
       setTimeout(enableMapEditMode, 500);


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes an issue that prevented the location-edit map from loading after the changes introduced in #944 
- Fixes another problem related to binning features according to their zoom thresholds: Say, a feature's zoom threshold is 10. When the map zooms from zoom level 5 to zoom level 12 and the feature is not inside the resulting map view, the feature's display is not updated. When the map then zooms from zoom level 12 to 11, the feature is not evaluated because only zoom thresholds 11 and 12 get evaluated; even if that feature is now visible in the map view. In this case, the marker is displayed incorrectly instead of the actual feature geometry. The problem is fixed by removing the zoom-level bins and always checking all features inside the resulting map view. 

### When should this PR be merged

ASAP, before the next release.

### Risks

Low.

### Follow up actions

None.

