### PR TITLE
User is redirected to profile after changing password

### DIFF
--- a/cadasta/accounts/views/default.py
+++ b/cadasta/accounts/views/default.py
@@ -1,7 +1,6 @@
 from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext as _
 from django.contrib import messages
-from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.utils import timezone
 
@@ -11,7 +10,6 @@ from core.views.mixins import SuperUserCheckMixin
 import allauth.account.views as allauth_views
 from allauth.account.views import ConfirmEmailView, LoginView
 from allauth.account.utils import send_email_confirmation
-from allauth.account import signals
 
 from ..models import User
 from ..forms import ProfileForm, ChangePasswordForm, ResetPasswordKeyForm
@@ -21,18 +19,6 @@ class PasswordChangeView(LoginRequiredMixin,
                          SuperUserCheckMixin,
                          allauth_views.PasswordChangeView):
     success_url = reverse_lazy('account:profile')
-
-    def form_valid(self, form):
-        form.save()
-
-        # Update session to keep user logged in.
-        update_session_auth_hash(self.request, form.user)
-
-        signals.password_changed.send(sender=self.request.user.__class__,
-                                      request=self.request,
-                                      user=self.request.user)
-        return super(PasswordChangeView, self).form_valid(form)
-
     form_class = ChangePasswordForm
 
 

--- a/cadasta/accounts/views/default.py
+++ b/cadasta/accounts/views/default.py
@@ -1,6 +1,7 @@
 from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext as _
 from django.contrib import messages
+from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.utils import timezone
 
@@ -10,6 +11,7 @@ from core.views.mixins import SuperUserCheckMixin
 import allauth.account.views as allauth_views
 from allauth.account.views import ConfirmEmailView, LoginView
 from allauth.account.utils import send_email_confirmation
+from allauth.account import signals
 
 from ..models import User
 from ..forms import ProfileForm, ChangePasswordForm, ResetPasswordKeyForm
@@ -18,6 +20,19 @@ from ..forms import ProfileForm, ChangePasswordForm, ResetPasswordKeyForm
 class PasswordChangeView(LoginRequiredMixin,
                          SuperUserCheckMixin,
                          allauth_views.PasswordChangeView):
+    success_url = reverse_lazy('account:profile')
+
+    def form_valid(self, form):
+        form.save()
+
+        # Update session to keep user logged in.
+        update_session_auth_hash(self.request, form.user)
+
+        signals.password_changed.send(sender=self.request.user.__class__,
+                                      request=self.request,
+                                      user=self.request.user)
+        return super(PasswordChangeView, self).form_valid(form)
+
     form_class = ChangePasswordForm
 
 


### PR DESCRIPTION
### Proposed changes in this pull request
- Fixes #904 
- Users are now redirected to profile page after changing their password

### When should this PR be merged
- Whenever

### Risks
- None

### Follow up actions
- None

---
### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [x] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [x] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [x] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [x] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [x] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [x] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [x] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [x] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [x] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [x] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
