### PR TITLE
Fix repeat groups and question order in XForms

### DIFF
--- a/cadasta/questionnaires/serializers.py
+++ b/cadasta/questionnaires/serializers.py
@@ -149,7 +149,7 @@ class QuestionnaireSerializer(serializers.ModelSerializer):
     )
     version = serializers.IntegerField(required=False, default=1)
     questions = serializers.SerializerMethodField()
-    question_groups = QuestionGroupSerializer(many=True, read_only=True)
+    question_groups = serializers.SerializerMethodField()
 
     class Meta:
         model = models.Questionnaire
@@ -210,4 +210,9 @@ class QuestionnaireSerializer(serializers.ModelSerializer):
     def get_questions(self, instance):
         questions = instance.questions.filter(question_group__isnull=True)
         serializer = QuestionSerializer(questions, many=True)
+        return serializer.data
+
+    def get_question_groups(self, instance):
+        groups = instance.question_groups.filter(question_group__isnull=True)
+        serializer = QuestionGroupSerializer(groups, many=True)
         return serializer.data

--- a/cadasta/questionnaires/tests/test_serializers.py
+++ b/cadasta/questionnaires/tests/test_serializers.py
@@ -113,6 +113,17 @@ class QuestionnaireSerializerTest(FileStorageTestCase, TestCase):
 
     def test_serialize(self):
         questionnaire = factories.QuestionnaireFactory()
+
+        factories.QuestionFactory.create(questionnaire=questionnaire,
+                                         question_group=None)
+        group = factories.QuestionGroupFactory.create(
+            questionnaire=questionnaire,
+            question_group=None)
+        factories.QuestionGroupFactory.create(questionnaire=questionnaire,
+                                              question_group=group)
+        factories.QuestionFactory.create(questionnaire=questionnaire,
+                                         question_group=group)
+
         serializer = serializers.QuestionnaireSerializer(questionnaire)
 
         assert serializer.data['id'] == questionnaire.id
@@ -122,6 +133,12 @@ class QuestionnaireSerializerTest(FileStorageTestCase, TestCase):
         assert serializer.data['xls_form'] == questionnaire.xls_form.url
         assert serializer.data['version'] == questionnaire.version
         assert 'project' not in serializer.data
+
+        assert len(serializer.data['questions']) == 1
+        assert len(serializer.data['question_groups']) == 1
+        assert len(serializer.data['question_groups'][0]['questions']) == 1
+        assert (
+            len(serializer.data['question_groups'][0]['question_groups']) == 1)
 
     def test_huge(self):
         data = {

--- a/cadasta/xforms/renderers.py
+++ b/cadasta/xforms/renderers.py
@@ -96,11 +96,15 @@ class XFormRenderer(BaseRenderer):
     def transform_groups(self, groups):
         transformed_groups = []
         for g in groups:
+            questions = self.transform_questions(g.get('questions', []))
+            groups = self.transform_groups(g.get('question_groups', []))
+            children = sorted(questions + groups,
+                              key=lambda x: x['index'])
             group = {
-                'type': 'group',
+                'type': g.get('type', 'group'),
                 'name': g.get('name'),
                 'label': g.get('label'),
-                'children': self.transform_questions(g.get('questions')),
+                'children': children,
                 'index': g.get('index')
             }
             if group['label'] is None:

--- a/cadasta/xforms/tests/test_renderer.py
+++ b/cadasta/xforms/tests/test_renderer.py
@@ -50,35 +50,50 @@ class XFormRendererTest(TestCase):
         groups = [{
             'id': '123',
             'name': 'group_1',
-            'label': 'Group 2',
+            'label': 'Group 1',
+            'type': 'group',
             'relevant': "${party_type}='IN'",
+            'index': 0,
             'questions': [{
                 'id': "bzs2984c3gxgwcjhvambdt3w",
                 'name': "start",
                 'label': None,
                 'type': "ST",
+                'index': 0
             }]
         }, {
             'id': '456',
             'name': 'group_2',
             'label': None,
+            'type': 'repeat',
+            'index': 1,
             'questions': [{
                 'id': "xp8vjr6dsk46p47u22fft7bg",
                 'name': "tenure_type",
                 'label': "What is the social tenure type?",
                 'type': "TX",
+                'index': 0
+            }],
+            'question_groups': [{
+                'id': "xp8vjr6dsk46p47u22fft7aa",
+                'name': 'group_3',
+                'label': 'Group 3',
+                'type': 'group',
+                'index': 1
             }]
         }]
         renderer = XFormRenderer()
         transformed = renderer.transform_groups(groups)
         assert len(transformed) == 2
         for g in transformed:
-            assert g['type'] == 'group'
-            assert len(g['children']) == 1
             if g['name'] == 'group_1':
                 assert g['bind']['relevant'] == "${party_type}='IN'"
+                assert g['type'] == 'group'
+                assert len(g['children']) == 1
             if g['name'] == 'group_2':
                 assert 'label' not in g
+                assert g['type'] == 'repeat'
+                assert len(g['children']) == 2
 
     def test_transform_to_xform_json(self):
         data = {


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes three issues regarding the rendering of XForms:

- Repeat groups were not rendered as such in XForm, but as standard groups instead. This issue is fixed by reading the correct type from the serialized object in the renderer. 
- Groups were not serialized with the right nesting; i.e. groups that are children of other groups were placed into the top level. This is fixed reading only groups without parent groups in the questionnaire serializer and traversing the hierarchy from there. 
- Groups did not render child groups; a group in a repeat group will not be rendered in the form. This is fixed by reading both child questions and groups when rendering a question group. 

### When should this PR be merged

It fixes some critical bugs, so the sooner the better

### Risks

Low

### Follow up actions

None.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
