### PR TITLE
Loadpolicies bugfix & provisioning

### DIFF
--- a/cadasta/accounts/load.py
+++ b/cadasta/accounts/load.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from tutelary import models
 
 
-def run(verbose=True, force=False, update=False):
+def run(verbose=True, force=False):
     PERMISSIONS_DIR = settings.BASE_DIR + '/permissions/'
 
     if force:
@@ -16,9 +16,8 @@ def run(verbose=True, force=False, update=False):
                 'project-manager', 'data-collector', 'project-user']:
         try:
             pols[pol] = models.Policy.objects.get(name=pol)
-            if update:
-                pols[pol].body = open(PERMISSIONS_DIR + pol + '.json').read()
-                pols[pol].save()
+            pols[pol].body = open(PERMISSIONS_DIR + pol + '.json').read()
+            pols[pol].save()
         except:
             pols[pol] = models.Policy.objects.create(
                 name=pol,

--- a/cadasta/accounts/management/commands/loadpolicies.py
+++ b/cadasta/accounts/management/commands/loadpolicies.py
@@ -13,11 +13,5 @@ class Command(BaseCommand):
             dest='force',
             default=False)
 
-        parser.add_argument(
-            '--update',
-            action='store_true',
-            dest='update',
-            default=False)
-
     def handle(self, *args, **options):
-        load.run(force=options['force'], update=options['update'])
+        load.run(force=options['force'])

--- a/cadasta/accounts/tests/test_load.py
+++ b/cadasta/accounts/tests/test_load.py
@@ -1,0 +1,37 @@
+from core.tests.factories import PolicyFactory
+from tutelary.models import PermissionSet, Role, Policy
+from django.test import TestCase
+from .. import load
+
+policies = ['default', 'superuser', 'org-admin', 'org-member',
+            'project-manager', 'data-collector', 'project-user']
+
+
+class LoadTest(TestCase):
+    def test_load_create(self):
+        assert PermissionSet.objects.exists() is False
+        assert Role.objects.exists() is False
+        assert Policy.objects.exists() is False
+
+        load.run()
+
+        for pol in policies:
+            assert Policy.objects.get(name=pol)
+
+    def test_load(self):
+        PolicyFactory.load_policies()
+        existing_pols = {p: Policy.objects.get(name=p) for p in policies}
+
+        load.run()
+
+        for pol in policies:
+            assert Policy.objects.get(name=pol) == existing_pols[pol]
+
+    def test_load_force(self):
+        PolicyFactory.load_policies()
+        existing_pols = {p: Policy.objects.get(name=p) for p in policies}
+
+        load.run(force=True)
+
+        for pol in policies:
+            assert Policy.objects.get(name=pol) != existing_pols[pol]

--- a/cadasta/accounts/tests/test_management_commands_loadpolicies.py
+++ b/cadasta/accounts/tests/test_management_commands_loadpolicies.py
@@ -25,10 +25,10 @@ class LoadPoliciesTest(TestCase):
         call_command('loadpolicies')
         assert accounts.load.run.call_count == 1
         assert accounts.load.run.args == ()
-        assert accounts.load.run.kwargs == {'force': False, 'update': False}
+        assert accounts.load.run.kwargs == {'force': False}
 
     def test_command_with_args(self):
-        call_command('loadpolicies', force=True, update=True)
+        call_command('loadpolicies', force=True)
         assert accounts.load.run.call_count == 1
         assert accounts.load.run.args == ()
-        assert accounts.load.run.kwargs == {'force': True, 'update': True}
+        assert accounts.load.run.kwargs == {'force': True}

--- a/cadasta/core/management/commands/loadstatic.py
+++ b/cadasta/core/management/commands/loadstatic.py
@@ -19,30 +19,19 @@ class Command(BaseCommand):
             default=False,
             help='Force object deletion and recreation'
         )
-        parser.add_argument(
-            '--update-policies',
-            action='store_true',
-            dest='update_policies',
-            default=False,
-            help='Force update of tutelary policies from JSON files'
-        )
 
     def handle(self, *args, **options):
-        if options['update_policies']:
-            print('PERFORMING POLICY UPDATE FROM FILES!!!\n')
-            loadpolicies.Command().handle(force=False, update=True)
-        else:
-            # All of the following are idempotent unless "force" is used.
-            if options['force']:
-                print('FORCING STATIC DATA RELOAD!!!\n')
+        # All of the following are idempotent unless "force" is used.
+        if options['force']:
+            print('FORCING STATIC DATA RELOAD!!!\n')
 
-            print('LOADING SITE\n')
-            loadsite.Command().handle(force=options['force'])
-            print('LOADING COUNTRIES\n')
-            loadcountries.Command().handle(force=options['force'])
-            print('LOADING POLICIES\n')
-            loadpolicies.Command().handle(force=options['force'], update=False)
-            print('LOADING ATTRIBUTE TYPES\n')
-            loadattrtypes.Command().handle(force=options['force'])
-            print('LOADING TENURE RELATIONSHIP TYPES\n')
-            loadtenurereltypes.Command().handle(force=options['force'])
+        print('LOADING SITE\n')
+        loadsite.Command().handle(force=options['force'])
+        print('LOADING COUNTRIES\n')
+        loadcountries.Command().handle(force=options['force'])
+        print('LOADING POLICIES\n')
+        loadpolicies.Command().handle(force=options['force'])
+        print('LOADING ATTRIBUTE TYPES\n')
+        loadattrtypes.Command().handle(force=options['force'])
+        print('LOADING TENURE RELATIONSHIP TYPES\n')
+        loadtenurereltypes.Command().handle(force=options['force'])

--- a/cadasta/core/tests/factories.py
+++ b/cadasta/core/tests/factories.py
@@ -28,8 +28,8 @@ class PolicyFactory(factory.django.DjangoModelFactory):
         kwargs['body'] = open(body_file).read()
         return kwargs
 
-    def load_policies(update=False):
-        load.run(force=not update, update=update)
+    def load_policies(force=True):
+        load.run(force)
 
 
 class RoleFactory(factory.django.DjangoModelFactory):

--- a/cadasta/core/tests/test_management_commands.py
+++ b/cadasta/core/tests/test_management_commands.py
@@ -20,8 +20,6 @@ class FixturesTest(TestCase):
         data.delete_test_projects()
         data.add_test_organizations()
         PolicyFactory.load_policies()
-        # Just for test coverage...
-        PolicyFactory.load_policies(update=True)
         create_attribute_types()
         load_tenure_relationship_types()
         data.add_test_users_and_roles()

--- a/cadasta/core/tests/test_management_commands.py
+++ b/cadasta/core/tests/test_management_commands.py
@@ -20,6 +20,8 @@ class FixturesTest(TestCase):
         data.delete_test_projects()
         data.add_test_organizations()
         PolicyFactory.load_policies()
+        # Just for test coverage...
+        PolicyFactory.load_policies(force=True)
         create_attribute_types()
         load_tenure_relationship_types()
         data.add_test_users_and_roles()

--- a/provision/roles/webserver/production/tasks/main.yml
+++ b/provision/roles/webserver/production/tasks/main.yml
@@ -85,6 +85,14 @@
   notify:
     - Restart nginx
 
+- name: Load static data
+  become: yes
+  become_user: "{{ app_user }}"
+  django_manage: command=loadstatic
+                 app_path="{{ application_path }}cadasta"
+                 virtualenv="{{ virtualenv_path }}"
+                 settings="{{ django_settings }}"
+
 - name: Link static content
   become: yes
   become_user: "{{ app_user }}"


### PR DESCRIPTION
### Proposed changes in this pull request

Fix to ensure policies are updated during provisioning -- see #978 

This PR:

1. Removes update flag from loadpolicies and cleans up tests
2. Restores provisioning step
3. Cleans up tests to prevent cruft

### When should this PR be merged

For Sprint 11 Release

### Risks

Low

### Follow up actions

As long as we're happy with this process, I'll update in Sprint 12 to move the provisioning command into a single task file for both dev and prod to eliminate duplication.