### PR TITLE
Fix #662 -- Define MIMETYPE_LOOKUP to detect type from file extension

### DIFF
--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -346,7 +346,7 @@ ATTRIBUTE_GROUPS = {
 ICON_URL = ('https://s3-us-west-2.amazonaws.com/cadasta-platformprod'
             '-bucket/icons/{}.png')
 
-MIME_LOOKUPS = {
+ICON_LOOKUPS = {
     'application/pdf': 'pdf',
     'audio/1d-interleaved-parityfec': '1d-interleaved-parityfec',
     'audio/32kadpcm': '32kadpcm',
@@ -485,7 +485,12 @@ MIME_LOOKUPS = {
     'image/png': 'png',
     'image/gif': 'gif',
     'image/tif': 'tiff',
-    'image/tiff': 'tiff'
+    'image/tiff': 'tiff',
+    'application/gpx+xml': 'gpx'
+}
+
+MIME_LOOKUPS = {
+     'gpx': 'application/gpx+xml'
 }
 
 FILE_UPLOAD_HANDLERS = [

--- a/cadasta/core/static/js/file-upload.js
+++ b/cadasta/core/static/js/file-upload.js
@@ -16,7 +16,10 @@ $(function() {
 
     $('input[name="original_file"]').val(file.name);
     $('input[name="details-original_file"]').val(file.name);
-    $('input[name="mime_type"]').val(file.type);
+
+    var ext = file.name.split('.').slice(-1)[0];
+    var type = file.type || MIME_LOOKUPS[ext];
+    $('input[name="mime_type"]').val(type);
 
     // import wizard
     $('input[name="select_file-original_file"]').val(file.name);

--- a/cadasta/resources/models.py
+++ b/cadasta/resources/models.py
@@ -99,7 +99,7 @@ class Resource(RandomIDModel):
     @property
     def thumbnail(self):
         if not hasattr(self, '_thumbnail'):
-            icon = settings.MIME_LOOKUPS.get(self.mime_type, None)
+            icon = settings.ICON_LOOKUPS.get(self.mime_type, None)
             if 'image' in self.mime_type and 'tif' not in self.mime_type:
                 ext = self.file_name.split('.')[-1]
                 base_url = self.file.url[:self.file.url.rfind('.')]

--- a/cadasta/resources/validators.py
+++ b/cadasta/resources/validators.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
-ACCEPTED_TYPES = settings.MIME_LOOKUPS.keys()
+ACCEPTED_TYPES = settings.ICON_LOOKUPS.keys()
 
 
 def validate_file_type(type):

--- a/cadasta/templates/resources/form.html
+++ b/cadasta/templates/resources/form.html
@@ -8,7 +8,7 @@
       <label class="control-label required" for="{{ form.file.id_for_label }}">{% trans "Select the file to upload" %}</label>
       <div class="well file-well">
         {{ form.file }}
-        <p class="help-block">{% trans "Accepted file types: pdf, mp3, mp4, doc, docx, jpg, png, xml (gpx), csv" %}</p>
+        <p class="help-block">{% trans "Accepted file types: pdf, mp3, mp4, doc, docx, jpg, png, gpx, csv" %}</p>
       </div>
       <div class="error-block">{{ form.file.errors }}</div>
     </div>

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -20,7 +20,7 @@ django-audit-log==0.7.0
 django-simple-history==1.8.1
 simplejson==3.8.1
 django-widget-tweaks==1.4.1
-django-buckets==0.1.19a6
+django-buckets==0.1.19
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.4.2

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -20,7 +20,7 @@ django-audit-log==0.7.0
 django-simple-history==1.8.1
 simplejson==3.8.1
 django-widget-tweaks==1.4.1
-django-buckets==0.1.19a5
+django-buckets==0.1.19a6
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.4.2

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -20,7 +20,7 @@ django-audit-log==0.7.0
 django-simple-history==1.8.1
 simplejson==3.8.1
 django-widget-tweaks==1.4.1
-django-buckets==0.1.18
+django-buckets==0.1.19a5
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.4.2


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #662
- Fixes #972 (The fix comes with the new django-buckets version, I did not chnage any code in the platform. When reviewing, it should be tested if uploading and deleting files work as expected)
- Bump django-buckets to 0.1.19a5, which is a pre-release version. I suggest to check this PR, and when it's accepted, I will make a full release and update the requirements before merging. 
- Rename `MIME_LOOKUPS` to `ICON_LOOKUPS` to make it more obvious what the `dict` is for (looking up icons for mime types).
- Introduces a new `MIME_LOOKUPS` `dict` to lookup mime types for file extensions that are otherwise not detected in the browser.
- Change `file-upload.js` to use either the mime type detected by the browser or the one defined in `MIME_LOOKUPS`.

### When should this PR be merged

Soon, as #972 is a high priority bug.

### Risks

None foreseen.

### Follow up actions

Before merging the PR, we should make a release of django-buckets and update the requirements. 


### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [x] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [x] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [x] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [x] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [x] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [x] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [x] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [x] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [x] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [x] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

