### PR TITLE
Parties detail page - updated left nav tab on

### DIFF
--- a/cadasta/templates/party/party_detail.html
+++ b/cadasta/templates/party/party_detail.html
@@ -1,7 +1,7 @@
 {% extends "organization/project_wrapper.html" %}
 {% load i18n %}
 
-{% block left-nav %}map{% endblock %}
+{% block left-nav %}parties{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Completes #993
- When viewing party detail page (from party index or location relationship), parties tab is highlighted in left subnav


### When should this PR be merged

- When convenient

### Risks

- None foreseen

### Follow up actions

- None


