### PR TITLE
Fix #1008 -- Unassign policies when roles are deleted

### DIFF
--- a/cadasta/organization/tests/test_models.py
+++ b/cadasta/organization/tests/test_models.py
@@ -79,7 +79,7 @@ class OrganizationRoleTest(UserTestCase, TestCase):
                                    {'organization': self.org.slug}))
         self._admin_role(True, False, False)
 
-    def test_delete_project_roles(self):
+    def test_delete_org_role(self):
         ProjectFactory.create_batch(2, add_users=[self.user],
                                     organization=self.org)
         ProjectFactory.create_batch(2, add_users=[self.user])
@@ -88,6 +88,15 @@ class OrganizationRoleTest(UserTestCase, TestCase):
         role = self._get_role()
         role.delete()
         assert ProjectRole.objects.filter(user=self.user).count() == 2
+
+    def test_delete_admin_role(self):
+        role = self._get_role()
+        role.admin = True
+        role.save()
+        assert self.user.has_perm('org.update', self.org) is True
+
+        role.delete()
+        assert self.user.has_perm('org.update', self.org) is False
 
 
 class ProjectTest(TestCase):
@@ -174,10 +183,22 @@ class ProjectTest(TestCase):
 
 
 class ProjectRoleTest(UserTestCase, TestCase):
+    def _get_roles(self):
+        pass
+
     def setUp(self):
         super().setUp()
         self.project = ProjectFactory.create()
         self.user = UserFactory.create()
+        v = {
+            'organization': self.project.organization.slug,
+            'project': self.project.slug
+        }
+        self.roles = {
+            'PM': (Policy.objects.get(name='project-manager'), v),
+            'DC': (Policy.objects.get(name='data-collector'), v),
+            'PU': (Policy.objects.get(name='project-user'), v)
+        }
 
     def test_repr(self):
         user = UserFactory.build(username='john')
@@ -186,59 +207,72 @@ class ProjectRoleTest(UserTestCase, TestCase):
         assert repr(role) == ('<ProjectRole id=abc123 user=john project=prj '
                               'role=DC>')
 
-    def _has(self, action, state):
-        assert self.user.has_perm(action, self.project) is state
+    def _has(self, role, state=True):
+        assert (self.roles[role] in self.user.assigned_policies()) is state
 
     def _add_role(self, role):
         return ProjectRole.objects.create(
             project=self.project, user=self.user, role=role)
 
-    def _change_role(self, action, before_role, before, after_role, after):
+    def _change_role(self, before_role, after_role):
         role = self._add_role(before_role)
-        self._has(action, before)
+        self._has(before_role)
         role.role = after_role
         role.save()
-        self._has(action, after)
-
-    def _change_manager(self, action, role, before, manager, after):
-        role = self._add_role(role)
-        self._has(action, before)
-        role.manager = manager
-        role.save()
-        self._has(action, after)
+        self._has(after_role)
+        if before_role != after_role:
+            self._has(before_role, state=False)
 
     def test_assign_new_manager(self):
         self._add_role('PM')
-        self._has('project.edit', True)
+        self._has('PM')
 
     def test_add_manager_role(self):
-        self._has('project.edit', False)
+        self._has('PM', state=False)
         self._add_role('PM')
-        self._has('project.edit', True)
+        self._has('PM', state=True)
 
     def test_keep_manager_role(self):
-        self._change_manager('project.edit', 'PM', True, True, True)
+        self._change_role('PM', 'PM')
 
     def test_keep_non_manager_role(self):
-        self._change_manager('project.edit', 'PU', False, False, False)
+        self._change_role('PU', 'PU')
 
     def test_remove_manager_role(self):
-        self._change_role('project.edit', 'PM', True, 'PU', False)
+        self._change_role('PM', 'PU')
 
     def test_assign_new_collector(self):
         self._add_role('DC')
-        self._has('resource.add', True)
+        self._has('DC')
 
     def test_add_collector_role(self):
-        self._has('resource.add', False)
+        self._has('DC', state=False)
         self._add_role('DC')
-        self._has('resource.add', True)
+        self._has('DC', state=True)
 
     def test_keep_collector_role(self):
-        self._change_role('resource.add', 'DC', True, 'DC', True)
+        self._change_role('DC', 'DC')
 
     def test_keep_non_collector_role(self):
-        self._change_role('resource.add', 'PU', False, 'PU', False)
+        self._change_role('PU', 'PU')
 
     def test_remove_collector_role(self):
-        self._change_role('resource.add', 'DC', True, 'PU', False)
+        self._change_role('DC', 'PU')
+
+    def test_delete_manager_role(self):
+        self._add_role('PM')
+        self._has('PM', state=True)
+        ProjectRole.objects.get(project=self.project, user=self.user).delete()
+        self._has('PM', state=False)
+
+    def test_delete_collector_role(self):
+        self._add_role('DC')
+        self._has('DC', state=True)
+        ProjectRole.objects.get(project=self.project, user=self.user).delete()
+        self._has('DC', state=False)
+
+    def test_delete_user_role(self):
+        self._add_role('PU')
+        self._has('PU', state=True)
+        ProjectRole.objects.get(project=self.project, user=self.user).delete()
+        self._has('PU', state=False)

--- a/cadasta/organization/tests/test_models.py
+++ b/cadasta/organization/tests/test_models.py
@@ -183,9 +183,6 @@ class ProjectTest(TestCase):
 
 
 class ProjectRoleTest(UserTestCase, TestCase):
-    def _get_roles(self):
-        pass
-
     def setUp(self):
         super().setUp()
         self.project = ProjectFactory.create()


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #1008: As @seav stated in the original bug report, permission policies were not removed from the user's assign policies when a project role is deleted. Policies were also not removed correctly when an organization admin role was deleted (as reported by @linzjax in the comments).
- Introduces a `post_delete` hook for `ProjectRole` instances that makes sure policies are unassigned correctly. The functionality to reassign project roles now lives in `assign_prj_policies`, which is used for both updating and removing project roles. 
- Adds changes to `assign_org_policies` (formerly `reassign_user_policies` to make sure policies are removed when an organization admin role instance is deleted.
- I also refactored functions related to permission assignment for both organisations and projects to make naming and functionality more consistent:
    - `reassign_user_policies` renamed to `assign_org_policies`
    - `remove_project_membership` renamed to `remove_org_permissions`
    - `assign_org_policies` to use `delete` flag instead of `adding`
- `organization.tests.test_models.ProjectRoleTest` was refactored to test whether the policies are assigned to the user instead of specific permissions. This was necessary because the project user policy does not currently contain any permissions; it would not be possible to test if the role is assigned correctly.

### When should this PR be merged

ASAP

### Risks

None

### Follow up actions

None

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
