### PR TITLE
detach_object_resources now works for deferred objects

### DIFF
--- a/cadasta/party/models.py
+++ b/cadasta/party/models.py
@@ -14,7 +14,7 @@ from organization.models import Project
 from organization.validators import validate_contact
 from simple_history.models import HistoricalRecords
 
-from resources.mixins import ResourceModelMixin, detach_object_resources
+from resources.mixins import ResourceModelMixin
 from spatial.models import SpatialUnit
 from tutelary.decorators import permissioned_model
 
@@ -135,9 +135,6 @@ class Party(ResourceModelMixin, RandomIDModel):
                 'party': self.id,
             },
         )
-
-
-models.signals.pre_delete.connect(detach_object_resources, sender=Party)
 
 
 @fix_model_for_attributes
@@ -329,10 +326,6 @@ class TenureRelationship(ResourceModelMixin, RandomIDModel):
                 'relationship': self.id,
             },
         )
-
-
-models.signals.pre_delete.connect(
-    detach_object_resources, sender=TenureRelationship)
 
 
 class TenureRelationshipType(models.Model):

--- a/cadasta/resources/mixins.py
+++ b/cadasta/resources/mixins.py
@@ -1,5 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.apps import apps
+from django.dispatch import receiver
+from django.db.models.signals import pre_delete
 
 
 class ResourceModelMixin:
@@ -24,9 +26,14 @@ class ResourceModelMixin:
             del self._resources
 
 
+@receiver(pre_delete)
 def detach_object_resources(sender, instance, **kwargs):
-    for resource in instance.resources:
-        content_object = resource.content_objects.get(
-            object_id=instance.id,
-            resource__project__slug=instance.project.slug)
-        content_object.delete()
+    list_of_models = ('Party', 'TenureRelationship', 'SpatialUnit')
+    sender = sender.__base__ if sender._deferred else sender
+
+    if sender.__name__ in list_of_models:
+        for resource in instance.resources:
+            content_object = resource.content_objects.get(
+                object_id=instance.id,
+                resource__project__slug=instance.project.slug)
+            content_object.delete()

--- a/cadasta/spatial/models.py
+++ b/cadasta/spatial/models.py
@@ -12,7 +12,7 @@ from shapely.wkt import dumps
 
 from . import messages, managers
 from .choices import TYPE_CHOICES
-from resources.mixins import ResourceModelMixin, detach_object_resources
+from resources.mixins import ResourceModelMixin
 from jsonattrs.fields import JSONAttributeField
 from jsonattrs.decorators import fix_model_for_attributes
 
@@ -146,8 +146,6 @@ def reassign_spatial_geometry(instance):
 def check_extent(sender, instance, **kwargs):
     if instance.geometry:
         reassign_spatial_geometry(instance)
-
-models.signals.pre_delete.connect(detach_object_resources, sender=SpatialUnit)
 
 
 @fix_model_for_attributes


### PR DESCRIPTION
### Proposed changes in this pull request
- deferring attributes in record views caused a regression (#803)
- `detach_object_resources` now works for deferred objects
- added tests for deleting deferred objects

### When should this PR be merged
Whenever, unless this is a big enough bug that it needs to be added before releasing to platform.

### Risks
None

### Follow up actions
None