### PR TITLE
Fix #1036 -- Add permission check to GeoODK submissions

### DIFF
--- a/cadasta/xforms/mixins/model_helper.py
+++ b/cadasta/xforms/mixins/model_helper.py
@@ -39,7 +39,7 @@ class ModelHelper():
         roles = [superuser, org_admin, prj_manager, data_collector]
         assigned_policies = user.assigned_policies()
         if not any(role in assigned_policies for role in roles):
-            raise PermissionDenied(_("You don't have permission do contribute"
+            raise PermissionDenied(_("You don't have permission to contribute"
                                      " data to this project."))
 
     def create_models(self, data, user):

--- a/cadasta/xforms/mixins/model_helper.py
+++ b/cadasta/xforms/mixins/model_helper.py
@@ -1,8 +1,9 @@
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, PermissionDenied
 from django.core.files.storage import get_storage_class
 from django.db import transaction
 from django.utils.translation import ugettext as _
 from jsonattrs.models import Attribute, AttributeType
+from tutelary.models import Policy
 from party.models import Party, TenureRelationship, TenureRelationshipType
 from pyxform.xform2json import XFormToDict
 from questionnaires.models import Questionnaire
@@ -13,14 +14,39 @@ from xforms.models import XFormSubmission
 from xforms.utils import odk_geom_to_wkt
 
 
+def get_policy_instance(policy_name, variables=None):
+    return (Policy.objects.get(name=policy_name), variables)
+
+
 class ModelHelper():
     def __init__(self, *arg):
         self.arg = arg
 
-    def create_models(self, data):
+    def _check_perm(self, user, project):
+        superuser = get_policy_instance('superuser')
+        org_admin = get_policy_instance('org-admin', {
+            'organization': project.organization.slug
+        })
+        prj_manager = get_policy_instance('project-manager', {
+            'organization': project.organization.slug,
+            'project': project.slug
+        })
+        data_collector = get_policy_instance('data-collector', {
+            'organization': project.organization.slug,
+            'project': project.slug
+        })
+
+        roles = [superuser, org_admin, prj_manager, data_collector]
+        assigned_policies = user.assigned_policies()
+        if not any(role in assigned_policies for role in roles):
+            raise PermissionDenied(_("You don't have permission do contribute"
+                                     " data to this project."))
+
+    def create_models(self, data, user):
         questionnaire = self._get_questionnaire(
             id_string=data['id'], version=data['version']
         )
+        self._check_perm(user, questionnaire.project)
 
         # If xform has already been submitted, check for additional resources
         additional_resources = self.check_for_duplicate_submission(
@@ -238,7 +264,7 @@ class ModelHelper():
              parties, party_resources,
              locations, location_resources,
              tenure_relationships, tenure_resources
-             ) = self.create_models(submission)
+             ) = self.create_models(submission, request.user)
 
             party_submissions = [submission]
             location_submissions = [submission]

--- a/cadasta/xforms/tests/test_views_api.py
+++ b/cadasta/xforms/tests/test_views_api.py
@@ -407,6 +407,16 @@ class XFormSubmissionTest(APITestCase, UserTestCase, FileStorageTestCase,
                                 content_type='multipart/form-data')
         assert response.status_code == 403
 
+    def test_unauthorized_user(self):
+        self._create_questionnaire('t_questionnaire', 0)
+        data = self._submission(form='submission')
+        user = UserFactory.create()
+        response = self.request(method='POST', post_data=data, user=user,
+                                content_type='multipart/form-data')
+        assert response.status_code == 403
+        assert ("You don't have permission do contribute data to this project."
+                in response.content)
+
     def test_questionnaire_not_found(self):
         with pytest.raises(ValidationError):
             data = self._submission(form='submission_bad_questionnaire')

--- a/cadasta/xforms/tests/test_views_api.py
+++ b/cadasta/xforms/tests/test_views_api.py
@@ -414,7 +414,7 @@ class XFormSubmissionTest(APITestCase, UserTestCase, FileStorageTestCase,
         response = self.request(method='POST', post_data=data, user=user,
                                 content_type='multipart/form-data')
         assert response.status_code == 403
-        assert ("You don't have permission do contribute data to this project."
+        assert ("You don't have permission to contribute data to this project."
                 in response.content)
 
     def test_questionnaire_not_found(self):

--- a/cadasta/xforms/views/api.py
+++ b/cadasta/xforms/views/api.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 from django.utils.six import BytesIO
 from django.utils.translation import ugettext as _
@@ -30,8 +31,7 @@ OPEN_ROSA_ENVELOPE = """
 """
 
 
-class XFormSubmissionViewSet(OpenRosaHeadersMixin,
-                             viewsets.GenericViewSet):
+class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
     """
     Serves up the /collect/submissions/ api requests.
 
@@ -53,7 +53,9 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin,
             instance = ModelHelper().upload_submission_data(request)
         except InvalidXMLSubmission as e:
             logger.debug(str(e))
-            return self._sendErrorResponse(request, e)
+            return self._sendErrorResponse(request, e, 'HTTP_400_BAD_REQUEST')
+        except PermissionDenied as e:
+            return self._sendErrorResponse(request, e, 'HTTP_403_FORBIDDEN')
 
         # If an already existing XFormSummission is sent back
         # don't create another.
@@ -86,12 +88,12 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin,
                 content_type='application/xml'
             )
 
-    def _sendErrorResponse(self, request, e):
+    def _sendErrorResponse(self, request, e, code):
         message = _(OPEN_ROSA_ENVELOPE.format(message=str(e)))
         headers = self.get_openrosa_headers(
             request, location=False, content_length=False)
         return Response(
-            message, status=status.HTTP_400_BAD_REQUEST,
+            message, status=getattr(status, code),
             headers=headers, content_type='application/xml'
         )
 

--- a/cadasta/xforms/views/api.py
+++ b/cadasta/xforms/views/api.py
@@ -53,9 +53,11 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
             instance = ModelHelper().upload_submission_data(request)
         except InvalidXMLSubmission as e:
             logger.debug(str(e))
-            return self._sendErrorResponse(request, e, 'HTTP_400_BAD_REQUEST')
+            return self._sendErrorResponse(request, e,
+                                           status.HTTP_400_BAD_REQUEST)
         except PermissionDenied as e:
-            return self._sendErrorResponse(request, e, 'HTTP_403_FORBIDDEN')
+            return self._sendErrorResponse(request, e,
+                                           status.HTTP_403_FORBIDDEN)
 
         # If an already existing XFormSummission is sent back
         # don't create another.
@@ -88,12 +90,12 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
                 content_type='application/xml'
             )
 
-    def _sendErrorResponse(self, request, e, code):
+    def _sendErrorResponse(self, request, e, status):
         message = _(OPEN_ROSA_ENVELOPE.format(message=str(e)))
         headers = self.get_openrosa_headers(
             request, location=False, content_length=False)
         return Response(
-            message, status=getattr(status, code),
+            message, status=status,
             headers=headers, content_type='application/xml'
         )
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Adds a check whether the contributing user has permissions to add data to the project. The check is against user roles instead of permissions because we need to check against four different permissions here (`spatial.add`, `tenure_rel.add`, `party.add`, `resource.add`) as users upload everything at once. For our current setup, the proposed solution is sufficient; we need to revisit when we implement fine-grained permission settings. We could then either check if the user has all permissions, which means if one permission is missing they would not be able to add anything. Or we check if one permission is present, which means users could add information they are not supposed to. Both solutions obviously have flaws, and I have no idea how to solve this at this point. 
- Adds a test whether the permissions are checked correctly and `PermissionDenied` is raised as expected
- Adds a test whether the view returns `403` in case the authenticated user is not permitted to upload data.  

### When should this PR be merged

ASAP

### Risks

Low

### Follow up actions

None


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
