### PR TITLE
Fix map bounding box when there are no geometries

### DIFF
--- a/cadasta/core/static/js/map_utils.js
+++ b/cadasta/core/static/js/map_utils.js
@@ -94,7 +94,7 @@ function renderFeatures(map, featuresUrl, options) {
     projectBounds = boundary.getBounds();
     if (options.fitBounds === 'project') {map.fitBounds(projectBounds);}
   } else {
-    map.fitBounds([[-180, -90], [180, 90]]);
+    map.fitBounds([[-45.0, -180.0], [45.0, 180.0]]);
   }
   
   var geoJson = L.geoJson(null, {

--- a/cadasta/core/static/js/map_utils.js
+++ b/cadasta/core/static/js/map_utils.js
@@ -63,7 +63,10 @@ function renderFeatures(map, featuresUrl, options) {
       } else {
         $('#messages #loading').addClass('hidden');
         if (options.fitBounds === 'locations') {
-          map.fitBounds(markers.getBounds());
+          var bounds = markers.getBounds();
+          if (bounds.isValid()) {
+            map.fitBounds(bounds);  
+          }
         }
       }
 
@@ -90,6 +93,8 @@ function renderFeatures(map, featuresUrl, options) {
     boundary.addTo(map);
     projectBounds = boundary.getBounds();
     if (options.fitBounds === 'project') {map.fitBounds(projectBounds);}
+  } else {
+    map.fitBounds([[-180, -90], [180, 90]]);
   }
   
   var geoJson = L.geoJson(null, {

--- a/cadasta/templates/organization/project_edit_geometry.html
+++ b/cadasta/templates/organization/project_edit_geometry.html
@@ -27,6 +27,15 @@
       }
       add_map_controls(map);
 
+      {% if project.extent %}
+      var projectExtent = {{ project.extent.geojson|safe }};
+      {% else %}
+      var projectExtent = null;
+      {% endif %}
+      if (!projectExtent) {
+        map.fitBounds([[-180, -90], [180, 90]]);
+      }
+
       // Enable edit mode on map load and save the geometry on page save
       setTimeout(enableMapEditMode, 500);
       $('button.btn-primary[type=submit]')[0].addEventListener('click', saveOnMapEditMode);

--- a/cadasta/templates/organization/project_edit_geometry.html
+++ b/cadasta/templates/organization/project_edit_geometry.html
@@ -33,7 +33,7 @@
       var projectExtent = null;
       {% endif %}
       if (!projectExtent) {
-        map.fitBounds([[-180, -90], [180, 90]]);
+        map.fitBounds([[-45.0, -180.0], [45.0, 180.0]]);
       }
 
       // Enable edit mode on map load and save the geometry on page save


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes a bug that breaks the map when there are no project geometry or spatial units in a project. Currently, the the map extend is either based on the project extent or the extent of all spatial units in a project. If neither a present, an error is thrown. 

### When should this PR be merged

Soon

### Risks

None

### Follow up actions

None