### PR TITLE
Password strength requirements implemented for server-side

### DIFF
--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -119,15 +119,6 @@ class ChangePasswordForm(allauth_forms.ChangePasswordForm):
 
         return password
 
-    def clean_password2(self):
-        if ('password1' in self.cleaned_data and
-           'password2' in self.cleaned_data):
-            if (self.cleaned_data['password1'] !=
-               self.cleaned_data['password2']):
-                raise forms.ValidationError(_("Passwords do not match"))
-
-        return self.cleaned_data['password2']
-
 
 class ResetPasswordKeyForm(allauth_forms.ResetPasswordKeyForm):
     def __init__(self, *args, **kwargs):
@@ -138,12 +129,3 @@ class ResetPasswordKeyForm(allauth_forms.ResetPasswordKeyForm):
         validate_password(password, self.user)
 
         return password
-
-    def clean_password2(self):
-        if ('password1' in self.cleaned_data and
-           'password2' in self.cleaned_data):
-            if (self.cleaned_data['password1'] !=
-               self.cleaned_data['password2']):
-                raise forms.ValidationError(_("Passwords do not match"))
-
-        return self.cleaned_data['password2']

--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -2,7 +2,9 @@ from datetime import datetime, timezone, timedelta
 from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext as _
+from django.contrib.auth.password_validation import validate_password
 from allauth.account.utils import send_email_confirmation
+from allauth.account import forms as allauth_forms
 
 from .models import User
 from parsley.decorators import parsleyfy
@@ -13,6 +15,7 @@ class RegisterForm(forms.ModelForm):
     email = forms.EmailField(required=True)
     password1 = forms.CharField(widget=forms.PasswordInput())
     password2 = forms.CharField(widget=forms.PasswordInput())
+    MIN_LENGTH = 10
 
     class Meta:
         model = User
@@ -28,8 +31,23 @@ class RegisterForm(forms.ModelForm):
 
     def clean_password1(self):
         password = self.data.get('password1')
+        validate_password(password)
+        errors = []
+
         if password != self.data.get('password2'):
             raise forms.ValidationError(_("Passwords do not match"))
+
+        email = self.data.get('email').lower().split('@')
+        if email[0] in password:
+            errors.append(_("Passwords cannot contain your email."))
+
+        if self.data.get('username') in password:
+            errors.append(
+                _("The password is too similar to the username."))
+
+        if errors:
+            raise forms.ValidationError(errors)
+
         return password
 
     def clean_email(self):
@@ -89,3 +107,43 @@ class ProfileForm(forms.ModelForm):
 
         user.save()
         return user
+
+
+class ChangePasswordForm(allauth_forms.ChangePasswordForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def clean_password1(self):
+        password = self.cleaned_data['password1']
+        validate_password(password, user=self.user)
+
+        return password
+
+    def clean_password2(self):
+        if ('password1' in self.cleaned_data and
+           'password2' in self.cleaned_data):
+            if (self.cleaned_data['password1'] !=
+               self.cleaned_data['password2']):
+                raise forms.ValidationError(_("Passwords do not match"))
+
+        return self.cleaned_data['password2']
+
+
+class ResetPasswordKeyForm(allauth_forms.ResetPasswordKeyForm):
+    def __init__(self, *args, **kwargs):
+        super(ResetPasswordKeyForm, self).__init__(*args, **kwargs)
+
+    def clean_password1(self):
+        password = self.cleaned_data['password1']
+        validate_password(password, self.user)
+
+        return password
+
+    def clean_password2(self):
+        if ('password1' in self.cleaned_data and
+           'password2' in self.cleaned_data):
+            if (self.cleaned_data['password1'] !=
+               self.cleaned_data['password2']):
+                raise forms.ValidationError(_("Passwords do not match"))
+
+        return self.cleaned_data['password2']

--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.utils import timezone
 from django.utils.translation import ugettext as _
+from django.contrib.auth.password_validation import validate_password
 
 from rest_framework.serializers import EmailField, ValidationError
 from rest_framework.validators import UniqueValidator
@@ -38,6 +39,24 @@ class RegistrationSerializer(djoser_serializers.UserRegistrationSerializer):
             raise ValidationError(
                 _("Username cannot be “add” or “new”."))
         return username
+
+    def validate_password(self, password):
+        validate_password(password)
+
+        errors = []
+        if self.initial_data.get('email'):
+            email = self.initial_data.get('email').lower().split('@')
+            if email[0] in password:
+                errors.append(_("Passwords cannot contain your email."))
+
+        if self.initial_data.get('username') in password:
+            errors.append(
+                _("The password is too similar to the username."))
+
+        if errors:
+            raise ValidationError(errors)
+
+        return password
 
 
 class UserSerializer(djoser_serializers.UserSerializer):

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -267,7 +267,8 @@ class ChangePasswordFormTest(UserTestCase, TestCase):
         form = forms.ChangePasswordForm(user, data)
 
         assert form.is_valid() is False
-        assert _("Passwords do not match") in form.errors.get('password2')
+        assert (_('You must type the same password each time.') in
+                form.errors.get('password2'))
 
     def test_password_contains_username(self):
         user = UserFactory.create(
@@ -360,7 +361,8 @@ class ResetPasswordFormTest(UserTestCase, TestCase):
         form = forms.ResetPasswordKeyForm(data, user=user)
 
         assert form.is_valid() is False
-        assert _("Passwords do not match") in form.errors.get('password2')
+        assert (_('You must type the same password each time.') in
+                form.errors.get('password2'))
 
     def test_password_contains_username(self):
         user = UserFactory.create(

--- a/cadasta/accounts/tests/test_serializers.py
+++ b/cadasta/accounts/tests/test_serializers.py
@@ -19,7 +19,7 @@ from .factories import UserFactory
 BASIC_TEST_DATA = {
     'username': 'imagine71',
     'email': 'john@beatles.uk',
-    'password': 'iloveyoko79',
+    'password': 'iloveyoko79!',
     'full_name': 'John Lennon',
 }
 
@@ -48,8 +48,8 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
 
         data = {
             'username': 'imagine71',
-            'password': 'iloveyoko79',
-            'password_repeat': 'iloveyoko79',
+            'password': 'iloveyoko79!',
+            'password_repeat': 'iloveyoko79!',
             'full_name': 'John Lennon',
         }
 
@@ -65,8 +65,8 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'password': 'iloveyoko79',
-            'password_repeat': 'iloveyoko79',
+            'password': 'iloveyoko79!',
+            'password_repeat': 'iloveyoko79!',
             'full_name': 'John Lennon',
         }
 
@@ -80,8 +80,8 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': random.choice(invalid_usernames),
             'email': 'john@beatles.uk',
-            'password': 'iloveyoko79',
-            'password_repeat': 'iloveyoko79',
+            'password': 'iloveyoko79!',
+            'password_repeat': 'iloveyoko79!',
             'full_name': 'John Lennon',
         }
 
@@ -89,6 +89,62 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         assert not serializer.is_valid()
         assert (_("Username cannot be “add” or “new”.")
                 in serializer._errors['username'])
+
+    def test_password_contains_username(self):
+        data = {
+            'username': 'yoko79',
+            'email': 'john@beatles.uk',
+            'password': 'iloveyoko79!',
+            'password_repeat': 'iloveyoko79!',
+            'full_name': 'John Lennon',
+        }
+        serializer = RegistrationSerializer(data=data)
+        assert not serializer.is_valid()
+        assert (_("The password is too similar to the username.") in
+                serializer._errors['password'])
+
+    def test_password_contains_email(self):
+        data = {
+            'username': 'imagine71',
+            'email': 'john@beatles.uk',
+            'password': 'johnisjustheBest!!',
+            'password_repeat': 'johnisjustheBest!!',
+            'full_name': 'John Lennon',
+        }
+        serializer = RegistrationSerializer(data=data)
+        assert not serializer.is_valid()
+        assert (_("Passwords cannot contain your email.") in
+                serializer._errors['password'])
+
+    def test_password_contains_less_than_min_characters(self):
+        data = {
+            'username': 'imagine71',
+            'email': 'john@beatles.uk',
+            'password': 'yoko<3',
+            'password_repeat': 'yoko<3',
+            'full_name': 'John Lennon',
+        }
+        serializer = RegistrationSerializer(data=data)
+        assert not serializer.is_valid()
+        assert (_("This password is too short."
+                  " It must contain at least 10 characters.") in
+                serializer._errors['password'])
+
+    def test_password_does_not_meet_unique_character_requirements(self):
+        data = {
+            'username': 'imagine71',
+            'email': 'john@beatles.uk',
+            'password': 'iloveyoko',
+            'password_repeat': 'iloveyoko',
+            'full_name': 'John Lennon',
+        }
+        serializer = RegistrationSerializer(data=data)
+        assert not serializer.is_valid()
+        assert (_("Passwords must contain at least 3"
+                  " of the following 4 character types:\n"
+                  "lowercase characters, uppercase characters,"
+                  " special characters, and/or numerical character.\n"
+                  ) in serializer._errors['password'])
 
 
 class UserSerializerTest(UserTestCase, TestCase):

--- a/cadasta/accounts/tests/test_views_api.py
+++ b/cadasta/accounts/tests/test_views_api.py
@@ -68,7 +68,7 @@ class AccountSignupTest(APITestCase, UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'password': 'iloveyoko79',
+            'password': 'iloveyoko79!',
             'full_name': 'John Lennon',
         }
         response = self.request(method='POST', post_data=data)
@@ -80,7 +80,7 @@ class AccountSignupTest(APITestCase, UserTestCase, TestCase):
            to sign up with invalid data"""
         data = {
             'username': 'imagine71',
-            'password': 'iloveyoko79',
+            'password': 'iloveyoko79!',
             'full_name': 'John Lennon',
         }
         response = self.request(method='POST', post_data=data)
@@ -94,18 +94,18 @@ class AccountLoginTest(APITestCase, UserTestCase, TestCase):
     def setup_models(self):
         self.user = UserFactory.create(username='imagine71',
                                        email='john@beatles.uk',
-                                       password='iloveyoko79')
+                                       password='iloveyoko79!')
 
     def test_successful_login(self):
         """The view should return a token to authenticate API calls"""
-        data = {'username': 'imagine71', 'password': 'iloveyoko79'}
+        data = {'username': 'imagine71', 'password': 'iloveyoko79!'}
         response = self.request(method='POST', post_data=data)
         assert response.status_code == 200
         assert 'auth_token' in response.content
 
     def test_unsuccessful_login(self):
         """The view should return a token to authenticate API calls"""
-        data = {'username': 'imagine71', 'password': 'iloveyoko78'}
+        data = {'username': 'imagine71', 'password': 'iloveyoko78!'}
         response = self.request(method='POST', post_data=data)
         assert response.status_code == 400
 
@@ -115,7 +115,7 @@ class AccountLoginTest(APITestCase, UserTestCase, TestCase):
            sent to the user."""
         self.user.verify_email_by = datetime.now()
         self.user.save()
-        data = {'username': 'imagine71', 'password': 'iloveyoko79'}
+        data = {'username': 'imagine71', 'password': 'iloveyoko79!'}
         response = self.request(method='POST', post_data=data)
         assert response.status_code == 400
         assert 'auth_token' not in response.content

--- a/cadasta/accounts/urls/default.py
+++ b/cadasta/accounts/urls/default.py
@@ -9,6 +9,9 @@ urlpatterns = [
         name='verify_email'),
     url(r'^password/change/$', default.PasswordChangeView.as_view(),
         name="account_change_password"),
+    url(r'^password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$',
+        default.PasswordResetFromKeyView.as_view(),
+        name="account_reset_password_from_key"),
     url(r'^password/reset/$', default.PasswordResetView.as_view(),
         name="account_reset_password"),
 ]

--- a/cadasta/accounts/validators.py
+++ b/cadasta/accounts/validators.py
@@ -1,0 +1,49 @@
+import string
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext as _
+
+
+DEFAULT_CHARACTER_TYPES = [
+            string.ascii_lowercase,
+            string.ascii_uppercase,
+            string.punctuation,
+            string.digits
+        ]
+
+
+class CharacterTypePasswordValidator(object):
+    def __init__(self, character_types=DEFAULT_CHARACTER_TYPES,
+                 unique_types=3):
+        self.character_types = character_types
+        self.unique_types = unique_types
+
+    def error_message(self):
+        return _((
+            "Passwords must contain at least {unique_types} of the following "
+            " {character_types} character types:\n"
+            "lowercase characters, uppercase characters, "
+            "special characters, "
+            "and/or numerical character.\n").format(
+            unique_types=self.unique_types,
+            character_types=len(self.character_types)))
+
+    def validate(self, password, user=None):
+        errors = 0
+
+        for character_type in self.character_types:
+            if len(set(character_type).intersection(password)) == 0:
+                errors += 1
+
+        if len(self.character_types) - self.unique_types < errors:
+            raise ValidationError(self.error_message())
+
+
+class EmailSimilarityValidator(object):
+    def validate(self, password, user=None):
+        if not user:
+            return None
+
+        email = user.email.lower().split('@')
+        if email[0] in password:
+            raise ValidationError(
+                _("Passwords cannot contain your email."))

--- a/cadasta/accounts/validators.py
+++ b/cadasta/accounts/validators.py
@@ -18,9 +18,9 @@ class CharacterTypePasswordValidator(object):
         self.unique_types = unique_types
 
     def error_message(self):
-        return _((
+        return (_(
             "Passwords must contain at least {unique_types} of the following "
-            " {character_types} character types:\n"
+            "{character_types} character types:\n"
             "lowercase characters, uppercase characters, "
             "special characters, "
             "and/or numerical character.\n").format(

--- a/cadasta/accounts/views/default.py
+++ b/cadasta/accounts/views/default.py
@@ -12,17 +12,24 @@ from allauth.account.views import ConfirmEmailView, LoginView
 from allauth.account.utils import send_email_confirmation
 
 from ..models import User
-from ..forms import ProfileForm
+from ..forms import ProfileForm, ChangePasswordForm, ResetPasswordKeyForm
 
 
 class PasswordChangeView(LoginRequiredMixin,
                          SuperUserCheckMixin,
                          allauth_views.PasswordChangeView):
+    form_class = ChangePasswordForm
     pass
 
 
 class PasswordResetView(SuperUserCheckMixin,
                         allauth_views.PasswordResetView):
+    pass
+
+
+class PasswordResetFromKeyView(SuperUserCheckMixin,
+                               allauth_views.PasswordResetFromKeyView):
+    form_class = ResetPasswordKeyForm
     pass
 
 

--- a/cadasta/accounts/views/default.py
+++ b/cadasta/accounts/views/default.py
@@ -19,7 +19,6 @@ class PasswordChangeView(LoginRequiredMixin,
                          SuperUserCheckMixin,
                          allauth_views.PasswordChangeView):
     form_class = ChangePasswordForm
-    pass
 
 
 class PasswordResetView(SuperUserCheckMixin,
@@ -30,7 +29,6 @@ class PasswordResetView(SuperUserCheckMixin,
 class PasswordResetFromKeyView(SuperUserCheckMixin,
                                allauth_views.PasswordResetFromKeyView):
     form_class = ResetPasswordKeyForm
-    pass
 
 
 class AccountProfile(LoginRequiredMixin, UpdateView):

--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -160,6 +160,36 @@ ACCOUNT_FORMS = {
 ACCOUNT_LOGOUT_ON_GET = True
 ACCOUNT_LOGOUT_REDIRECT_URL = LOGIN_URL
 
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': ('django.contrib.auth.'
+                 'password_validation.UserAttributeSimilarityValidator'),
+    },
+    {
+        'NAME':
+            'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {
+            'min_length': 10,
+        }
+    },
+    {
+        'NAME':
+            'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME':
+            'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+    {
+        'NAME':
+            'accounts.validators.CharacterTypePasswordValidator'
+    },
+    {
+        'NAME':
+            'accounts.validators.EmailSimilarityValidator'
+    },
+]
+
 OSM_ATTRIBUTION = _(
     "Base map data &copy; <a href=\"http://openstreetmap.org\">"
     "OpenStreetMap</a> contributors under "


### PR DESCRIPTION
### Proposed changes in this pull request
- Added password strength requirements to registration, update password, and reset password

### When should this PR be merged
Depends on whether or not we want to combine this PR with Chandra's which includes the parsley integration and updated copy. I just made up error messages, but wanted to create the PR to see if there were other things that need to fixed.


### Risks
- Currently doesn't include a way to trigger an already existing user if their password isn't up to snuff.

### Follow up actions
- Update copy to be consistent.
- Add trigger for existing users with weak passwords.

