### PR TITLE
Reconfigured allauth pre_authentication to use an exponential back-off

### DIFF
--- a/cadasta/accounts/adapter.py
+++ b/cadasta/accounts/adapter.py
@@ -1,0 +1,27 @@
+import time
+
+from django import forms
+from django.utils import timezone
+from django.core.cache import cache
+
+from allauth.account import adapter
+
+
+class DefaultAccountAdapter(adapter.DefaultAccountAdapter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def pre_authenticate(self, request, **credentials):
+        cache_key = super()._get_login_attempts_cache_key(
+            request, **credentials)
+        login_data = cache.get(cache_key, None)
+        if login_data:
+            dt = timezone.now()
+            current_attempt_time = time.mktime(dt.timetuple())
+            back_off = (1 << (len(login_data) - 1))
+
+            # if back_off is more than a day, reset to a day
+            back_off = back_off if back_off < 86400 else 86400
+            if current_attempt_time < (login_data[-1] + back_off):
+                raise forms.ValidationError(
+                    self.error_messages['too_many_login_attempts'])

--- a/cadasta/accounts/adapter.py
+++ b/cadasta/accounts/adapter.py
@@ -20,11 +20,9 @@ class DefaultAccountAdapter(adapter.DefaultAccountAdapter):
 
             # ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT should be set to maximum amount of
             # time a user can be locked out.
-            print('back_off:', back_off)
             if back_off > ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT:
                 back_off = ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT
 
-            print('back_off take two:', back_off)
             if current_attempt_time < (login_data[-1] + back_off):
                 raise forms.ValidationError(
                     self.error_messages['too_many_login_attempts'])

--- a/cadasta/accounts/adapter.py
+++ b/cadasta/accounts/adapter.py
@@ -20,9 +20,11 @@ class DefaultAccountAdapter(adapter.DefaultAccountAdapter):
 
             # ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT should be set to maximum amount of
             # time a user can be locked out.
+            print('back_off:', back_off)
             if back_off > ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT:
                 back_off = ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT
 
+            print('back_off take two:', back_off)
             if current_attempt_time < (login_data[-1] + back_off):
                 raise forms.ValidationError(
                     self.error_messages['too_many_login_attempts'])

--- a/cadasta/accounts/tests/test_adapter.py
+++ b/cadasta/accounts/tests/test_adapter.py
@@ -55,6 +55,9 @@ class AccountAdapterTests(UserTestCase, TestCase):
 
         a().pre_authenticate(request, **credentials)
 
+    @override_settings(CACHES={
+        'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
+        })
     def test_pre_authenticate_maxes_out(self):
         UserFactory.create(username='john_snow', password='Winteriscoming!')
         credentials = {'username': 'john_snow', 'password': 'knowsnothing'}

--- a/cadasta/accounts/tests/test_adapter.py
+++ b/cadasta/accounts/tests/test_adapter.py
@@ -1,0 +1,56 @@
+import time
+import pytest
+from datetime import timedelta
+
+from django.core.urlresolvers import reverse
+from django.core.cache import cache
+from django.forms import ValidationError
+from django.test import TestCase, override_settings
+from django.utils import timezone
+from allauth.account.adapter import DefaultAccountAdapter as all_auth
+
+from config.settings.default import ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT
+from core.tests.utils.cases import UserTestCase
+from .factories import UserFactory
+from ..adapter import DefaultAccountAdapter as a
+
+
+class AccountAdapterTests(UserTestCase, TestCase):
+    @override_settings(CACHES={
+        'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
+        })
+    def test_pre_authenticate(self):
+        UserFactory.create(username='john_snow', password='Winteriscoming!')
+        credentials = {'username': 'john_snow', 'password': 'knowsnothing'}
+        request = self.client.get(
+            reverse('account:login'),
+            {'login': 'john_snow', 'password': 'knowsnothing'})
+        a().pre_authenticate(request, **credentials)
+
+    @override_settings(CACHES={
+        'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
+        })
+    def test_pre_authenticate_fails(self):
+        UserFactory.create(username='john_snow', password='Winteriscoming!')
+        credentials = {'username': 'john_snow', 'password': 'knowsnothing'}
+        request = self.client.get(
+            reverse('account:login'),
+            {'login': 'john_snow', 'password': 'knowsnothing'})
+        cache_key = all_auth()._get_login_attempts_cache_key(
+            request, **credentials)
+
+        data = []
+        dt = timezone.now()
+
+        data.append(time.mktime(dt.timetuple()))
+        cache.set(cache_key, data, ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT)
+
+        with pytest.raises(ValidationError):
+            a().pre_authenticate(request, **credentials)
+
+        # fake a user waiting 2 seconds
+        dt = timezone.now() - timedelta(seconds=2)
+        data.append(time.mktime(dt.timetuple()))
+        cache.set(cache_key, data, ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT)
+
+        a().pre_authenticate(request, **credentials)

--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -157,8 +157,10 @@ ACCOUNT_FORMS = {
     'signup': 'accounts.forms.RegisterForm',
     'profile': 'accounts.forms.ProfileForm',
 }
+ACCOUNT_ADAPTER = 'accounts.adapter.DefaultAccountAdapter'
 ACCOUNT_LOGOUT_ON_GET = True
 ACCOUNT_LOGOUT_REDIRECT_URL = LOGIN_URL
+ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT = 86400
 
 AUTH_PASSWORD_VALIDATORS = [
     {

--- a/cadasta/config/settings/dev.py
+++ b/cadasta/config/settings/dev.py
@@ -70,7 +70,8 @@ LEAFLET_CONFIG['TILES'][0] = (
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache'
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'default'
     },
     'jsonattrs': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',


### PR DESCRIPTION
### Proposed changes in this pull request

[List all changes you want to add here. If you fixed an issue, please
add a reference to that issue as well.]
- Reconfigured allauth pre_authentication to use an exponential back-off method instead of a static time and attempt count.
- Changed default cache in the dev environment to LocMemCache
- Fixes #945

### When should this PR be merged
- Whenever

### Risks
- This might confuse some users. It might be useful to add some addition information to the `Too many failed login attempts. Try again later.` message indicating the amount of time they should wait.

### Follow up actions
- Update messaging?

---

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
