### PR TITLE
Adjusted PublicPrivateToggle to work with django 1.10

### DIFF
--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -924,7 +924,6 @@ class ProjectEditDetailsTest(ViewTestCase, UserTestCase,
     post_data = {
         'name': 'New Name',
         'description': 'New Description',
-        'access': 'public',
         'urls': '',
         'questionnaire': '',
         'contacts-TOTAL_FORMS': 1,
@@ -1079,6 +1078,23 @@ class ProjectEditDetailsTest(ViewTestCase, UserTestCase,
 
         assert response.status_code == 200
         assert response.content == self.render_content(form=form)
+
+    def test_post_private_project_form(self):
+        user = UserFactory.create()
+        assign_policies(user)
+
+        response = self.request(user=user, method='POST',
+                                post_data={'access': ['on']})
+
+        assert response.status_code == 302
+        self.project.refresh_from_db()
+        assert self.project.access == 'private'
+
+        response = self.request(user=user, method='POST',
+                                post_data={})
+        assert response.status_code == 302
+        self.project.refresh_from_db()
+        assert self.project.access == 'public'
 
     def test_post_with_unauthorized_user(self):
         user = UserFactory.create()

--- a/cadasta/organization/widgets.py
+++ b/cadasta/organization/widgets.py
@@ -105,6 +105,9 @@ class PublicPrivateToggle(Widget):
             checked=('checked' if value in ['private', 'on'] else '')
         )
 
+    def value_omitted_from_data(self, data, files, name):
+        return False
+
 
 class ContactsWidget(Widget):
     html = (


### PR DESCRIPTION
### Proposed changes in this pull request
- Disabled `value_omitted_from_data` (newly added in django 1.10) for `PublicPrivateToggle` so that projects can be set to public and private again.
- Removed `access` from `ProjectEditDetailsTest`'s post_data since it is not present in post data if the project is public.
- Added a test for toggling a project's access from public to private and back.
- Fixes #1038 

### When should this PR be merged

 Whenever


### Risks

Low

### Follow up actions

None


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
