### PR TITLE
Fix #1018: Make project details editing work again

### DIFF
--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -345,6 +345,17 @@ class ProjectEditDetails(forms.ModelForm):
         fields = ['name', 'description', 'access', 'urls', 'questionnaire',
                   'contacts']
 
+    def clean_questionnaire(self):
+        new_form = self.data.get('questionnaire')
+        current_form = self.initial.get('questionnaire')
+
+        if (self.instance.has_records and new_form is not None and
+                new_form != current_form):
+            raise ValidationError(
+                _("Data has already been contributed to this project. To "
+                  "ensure data integrity, uploading a new questionnaire is "
+                  "disabled for this project."))
+
     def save(self, *args, **kwargs):
         new_form = self.data.get('questionnaire')
         original_file = self.data.get('original_file')
@@ -357,7 +368,7 @@ class ProjectEditDetails(forms.ModelForm):
                     original_file=original_file,
                     project=self.instance
                 )
-        else:
+        elif not self.instance.has_records:
             self.instance.current_questionnaire = ''
 
         return super().save(*args, **kwargs)

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -349,8 +349,8 @@ class ProjectEditDetails(forms.ModelForm):
         new_form = self.data.get('questionnaire')
         current_form = self.initial.get('questionnaire')
 
-        if (self.instance.has_records and new_form is not None and
-                new_form != current_form):
+        if (new_form is not None and new_form != current_form and
+                self.instance.has_records):
             raise ValidationError(
                 _("Data has already been contributed to this project. To "
                   "ensure data integrity, uploading a new questionnaire is "
@@ -368,7 +368,7 @@ class ProjectEditDetails(forms.ModelForm):
                     original_file=original_file,
                     project=self.instance
                 )
-        elif not self.instance.has_records:
+        elif new_form is not None and not self.instance.has_records:
             self.instance.current_questionnaire = ''
 
         return super().save(*args, **kwargs)

--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -925,7 +925,6 @@ class ProjectEditDetailsTest(ViewTestCase, UserTestCase,
         'description': 'New Description',
         'access': 'public',
         'urls': '',
-        'questionnaire': '',
         'contacts-TOTAL_FORMS': 1,
         'contacts-INITIAL_FORMS': 0,
         'contacts-0-name': '',
@@ -934,7 +933,7 @@ class ProjectEditDetailsTest(ViewTestCase, UserTestCase,
     }
 
     def setup_models(self):
-        self.project = ProjectFactory.create(current_questionnaire='abc')
+        self.project = ProjectFactory.create()
 
     def setup_url_kwargs(self):
         return {
@@ -1010,6 +1009,7 @@ class ProjectEditDetailsTest(ViewTestCase, UserTestCase,
         self.project.refresh_from_db()
         assert self.project.name == self.post_data['name']
         assert self.project.description == self.post_data['description']
+        assert self.project.current_questionnaire == ''
 
     def test_post_with_blocked_questionnaire_upload(self):
         SpatialUnitFactory.create(project=self.project)
@@ -1017,11 +1017,12 @@ class ProjectEditDetailsTest(ViewTestCase, UserTestCase,
         assign_policies(user)
         response = self.request(user=user, method='POST')
 
-        assert response.status_code == 200
+        assert response.status_code == 302
+        assert self.expected_success_url in response.location
         self.project.refresh_from_db()
-        assert self.project.name != self.post_data['name']
-        assert self.project.description != self.post_data['description']
-        assert self.project.current_questionnaire == 'abc'
+        assert self.project.name == self.post_data['name']
+        assert self.project.description == self.post_data['description']
+        assert self.project.current_questionnaire == ''
 
     def test_post_invalid_form(self):
         question = self.get_form('xls-form-invalid')

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -652,7 +652,7 @@ class ProjectEditDetails(ProjectEdit, generic.UpdateView):
 
     def post(self, *args, **kwargs):
         if self.get_project().has_records:
-            return self.get(*args, **kwargs)
+            return super().post(*args, **kwargs)
         else:
             try:
                 return super().post(*args, **kwargs)

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -651,16 +651,13 @@ class ProjectEditDetails(ProjectEdit, generic.UpdateView):
         return initial
 
     def post(self, *args, **kwargs):
-        if self.get_project().has_records:
+        try:
             return super().post(*args, **kwargs)
-        else:
-            try:
-                return super().post(*args, **kwargs)
-            except InvalidXLSForm as e:
-                form = self.get_form()
-                for err in e.errors:
-                    form.add_error('questionnaire', err)
-                return self.form_invalid(form)
+        except InvalidXLSForm as e:
+            form = self.get_form()
+            for err in e.errors:
+                form.add_error('questionnaire', err)
+            return self.form_invalid(form)
 
 
 class ProjectEditPermissions(ProjectEdit, generic.UpdateView):


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #1018:
    - Corrected call to `super().post()`.
    - Update unit tests. In particular, _test_post_with_blocked_questionnaire_upload_ should have resulted in a successful form submission. Also, `questionnaire` is removed from the default `post_data` in order to simulate the missing questionnaire fields in the template if the project has records.

### When should this PR be merged
Soon.

### Risks
None foreseen.

### Follow up actions
None.


### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [x] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [x] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [x] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [x] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [x] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [x] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [x] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [x] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [x] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [x] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [x] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
