### PR TITLE
Fix #950 -- Remove LoginRequiredMixin from PasswordResetView

### DIFF
--- a/cadasta/accounts/views/default.py
+++ b/cadasta/accounts/views/default.py
@@ -21,8 +21,7 @@ class PasswordChangeView(LoginRequiredMixin,
     pass
 
 
-class PasswordResetView(LoginRequiredMixin,
-                        SuperUserCheckMixin,
+class PasswordResetView(SuperUserCheckMixin,
                         allauth_views.PasswordResetView):
     pass
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #950: `PasswordResetView` requires users log in before the page can be accessed. I removed `LoginRequiredMixin`; the page is now also accessible to unauthenticated users. 

### When should this PR be merged

Anytime.



### Risks

Low.

### Follow up actions

N/A