### PR TITLE
PostGIS 2.3 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ python:
   - '3.5'
 addons:
   postgresql: '9.4'
+  apt:
+    packages:
+      - postgresql-9.4-postgis-2.3
 
 before_install:
   - export DEBIAN_FRONTEND=noninteractive
   - sudo -E apt-get -yq update &>> ~/apt-get-update.log
-  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install postgresql-9.4-postgis-2.2 squid3
+  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install squid3
   - sudo apt-get -yq install libgdal-dev
   - gdal-config --version
   - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")


### PR DESCRIPTION
### Proposed changes in this pull request

- Upgrade `.travis.yml` to use PostGIS 2.3

### When should this PR be merged

ASAP


### Risks

None
 
### Follow up actions

Revisit whether we use PostGIS 2.3 on our production systems or make builds pass with PostGIS 2.1.