### PR TITLE
removed `destroy` option from ProjectDetail api view

### DIFF
--- a/cadasta/organization/tests/test_views_api_projects.py
+++ b/cadasta/organization/tests/test_views_api_projects.py
@@ -856,3 +856,9 @@ class ProjectDetailAPITest(APITestCase, UserTestCase, TestCase):
         assert response.status_code == 400
         self.project.refresh_from_db()
         assert self.project.access == 'public'
+
+    def test_delete_fails(self):
+        response = self.request(method='DELETE', user=self.user)
+        assert response.status_code == 405
+        self.project.refresh_from_db()
+        assert Project.objects.filter(id=self.project.id).exists()

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -191,7 +191,7 @@ class ProjectList(PermissionsFilterMixin,
 
 class ProjectDetail(APIPermissionRequiredMixin,
                     mixins.OrganizationMixin,
-                    generics.RetrieveUpdateDestroyAPIView):
+                    generics.RetrieveUpdateAPIView):
     def get_actions(self, request):
         if self.get_object().archived:
             return 'project.view_archived'


### PR DESCRIPTION
### Proposed changes in this pull request
- change ProjectDetail view from `RetrieveUpdateDestroy` to `RetrieveUpdate`
- Fixes #1048 

### When should this PR be merged
Probably sooner rather than later?

### Risks
None

### Follow up actions
None

---
### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
