### PR TITLE
Include AWS CLI for all envs

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -30,3 +30,4 @@ pytz==2016.4
 shapely==1.5.16
 gdal==1.10.0
 pylibmc==1.5.1
+awscli==1.11.23


### PR DESCRIPTION
### Proposed changes in this pull request

Adds the AWS CLI pip package to requirements for all envs. Required for testing (in dev) and utilizing (in staging/demo/production) SQS for the ElasticSearch implementation.

### When should this PR be merged

Anytime

### Risks

None

### Follow up actions

Anyone who needs to interact with the SQS staging queue or other AWS components via the CLI should contact me for API access keys and account permissions configuration.