### PR TITLE
Fix #984 -- Remove client-side validation

### DIFF
--- a/cadasta/accounts/tests/test_views_default.py
+++ b/cadasta/accounts/tests/test_views_default.py
@@ -8,12 +8,12 @@ from core.tests.utils.cases import UserTestCase
 
 from allauth.account.models import EmailConfirmation, EmailAddress
 
-from ..views.default import AccountProfile, AccountLogin, ConfirmEmail
+from ..views import default
 from ..forms import ProfileForm
 
 
 class ProfileTest(ViewTestCase, UserTestCase, TestCase):
-    view_class = AccountProfile
+    view_class = default.AccountProfile
     template = 'accounts/profile.html'
 
     def setup_template_context(self):
@@ -66,7 +66,7 @@ class ProfileTest(ViewTestCase, UserTestCase, TestCase):
 
 
 class LoginTest(ViewTestCase, UserTestCase, TestCase):
-    view_class = AccountLogin
+    view_class = default.AccountLogin
 
     def setup_models(self):
         self.user = UserFactory.create(username='imagine71',
@@ -93,7 +93,7 @@ class LoginTest(ViewTestCase, UserTestCase, TestCase):
 
 
 class ConfirmEmailTest(ViewTestCase, UserTestCase, TestCase):
-    view_class = ConfirmEmail
+    view_class = default.ConfirmEmail
     url_kwargs = {'key': '123'}
 
     def setup_models(self):

--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -5436,10 +5436,7 @@ header {
   .page-header .page-title h1, .page-header .page-title h2 {
     white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis; }
-    .page-header .page-title h1:hover, .page-header .page-title h2:hover {
-      overflow: visible;
-      white-space: normal; } }
+    text-overflow: ellipsis; } }
 
 /* =Page header single project or organizations
 -------------------------------------------------------------- */

--- a/cadasta/templates/allauth/account/password_reset_from_key.html
+++ b/cadasta/templates/allauth/account/password_reset_from_key.html
@@ -5,10 +5,6 @@
 {% load i18n %}
 {% block head_title %}{% trans "Change Password" %}{% endblock %}
 
-{% block extra_script %}
-<script src="{% static 'js/parsleyAddValidator.js' %}"></script>
-{% endblock %}
-
 {% block content %}
 
 <div class="narrow">
@@ -20,8 +16,6 @@
     {% else %}
         {% if form %}
             <form method="POST" action="." data-parsley-validate>
-                <input type="hidden" id="id_username" value="{{ user.username }}">
-                <input type="hidden" id="id_email" value="{{ user.email }}">
                 {% csrf_token %}
 
                 <div class="form-group{% if form.password1.errors %} has-error{% endif %}">


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix #984 
- Removes all client-side validation from the view. Let me explain: I had a PR ready that adds the user's username and email to the template and enables client-side validation. In this particular case, however, we might open a security hole, when we make the user's credentials public. If someone gets hold of the password reset link, they will get the username associated with the account and the new password, i.e. all information necessary to hijack the account. I checked back with Adrienne, and we decided to move validation entirely to the back-end for this view because it's too risky. 

### When should this PR be merged

Soon.


### Risks

None.

### Follow up actions

None.
