### PR TITLE
Fix #1035: Make archived filtering work when not using English

### DIFF
--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -6125,10 +6125,6 @@ body.map .content-single {
     min-width: 60px !important; }
   .table div.org-logo {
     padding: 4px 0; }
-  .table td.archived, .table td.unarchived {
-    display: none !important; }
-  .table th.archived, .table th.unarchived {
-    display: none !important; }
 
 table.table-location {
   border-top: none; }

--- a/cadasta/core/static/css/main.scss
+++ b/cadasta/core/static/css/main.scss
@@ -641,12 +641,6 @@ body.map .content-single {
   div.org-logo {
     padding: 4px 0;
   }
-  td.archived, td.unarchived {
-    display: none !important
-  }
-  th.archived, th.unarchived {
-    display: none !important
-  }
 }
 
 table.table-location { // location details in map area

--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -62,7 +62,6 @@ class OrganizationListTest(ViewTestCase, UserTestCase, TestCase):
             'object_list': sorted(self.all_orgs, key=lambda p: p.slug),
             'user': self.user,
             'is_superuser': False,
-            'any_archived': False,
         }
 
     def test_get_with_user(self):
@@ -84,8 +83,7 @@ class OrganizationListTest(ViewTestCase, UserTestCase, TestCase):
             organization=self.archived_org, user=adminuser, admin=True)
         response = self.request(user=adminuser)
         assert response.status_code == 200
-        assert response.content == self.render_content(user=adminuser,
-                                                       any_archived=True)
+        assert response.content == self.render_content(user=adminuser)
 
     def test_get_with_superuser(self):
         superuser = UserFactory.create()
@@ -94,8 +92,7 @@ class OrganizationListTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(user=superuser)
         assert response.status_code == 200
         assert response.content == self.render_content(user=superuser,
-                                                       is_superuser=True,
-                                                       any_archived=True)
+                                                       is_superuser=True)
 
 
 class OrganizationAddTest(ViewTestCase, UserTestCase, TestCase):

--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -111,7 +111,6 @@ class ProjectListTest(ViewTestCase, UserTestCase, TestCase):
             'object_list': sorted(projs, key=self.sort_key),
             'add_allowed': False,
             'is_superuser': False,
-            'any_archived': False,
         }
 
     def test_get_with_valid_user(self):
@@ -169,8 +168,7 @@ class ProjectListTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 200
         assert response.content == self.render_content(
             object_list=sorted(projs, key=self.sort_key),
-            add_allowed=True,
-            any_archived=True)
+            add_allowed=True)
 
     def test_get_with_superuser(self):
         superuser = UserFactory.create()
@@ -182,9 +180,7 @@ class ProjectListTest(ViewTestCase, UserTestCase, TestCase):
         assert response.content == self.render_content(
             object_list=sorted(Project.objects.all(), key=self.sort_key),
             add_allowed=True,
-            is_superuser=True,
-            any_archived=True,
-        )
+            is_superuser=True)
 
 
 class ProjectDashboardTest(ViewTestCase, UserTestCase, TestCase):

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -40,12 +40,6 @@ class OrganizationList(PermissionRequiredMixin, generic.ListView):
     # organization in order to count the number of projects per org
     queryset = Organization.objects.annotate(num_projects=Count('projects'))
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['any_archived'] = self.get_queryset().filter(
-            archived=True).exists()
-        return context
-
 
 class OrganizationAdd(LoginPermissionRequiredMixin, generic.CreateView):
     model = Organization
@@ -358,12 +352,6 @@ class ProjectList(PermissionRequiredMixin,
     permission_required = 'project.list'
     permission_filter_queryset = permission_filter
     project_create_check_multiple = True
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['any_archived'] = self.get_queryset().filter(
-            archived=True).exists()
-        return context
 
     def get(self, request, *args, **kwargs):
         user = self.request.user

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -192,13 +192,8 @@
     <script src="{% static 'js/bootstrap.min.js' %}"></script>
     <script src="{% static 'js/parsleyConfig.js' %}"></script>
     <script src="{% static 'js/parsley.js' %}"></script>
-    <script type="text/javascript"
-            src="https://cdn.datatables.net/r/bs-3.3.5/jqc-1.11.3,dt-1.10.8/datatables.min.js">
-    </script>
-    <script type="text/javascript" src="{% static 'js/dataTables.conditionalPaging.js' %}">
-    </script>
-    <script type="text/javascript" src="{% static 'js/dataTables.selectFiltering.js' %}">
-    </script>
+    <script type="text/javascript" src="https://cdn.datatables.net/r/bs-3.3.5/jqc-1.11.3,dt-1.10.8/datatables.min.js"></script>
+    <script type="text/javascript" src="{% static 'js/dataTables.conditionalPaging.js' %}"></script>
     {% block extra_script %}{% endblock %}
     <script>
     $(document).ready(function () {

--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -1,9 +1,14 @@
 {% extends "organization/organization_wrapper.html" %}
 
 {% load i18n %}
+{% load staticfiles %}
 
 {% block page_title %}{% trans "Overview" %} | {% endblock %}
 {% block left-nav %}overview{% endblock %}
+
+{% block extra_script %}
+    <script type="text/javascript" src="{% static 'js/dataTables.selectFiltering.js' %}"></script>
+{% endblock %}
 
 {% block content %}
 
@@ -20,30 +25,25 @@
             <table class="table table-hover datatable" data-paging-type="simple">
               <thead>
                 <tr>
-                  <th class="unarchived"><div>{% trans "Archived" %}</div></th>
                   <th class="col-md-6">{% trans "Project" %}</th>
                   <th class="col-md-2 hidden-xs">{% trans "Country" %}</th>
                   <th class="col-md-2">{% trans "Last updated" %}</th>
+                  <th class="hidden"><!-- Hidden archived status column --></th>
                 </tr>
               </thead>
               <tbody>
-                {% for prj in projects %}
-                <tr class="linked" onclick="window.document.location='{% url 'organization:project-dashboard' organization=organization.slug project=prj.slug %}';">
-                  {% if prj.archived %}
-                    <td class="archived"><div>{% trans "True" %}</div></td>
-                  {% else %}
-                    <td class="unarchived"><div>{% trans "False" %}</div></td>
-                  {% endif %}
+                {% for proj in projects %}
+                <tr class="linked" onclick="window.document.location='{% url 'organization:project-dashboard' organization=organization.slug project=proj.slug %}';">
                   <td>
-                      <a href="{% url 'organization:project-dashboard' organization=organization.slug project=prj.slug %}">{{ prj.name }}</a>
-                      {% if prj.archived %}
-                      <span class="label label-danger">
-                        {% trans "Archived" %}
-                      </span>
-                      {% endif %}
+                    <a href="{% url 'organization:project-dashboard' organization=organization.slug project=proj.slug %}">{{ proj.name }}</a>
+                    {% if proj.archived %}
+                    <span class="label label-danger">{% trans "Archived" %}</span>
+                    {% endif %}
                   </td>
-                  <td class="hidden-xs">{{ prj.country }}</td>
-                  <td data-sort="{{ prj.last_updated|date:'U' }}">{{ prj.last_updated }}</td>
+                  
+                  <td class="hidden-xs">{{ proj.country }}</td>
+                  <td data-sort="{{ proj.last_updated|date:'U' }}">{{ proj.last_updated }}</td>
+                  <td class="hidden" data-filter="archived-{{ proj.archived }}"></td>
                 </tr>
                 {% endfor %}
               </tbody>

--- a/cadasta/templates/organization/organization_list.html
+++ b/cadasta/templates/organization/organization_list.html
@@ -1,11 +1,16 @@
 {% extends "core/base.html" %}
 
 {% load i18n %}
+{% load staticfiles %}
 {% load widget_tweaks %}
 
 {% block top-nav %}organizations{% endblock %}
 
 {% block title %} | {% trans "Organizations" %}{% endblock %}
+
+{% block extra_script %}
+    <script type="text/javascript" src="{% static 'js/dataTables.selectFiltering.js' %}"></script>
+{% endblock %}
 
 {% block page-header %}
 
@@ -32,22 +37,13 @@
 <table class="table table-hover datatable" data-paging-type="simple">
   <thead>
     <tr>
-      {% if any_archived %}
-      <th class="archived">{% trans "Archived" %}</th>
-      {% else %}
-      <th class="unarchived">{% trans "Archived" %}</th>
-      {% endif %}
       <th class="col-md-10">{% trans "Organization" %}</th>
       <th class="col-md-2 hidden-xs">{% trans "Projects" %}</th>
+      <th class="hidden"><!-- Hidden archived status column --></th>
     </tr>
   </thead>
   {% for org in object_list %}
   <tr class="linked" onclick="window.document.location='{% url 'organization:dashboard' slug=org.slug %}';">
-  {% if org.archived %}
-    <td class="archived"><div>{% trans "True" %}</div></td>
-  {% else %}
-    <td class="unarchived"><div>{% trans "False" %}</div></td>
-  {% endif %}
     <td>
       {% if org.logo %}
       <div class="org-logo">
@@ -66,7 +62,8 @@
         {% endif %}
       </div>
     </td>
-    <td class=" hidden-xs">{{ org.num_projects }}</td>
+    <td class="hidden-xs">{{ org.num_projects }}</td>
+    <td class="hidden" data-filter="archived-{{ org.archived }}"></td>
   </tr>
   {% endfor %}
 </table>

--- a/cadasta/templates/organization/project_list.html
+++ b/cadasta/templates/organization/project_list.html
@@ -1,10 +1,15 @@
 {% extends "core/base.html" %}
 
 {% load i18n %}
+{% load staticfiles %}
 
 {% block top-nav %}projects{% endblock %}
 
 {% block title %} | {% trans "Projects" %}{% endblock %}
+
+{% block extra_script %}
+    <script type="text/javascript" src="{% static 'js/dataTables.selectFiltering.js' %}"></script>
+{% endblock %}
 
 {% block page-header %}
 
@@ -33,24 +38,15 @@
 <table class="table table-hover datatable" data-paging-type="simple">
   <thead>
     <tr>
-      {% if any_archived %}
-      <th class="archived">{% trans "Archived" %}</th>
-      {% else %}
-      <th class="unarchived">{% trans "Archived" %}</th>
-      {% endif %}
       <th class="col-md-6">{% trans "Project" %}</th>
       <th class="col-md-2 hidden-xs">{% trans "Organization" %}</th>
       <th class="col-md-2 hidden-xs hidden-sm">{% trans "Country" %}</th>
       <th class="col-md-2 hidden-xs hidden-sm">{% trans "Last updated" %}</th>
+      <th class="hidden"><!-- Hidden archived status column --></th>
     </tr>
   </thead>
   {% for proj in object_list %}
   <tr class="linked" onclick="window.document.location='{% url 'organization:project-dashboard' organization=proj.organization.slug project=proj.slug %}';">
-    {% if proj.archived %}
-      <td class="archived"><div>{% trans "True" %}</div></td>
-    {% else %}
-      <td class="unarchived"><div>{% trans "False" %}</div></td>
-    {% endif %}
     <td>
       <h4>
           <a href="{% url 'organization:project-dashboard' organization=proj.organization.slug project=proj.slug %}">{{ proj.name }}</a>
@@ -74,6 +70,7 @@
     </td>
     <td class="hidden-xs hidden-sm">{{ proj.country.name }}</td>
     <td class="hidden-xs hidden-sm" data-sort="{{ proj.last_updated|date:'U' }}">{{ proj.last_updated }}</td>
+    <td class="hidden" data-filter="archived-{{ proj.archived }}"></td>
   </tr>
   {% endfor %}
 </table>


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #1035:
    - Note: See the bug report for the root cause.
    - Move the first archived status column as the last column and use DataTables' `data-filter` HTML attribute with "archived-True" and "archived-False" values instead of cell contents "True" and "False" that get translated with "archived" and "unarchived" HTML classes. Using data attributes should avoid things getting unnecessarily translated, which led to the bug. Also, delete the explicit CSS to hide this column in favor of using the usual Bootstrap "hidden" class.
    - Update static/js/dataTables.selectFiltering.js:
        - Make the "Active", "Archived", and "All" labels translatable.
        - Use a [custom DataTables search function](https://datatables.net/examples/plug-ins/range_filtering.html) to make the filtering code simpler.
    - Since dataTables.selectFiltering.js is only used in 3 pages, remove loading this script from base.html and instead add them to those 3 pages.

Note: My original idea of adding data attributes to the table row will not work with DataTables because DataTables only uses table cell contents and specific cell data attributes for searching/filtering. Hence, the hidden archived status column is still needed.

### When should this PR be merged
Before Sprint 12 release.

### Risks
No risks foreseen.

### Follow up actions
None.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
