### PR TITLE
Add asychronous loading to map views

### DIFF
--- a/cadasta/config/urls/default.py
+++ b/cadasta/config/urls/default.py
@@ -63,6 +63,12 @@ api = [
     url(r'^v1/', include(api_v1, namespace='v1'))
 ]
 
+async = [
+    url(r'^',
+        include('spatial.urls.async',
+                namespace='spatial')),
+]
+
 urlpatterns = [
     url(r'^',
         include('core.urls',
@@ -96,6 +102,9 @@ urlpatterns = [
     url(r'^api/',
         include(api,
                 namespace='api')),
+    url(r'^async/',
+        include(async,
+                namespace='async')),
     url(r'^collect/', include('xforms.urls.api')),
 
     url(r'^i18n/',

--- a/cadasta/core/static/js/L.Map.Deflate.js
+++ b/cadasta/core/static/js/L.Map.Deflate.js
@@ -112,5 +112,12 @@ L.Deflate = function(options) {
         map.on('dragend', deflate);
     }
 
-    return { addTo: addTo }
+    function getBounds() {
+        return markers.getBounds();
+    }
+
+    return {
+        addTo: addTo,
+        getBounds: getBounds
+    }
 }

--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -24,7 +24,6 @@ from resources.tests.utils import clear_temp  # noqa
 from resources.utils.io import ensure_dirs
 from skivvy import ViewTestCase
 from spatial.models import SpatialUnit
-from spatial.serializers import SpatialUnitGeoJsonSerializer
 from spatial.tests.factories import SpatialUnitFactory
 from tutelary.models import Policy, Role, assign_user_policies
 
@@ -211,7 +210,6 @@ class ProjectDashboardTest(ViewTestCase, UserTestCase, TestCase):
         return {
             'object': self.project,
             'project': self.project,
-            'geojson': '{"type": "FeatureCollection", "features": []}',
             'is_superuser': False,
             'is_administrator': False,
             'has_content': False,
@@ -412,16 +410,13 @@ class ProjectDashboardTest(ViewTestCase, UserTestCase, TestCase):
         assert response.content == expected
 
     def test_get_with_overview_stats(self):
-        su = SpatialUnitFactory.create(project=self.project)
+        SpatialUnitFactory.create(project=self.project)
         PartyFactory.create(project=self.project)
         ResourceFactory.create(project=self.project)
         ResourceFactory.create(project=self.project, archived=True)
-        geojson = json.dumps(
-            SpatialUnitGeoJsonSerializer([su], many=True).data)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert response.content == self.render_content(geojson=geojson,
-                                                       has_content=True,
+        assert response.content == self.render_content(has_content=True,
                                                        num_locations=1,
                                                        num_parties=1,
                                                        num_resources=1)

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -1,4 +1,3 @@
-import json
 import os
 from collections import OrderedDict
 
@@ -20,7 +19,6 @@ from django.shortcuts import get_object_or_404, redirect
 from questionnaires.exceptions import InvalidXLSForm
 from questionnaires.models import Questionnaire
 from resources.models import ContentObject, Resource
-from spatial.serializers import SpatialUnitGeoJsonSerializer
 
 from . import mixins
 from .. import messages as error_messages
@@ -419,12 +417,6 @@ class ProjectDashboard(PermissionRequiredMixin,
         context['num_locations'] = num_locations
         context['num_parties'] = num_parties
         context['num_resources'] = num_resources
-
-        su = self.object.spatial_units.all().only(
-            'id', 'type', 'geometry', 'project')
-        context['geojson'] = json.dumps(
-            SpatialUnitGeoJsonSerializer(su, many=True).data
-        )
 
         return context
 

--- a/cadasta/party/tests/test_views_default.py
+++ b/cadasta/party/tests/test_views_default.py
@@ -823,7 +823,6 @@ class PartyRelationshipDetailTest(ViewTestCase, UserTestCase, TestCase):
         return {'object': self.project,
                 'relationship': self.relationship,
                 'location': self.relationship.spatial_unit,
-                'geojson': '{"type": "FeatureCollection", "features": []}',
                 'attributes': (('Test field', 'test', ),
                                ('Test field 2', 'Choice 2', ),
                                ('Test field 3', 'Choice 1, Choice 3', ))}
@@ -898,8 +897,7 @@ class PartyRelationshipEditTest(ViewTestCase, UserTestCase, TestCase):
         return {'object': self.project,
                 'relationship': self.relationship,
                 'location': self.relationship.spatial_unit,
-                'form': form,
-                'geojson': '{"type": "FeatureCollection", "features": []}'}
+                'form': form}
 
     def setup_url_kwargs(self):
         return {
@@ -1014,8 +1012,7 @@ class PartyRelationshipDeleteTest(ViewTestCase, UserTestCase, TestCase):
     def setup_template_context(self):
         return {'object': self.project,
                 'relationship': self.relationship,
-                'location': self.relationship.spatial_unit,
-                'geojson': '{"type": "FeatureCollection", "features": []}'}
+                'location': self.relationship.spatial_unit}
 
     def setup_url_kwargs(self):
         return {
@@ -1133,8 +1130,7 @@ class PartyRelationshipResourceAddTest(ViewTestCase, UserTestCase, TestCase):
         return {'object': self.project,
                 'relationship': self.relationship,
                 'location': self.relationship.spatial_unit,
-                'form': form,
-                'geojson': '{"type": "FeatureCollection", "features": []}'}
+                'form': form}
 
     def setup_url_kwargs(self):
         return {
@@ -1268,8 +1264,7 @@ class PartyRelationshipResourceNewTest(ViewTestCase, UserTestCase,
         return {'object': self.project,
                 'location': self.relationship.spatial_unit,
                 'relationship': self.relationship,
-                'form': form,
-                'geojson': '{"type": "FeatureCollection", "features": []}'}
+                'form': form}
 
     def setup_post_data(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')

--- a/cadasta/party/views/mixins.py
+++ b/cadasta/party/views/mixins.py
@@ -1,4 +1,3 @@
-import json
 from django.http import Http404
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
@@ -6,7 +5,6 @@ from organization.views.mixins import ProjectMixin
 from resources.views.mixins import ResourceViewMixin
 from resources.models import Resource
 
-from spatial.serializers import SpatialUnitGeoJsonSerializer
 from party.models import Party, TenureRelationship
 
 
@@ -113,14 +111,6 @@ class PartyRelationshipObjectMixin(ProjectMixin):
         context['object'] = self.get_project()
         context['relationship'] = self.get_object()
         context['location'] = self.get_object().spatial_unit
-
-        locations = context['object'].spatial_units.exclude(
-            id=context['location'].id
-        ).only('id', 'type', 'geometry', 'project')
-
-        context['geojson'] = json.dumps(
-            SpatialUnitGeoJsonSerializer(locations, many=True).data
-        )
 
         return context
 

--- a/cadasta/spatial/tests/test_urls_async.py
+++ b/cadasta/spatial/tests/test_urls_async.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse, resolve
+from ..views import async
+
+
+class SpatialUrlTest(TestCase):
+
+    def test_project_spatial_unit_list(self):
+        actual = reverse('async:spatial:list',
+                         kwargs={
+                            'organization': 'habitat',
+                            'project': '123abc',
+                         })
+        expected = '/async/organizations/habitat/projects/123abc/spatial/'
+        assert actual == expected
+
+        resolved = resolve(
+            '/async/organizations/habitat/projects/123abc/spatial/')
+        assert resolved.func.__name__ == async.SpatialUnitList.__name__
+        assert resolved.kwargs['organization'] == 'habitat'
+        assert resolved.kwargs['project'] == '123abc'

--- a/cadasta/spatial/tests/test_views_async.py
+++ b/cadasta/spatial/tests/test_views_async.py
@@ -1,0 +1,197 @@
+import json
+
+from django.test import TestCase
+
+from tutelary.models import Policy, assign_user_policies
+from rest_framework.exceptions import PermissionDenied
+from skivvy import APITestCase
+
+from core.tests.utils.cases import UserTestCase
+from accounts.tests.factories import UserFactory
+from organization.tests.factories import ProjectFactory
+from organization.models import OrganizationRole
+from ..views import async
+from .factories import SpatialUnitFactory
+
+
+def assign_policies(user):
+    clauses = {
+        'clause': [
+            {
+                "effect": "allow",
+                "object": ["*"],
+                "action": ["org.*"]
+            }, {
+                'effect': 'allow',
+                'object': ['organization/*'],
+                'action': ['org.*', "org.*.*"]
+            }, {
+                'effect': 'allow',
+                'object': ['project/*/*'],
+                'action': ['project.*', 'project.*.*', 'spatial.*']
+            }, {
+                'effect': 'allow',
+                'object': ['spatial/*/*/*'],
+                'action': ['spatial.*', 'spatial.resources.*']
+            }
+        ]
+    }
+    policy = Policy.objects.create(
+        name='test-policy',
+        body=json.dumps(clauses))
+    assign_user_policies(user, policy)
+
+
+class SpatialUnitListAPITest(APITestCase, UserTestCase, TestCase):
+    view_class = async.SpatialUnitList
+
+    def setup_models(self):
+        self.user = UserFactory.create()
+        assign_policies(self.user)
+        self.prj = ProjectFactory.create(slug='test-project', access='public')
+
+    def setup_url_kwargs(self):
+        return {
+            'organization': self.prj.organization.slug,
+            'project': self.prj.slug
+        }
+
+    def test_full_list(self):
+        SpatialUnitFactory.create_batch(2, project=self.prj)
+        extra_record = SpatialUnitFactory.create()
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        assert len(response.content['features']) == 2
+        assert extra_record.id not in (
+            [u['id'] for u in response.content['features']])
+
+    def test_exclude(self):
+        SpatialUnitFactory.create_batch(2, project=self.prj)
+        excluded = SpatialUnitFactory.create(project=self.prj)
+
+        response = self.request(user=self.user,
+                                get_data={'exclude': excluded.id})
+        assert response.status_code == 200
+        assert len(response.content['features']) == 2
+        assert excluded.id not in (
+            [u['id'] for u in response.content['features']])
+
+    def test_pagination_page_1(self):
+        SpatialUnitFactory.create_batch(1010, project=self.prj)
+
+        response = self.request(user=self.user, get_data={'page': '1'})
+        assert response.status_code == 200
+        assert response.content['count'] == 1010
+        assert '?page=2' in response.content['next']
+        assert response.content['previous'] is None
+        assert len(response.content['features']) == 1000
+
+    def test_pagination_page_2(self):
+        SpatialUnitFactory.create_batch(1010, project=self.prj)
+
+        response = self.request(user=self.user, get_data={'page': '2'})
+        assert response.status_code == 200
+        assert len(response.content['features']) == 10
+        assert response.content['count'] == 1010
+        assert response.content['next'] is None
+
+    def test_full_list_with_unauthorized_user(self):
+        SpatialUnitFactory.create_batch(2, project=self.prj)
+        extra_record = SpatialUnitFactory.create()
+
+        response = self.request()
+        assert response.status_code == 200
+        assert len(response.content['features']) == 2
+        assert extra_record.id not in (
+            [u['id'] for u in response.content['features']])
+
+    def test_get_full_list_organization_does_not_exist(self):
+        response = self.request(user=self.user,
+                                url_kwargs={'organization': 'some-org'})
+        assert response.status_code == 404
+        assert response.content['detail'] == "Project not found."
+
+    def test_get_full_list_project_does_not_exist(self):
+        response = self.request(user=self.user,
+                                url_kwargs={'project': 'some-prj'})
+        assert response.status_code == 404
+        assert response.content['detail'] == "Project not found."
+
+    def test_list_private_record(self):
+        self.prj.access = 'private'
+        self.prj.save()
+
+        SpatialUnitFactory.create_batch(2, project=self.prj)
+        extra_record = SpatialUnitFactory.create()
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        assert len(response.content['features']) == 2
+        assert extra_record.id not in (
+            [u['id'] for u in response.content['features']])
+
+    def test_list_private_record_with_unauthorized_user(self):
+        self.prj.access = 'private'
+        self.prj.save()
+
+        response = self.request()
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+    def test_list_private_records_without_permission(self):
+        self.prj.access = 'private'
+        self.prj.save()
+
+        restricted_clauses = {
+            'clause': [
+                {
+                    'effect': 'allow',
+                    'object': ['project.list'],
+                    'action': ['organization/*']
+                },
+                {
+                    'effect': 'allow',
+                    'object': ['project.view'],
+                    'action': ['project/*/*']
+                }
+            ]
+        }
+        restricted_policy = Policy.objects.create(
+            name='restricted',
+            body=json.dumps(restricted_clauses))
+        assign_user_policies(self.user, restricted_policy)
+
+        response = self.request(user=self.user)
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+    def test_list_private_records_based_on_org_membership(self):
+        SpatialUnitFactory.create(project=self.prj)
+        user = UserFactory.create()
+        OrganizationRole.objects.create(organization=self.prj.organization,
+                                        user=user)
+        response = self.request(user=user)
+        assert response.status_code == 200
+
+    def test_archived_filter_with_unauthorized_user(self):
+        SpatialUnitFactory.create(project=self.prj, type='AP')
+        SpatialUnitFactory.create(project=self.prj, type='BU')
+        SpatialUnitFactory.create(project=self.prj, type='RW')
+        self.prj.archived = True
+        self.prj.save()
+
+        response = self.request()
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+    def test_archived_filter_with_org_admin(self):
+        SpatialUnitFactory.create(project=self.prj, type='AP')
+        SpatialUnitFactory.create(project=self.prj, type='BU')
+        SpatialUnitFactory.create(project=self.prj, type='RW')
+        user = UserFactory.create()
+        OrganizationRole.objects.create(organization=self.prj.organization,
+                                        user=user, admin=True)
+
+        self.prj.archived = True
+        self.prj.save()
+        response = self.request(user=user)
+        assert response.status_code == 200

--- a/cadasta/spatial/tests/test_views_default.py
+++ b/cadasta/spatial/tests/test_views_default.py
@@ -25,7 +25,6 @@ from .factories import SpatialUnitFactory
 from ..views import default
 from .. import forms
 from ..models import SpatialUnit
-from ..serializers import SpatialUnitGeoJsonSerializer
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
@@ -67,12 +66,9 @@ class LocationsListTest(ViewTestCase, UserTestCase, TestCase):
         SpatialUnitFactory.create()
 
     def setup_template_context(self):
-        geojson = json.dumps(
-            SpatialUnitGeoJsonSerializer(self.locations, many=True).data)
         return {
             'object': self.project,
             'object_list': self.locations,
-            'geojson': geojson,
             'is_allowed_add_location': True
         }
 
@@ -153,7 +149,6 @@ class LocationAddTest(ViewTestCase, UserTestCase, TestCase):
                      'selector': self.project.current_questionnaire}
                 )
             ),
-            'geojson': '{"type": "FeatureCollection", "features": []}',
             'is_allowed_add_location': True
         }
 
@@ -342,7 +337,6 @@ class LocationDetailTest(ViewTestCase, UserTestCase, TestCase):
         return {
             'object': self.project,
             'location': self.location,
-            'geojson': '{"type": "FeatureCollection", "features": []}',
             'attributes': (('Test field', 'test', ),
                            ('Test field 2', 'Choice 2', ),
                            ('Test field 3', 'Choice 1, Choice 3', )),
@@ -423,7 +417,6 @@ class LocationEditTest(ViewTestCase, UserTestCase, TestCase):
         return {'object': self.project,
                 'location': self.location,
                 'form': forms.LocationForm(instance=self.location),
-                'geojson': '{"type": "FeatureCollection", "features": []}',
                 'is_allowed_add_location': True}
 
     def setup_url_kwargs(self):
@@ -529,7 +522,6 @@ class LocationDeleteTest(ViewTestCase, UserTestCase, TestCase):
     def setup_template_context(self):
         return {'object': self.project,
                 'location': self.location,
-                'geojson': '{"type": "FeatureCollection", "features": []}',
                 'is_allowed_add_location': True}
 
     def setup_url_kwargs(self):
@@ -644,7 +636,6 @@ class LocationResourceAddTest(ViewTestCase, UserTestCase, TestCase):
         return {'object': self.project,
                 'location': self.location,
                 'form': form,
-                'geojson': '{"type": "FeatureCollection", "features": []}',
                 'is_allowed_add_location': True}
 
     def setup_url_kwargs(self):
@@ -767,7 +758,6 @@ class LocationResourceNewTest(ViewTestCase, UserTestCase,
         return {'object': self.project,
                 'location': self.location,
                 'form': form,
-                'geojson': '{"type": "FeatureCollection", "features": []}',
                 'is_allowed_add_location': True}
 
     def setup_post_data(self):
@@ -922,7 +912,6 @@ class TenureRelationshipAddTest(ViewTestCase, UserTestCase, TestCase):
                     'new_entity': not self.project.parties.exists(),
                 },
             ),
-            'geojson': '{"type": "FeatureCollection", "features": []}',
             'is_allowed_add_location': True
         }
 

--- a/cadasta/spatial/urls/async.py
+++ b/cadasta/spatial/urls/async.py
@@ -1,0 +1,19 @@
+from django.conf.urls import include, url
+
+from ..views import async
+
+
+urls = [
+    url(
+        r'^$',
+        async.SpatialUnitList.as_view(),
+        name='list'),
+]
+
+
+urlpatterns = [
+    url(
+        r'^organizations/(?P<organization>[-\w]+)/projects/'
+        '(?P<project>[-\w]+)/spatial/',
+        include(urls)),
+]

--- a/cadasta/spatial/views/async.py
+++ b/cadasta/spatial/views/async.py
@@ -1,0 +1,36 @@
+from tutelary.mixins import APIPermissionRequiredMixin
+from rest_framework import generics
+from rest_framework_gis.pagination import GeoJsonPagination
+
+from . import mixins
+from .. import serializers
+
+
+class Paginator(GeoJsonPagination):
+    page_size = 1000
+
+
+class SpatialUnitList(APIPermissionRequiredMixin,
+                      mixins.SpatialQuerySetMixin,
+                      generics.ListAPIView):
+    pagination_class = Paginator
+    serializer_class = serializers.SpatialUnitGeoJsonSerializer
+
+    def get_actions(self, request):
+        if self.get_project().archived:
+            return ['project.view_archived', 'spatial.list']
+        if self.get_project().public():
+            return ['project.view', 'spatial.list']
+        else:
+            return ['project.view_private', 'spatial.list']
+
+    permission_required = {
+        'GET': get_actions
+    }
+
+    def get_queryset(self, *args, **kwargs):
+        queryset = super().get_queryset(*args, **kwargs)
+        return queryset.exclude(id=self.request.GET.get('exclude'))
+
+    def get_perms_objects(self):
+        return [self.get_project()]

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -1,4 +1,3 @@
-import json
 from jsonattrs.mixins import JsonAttrsMixin
 import django.views.generic as base_generic
 from core.views import generic
@@ -12,7 +11,6 @@ from party.messages import TENURE_REL_CREATE
 from . import mixins
 from organization.views import mixins as organization_mixins
 from .. import forms
-from ..serializers import SpatialUnitGeoJsonSerializer
 from .. import messages as error_messages
 
 
@@ -149,17 +147,6 @@ class LocationResourceNew(LoginPermissionRequiredMixin,
     template_name = 'spatial/resources_new.html'
     permission_required = update_permissions('spatial.resources.add')
     permission_denied_message = error_messages.SPATIAL_ADD_RESOURCE
-
-    def get_context_data(self, *args, **kwargs):
-        context = super().get_context_data(*args, **kwargs)
-        project_locations = context['object'].spatial_units.only(
-            'id', 'type', 'geometry', 'project')
-        context['geojson'] = json.dumps(
-            SpatialUnitGeoJsonSerializer(
-                project_locations.exclude(id=context['location'].id),
-                many=True).data
-        )
-        return context
 
 
 class TenureRelationshipAdd(LoginPermissionRequiredMixin,

--- a/cadasta/spatial/views/mixins.py
+++ b/cadasta/spatial/views/mixins.py
@@ -49,8 +49,6 @@ class SpatialRelationshipQuerySetMixin(ProjectMixin):
 
 
 class SpatialUnitObjectMixin(SpatialQuerySetMixin):
-    queryset_excludes_object = True
-
     def get_object(self):
         if not hasattr(self, '_obj'):
             self._obj = get_object_or_404(

--- a/cadasta/spatial/views/mixins.py
+++ b/cadasta/spatial/views/mixins.py
@@ -1,4 +1,3 @@
-import json
 from django.http import Http404
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
@@ -6,7 +5,6 @@ from organization.views.mixins import ProjectMixin
 from resources.views.mixins import ResourceViewMixin
 from resources.models import Resource
 
-from ..serializers import SpatialUnitGeoJsonSerializer
 from ..models import SpatialUnit
 
 
@@ -14,28 +12,13 @@ class SpatialQuerySetMixin(ProjectMixin):
     def get_queryset(self):
         self.proj = self.get_project()
         if not hasattr(self, '_queryset'):
-            if (
-                hasattr(self, 'queryset_excludes_object') and
-                self.queryset_excludes_object
-            ):
-                self._queryset = self.proj.spatial_units.exclude(
-                    id=self.kwargs['location']).only(
-                    'id', 'type', 'geometry', 'project')
-            else:
-                self._queryset = self.proj.spatial_units.all().only(
-                    'id', 'type', 'geometry', 'project')
+            self._queryset = self.proj.spatial_units.all().only(
+                'id', 'type', 'geometry', 'project').order_by('id')
         return self._queryset
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context['object'] = self.get_project()
-        locations = self.get_queryset()
-        if locations.model == SpatialUnit:
-            context['geojson'] = json.dumps(
-                SpatialUnitGeoJsonSerializer(locations, many=True).data)
-        else:
-            context['geojson'] = (
-                '{"type": "FeatureCollection", "features": []}')
         return context
 
     def get_serializer_context(self, *args, **kwargs):

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -112,7 +112,6 @@
       <div id="page-content">
         {% block sub-nav %}{% endblock %}
         <main class="container-fluid{% block main-width %}{% endblock %}" role="main">
-          {% if messages %}
           <div id="messages">
             {% for message in messages %}
             <div class="alert alert-dismissible{% if message.tags %} alert-{{ message.tags }}{% endif %}" role="alert">
@@ -122,8 +121,10 @@
               {{message}}
             </div>
             {% endfor %}
+            <div class="alert alert-info hidden" role="alert" id="loading">
+              {% trans "Loading locations..." %}
+            </div>
           </div>
-          {% endif %}
           {% block content %}{% endblock %}
         </main>
       </div>

--- a/cadasta/templates/organization/project_dashboard.html
+++ b/cadasta/templates/organization/project_dashboard.html
@@ -28,8 +28,10 @@
     {% else %}
     var projectExtent = null;
     {% endif %}
-    var spatialUnits = {{ geojson|safe }};
-    renderFeatures(map, projectExtent, spatialUnits, trans, 'locations');
+
+    renderFeatures(map,
+                   '{% url "async:spatial:list" project.organization.slug project.slug %}',
+                   {projectExtent: projectExtent, trans: trans, fitBounds: 'locations'});
 
     var orgSlug = '{{ project.organization.slug }}';
     var projectSlug = '{{ project.slug }}';

--- a/cadasta/templates/spatial/location_add.html
+++ b/cadasta/templates/spatial/location_add.html
@@ -41,11 +41,8 @@
       }
       var options = detail.options;
       add_map_controls(detail.map);
-
       switch_layer_controls(detail.map, options);
 
-      // TODO: It seems Leaflet has a bug with L.geoJson()
-      // not returning the correct bounds (see #377 for details)
       var trans = {
         open: "{% trans 'Open location' %}"
       };
@@ -55,9 +52,10 @@
       {% else %}
       var projectExtent = null;
       {% endif %}
-      var spatialUnits = {{ geojson|safe }};
 
-      renderFeatures(detail.map, projectExtent, spatialUnits, trans, 'project');
+      renderFeatures(detail.map,
+                     '{% url "async:spatial:list" object.organization.slug object.slug %}',
+                     {projectExtent: projectExtent, trans: trans, fitBounds: 'locations'});
 
       var orgSlug = '{{ object.organization.slug }}';
       var projectSlug = '{{ object.slug }}';

--- a/cadasta/templates/spatial/location_edit.html
+++ b/cadasta/templates/spatial/location_edit.html
@@ -47,11 +47,8 @@
       add_spatial_resources(map, url);
 
       add_map_controls(map);
-
-      var data = {{ geojson|safe }};
-
-      var trans = {open: "{% trans 'Open location' %}"}
-      renderFeatures(detail.map, null, data, trans);
+      renderFeatures(detail.map,
+                     '{% url "async:spatial:list" object.organization.slug object.slug %}?exclude={{location.id}}');
 
       // Enable edit mode on map load and save the geometry on page save
       setTimeout(enableMapEditMode, 500);

--- a/cadasta/templates/spatial/location_map.html
+++ b/cadasta/templates/spatial/location_map.html
@@ -29,9 +29,10 @@
     {% else %}
     var projectExtent = null;
     {% endif %}
-    var spatialUnits = {{ geojson|safe }};
 
-    renderFeatures(map, projectExtent, spatialUnits, trans, 'locations');
+    renderFeatures(map,
+                   '{% url "async:spatial:list" object.organization.slug object.slug %}',
+                   {projectExtent: projectExtent, trans: trans, fitBounds: 'locations'});
 
     var orgSlug = '{{ object.organization.slug }}';
     var projectSlug = '{{ object.slug }}';

--- a/cadasta/templates/spatial/location_wrapper.html
+++ b/cadasta/templates/spatial/location_wrapper.html
@@ -32,19 +32,9 @@
     {% else %}
     var projectExtent = null;
     {% endif %}
-    var spatialUnits = {{ geojson|safe }};
-
-    renderFeatures(map, projectExtent, spatialUnits, trans, false);
-    
-    var orgSlug = '{{ object.organization.slug }}';
-    var projectSlug = '{{ object.slug }}';
-    var url = '/api/v1/organizations/'
-            + orgSlug + '/projects/' + projectSlug + '/spatialresources/';
-    add_spatial_resources(map, url);
-
 
     var data = {{ location.geometry.geojson|safe }};
-    var location = L.geoJson(data, {
+    var currentlocation = L.geoJson(data, {
       style: {color: '#edaa00', fillColor: '#edaa00', weight: 3},
       onEachFeature: function(feature, layer) {
         layer.bindPopup("<div class=\"text-wrap\">" +
@@ -53,8 +43,16 @@
                        "</div>");
       }
     });
-    location.addTo(map);
-    map.fitBounds(location.getBounds());
+
+    renderFeatures(map,
+                   '{% url "async:spatial:list" object.organization.slug object.slug %}?exclude={{location.id}}',
+                   {projectExtent: projectExtent, trans: trans, location: currentlocation});
+    
+    var orgSlug = '{{ object.organization.slug }}';
+    var projectSlug = '{{ object.slug }}';
+    var url = '/api/v1/organizations/'
+            + orgSlug + '/projects/' + projectSlug + '/spatialresources/';
+    add_spatial_resources(map, url);
   }
 
   $(document).ready(function() {


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolves #931: Improves responsiveness of map views by asynchronoulsy loading geographic features. 
- Introduces `spatial.views.asyc.SpatialUnitList`, which provides paginated access to spatial units on a project. The page size is set to 1000. The view uses a custom `Paginator` based on [`GeoJsonPagination`](https://github.com/djangonauts/django-rest-framework-gis#geojsonpagination)
- Removes synchronous loading of project locations from all map views. Views affected include:
  - `organization.views.default.ProjectDashboard`
  - `spatial.views.default.LocationList`
  - `spatial.views.default.LocationAdd`
  - `spatial.views.default.LocationDetail`
  - `spatial.views.default.LocationEdit`
  - `party.views.default.PartyRelationshipDetail`
  - `party.views.default.PartyRelationshipEdit`
  - `party.views.default.PartyRelationshipDelete`
  - `party.views.default.PartyRelationshipResourceAdd`
  - `party.views.default.PartyRelationshipResourceNew`
- Add asynchrousnoues loading of geographic feature from aforementioned  `spatial.views.asyc.SpatialUnitList`. `renderfeatures()` inside `core/static/js/map_utils.js` has been adapted accordingly.
- Adds a loading alert. The alert is added to `templates/core/base.html` and hidden by default. `renderfeatures()` shows and hides the alert. 

### When should this PR be merged

Anytime for sprint 11.

### Risks

Low.

### Follow up actions

While this PR should improve the responsiveness of map views, it will likely be only a stop-gap solution until we have implemented a more sustainable solution. Research into a sustainable solution should start now, and we should coordinate this with work towards [improving map interactions](#559). 