### PR TITLE
Fix #960 -- Hide Import button from UI

### DIFF
--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -218,7 +218,8 @@ class ProjectDashboardTest(ViewTestCase, UserTestCase, TestCase):
             'num_resources': 0,
             'is_allowed_add_location': False,
             'is_allowed_add_resource': False,
-            'is_project_member': False
+            'is_project_member': False,
+            'is_allowed_add_resource': False
         }
 
     def setup_url_kwargs(self):
@@ -251,7 +252,8 @@ class ProjectDashboardTest(ViewTestCase, UserTestCase, TestCase):
                                        is_administrator=True,
                                        is_allowed_add_location=True,
                                        is_allowed_add_resource=True,
-                                       is_project_member=True)
+                                       is_project_member=True,
+                                       is_allowed_import=True)
         assert response.content == expected
 
     def test_get_with_org_admin(self):
@@ -265,7 +267,8 @@ class ProjectDashboardTest(ViewTestCase, UserTestCase, TestCase):
         expected = self.render_content(is_administrator=True,
                                        is_allowed_add_location=True,
                                        is_allowed_add_resource=True,
-                                       is_project_member=True)
+                                       is_project_member=True,
+                                       is_allowed_import=True)
         assert response.content == expected
 
     def test_get_with_project_manager(self):
@@ -279,7 +282,8 @@ class ProjectDashboardTest(ViewTestCase, UserTestCase, TestCase):
         expected = self.render_content(is_administrator=True,
                                        is_allowed_add_location=True,
                                        is_allowed_add_resource=True,
-                                       is_project_member=True)
+                                       is_project_member=True,
+                                       is_allowed_import=True)
         assert response.content == expected
 
     def test_get_non_existent_project(self):
@@ -371,7 +375,8 @@ class ProjectDashboardTest(ViewTestCase, UserTestCase, TestCase):
                                        is_administrator=True,
                                        is_allowed_add_location=True,
                                        is_allowed_add_resource=True,
-                                       is_project_member=True)
+                                       is_project_member=True,
+                                       is_allowed_import=True)
         assert response.content == expected
 
     def test_get_archived_project_with_unauthorized_user(self):
@@ -406,6 +411,7 @@ class ProjectDashboardTest(ViewTestCase, UserTestCase, TestCase):
         expected = self.render_content(is_administrator=True,
                                        is_allowed_add_location=True,
                                        is_allowed_add_resource=True,
+                                       is_allowed_import=True,
                                        is_project_member=True)
         assert response.content == expected
 
@@ -837,7 +843,8 @@ class ProjectEditGeometryTest(ViewTestCase, UserTestCase, TestCase):
     def setup_template_context(self):
         return {'project': self.project,
                 'object': self.project,
-                'form': forms.ProjectAddExtents(instance=self.project)}
+                'form': forms.ProjectAddExtents(instance=self.project),
+                'is_allowed_import': True}
 
     def test_get_with_authorized_user(self):
         user = UserFactory.create()
@@ -947,7 +954,8 @@ class ProjectEditDetailsTest(ViewTestCase, UserTestCase,
                     instance=self.project,
                     initial={'questionnaire': self.questionnaire.xls_form.url,
                              'original_file': self.questionnaire.original_file}
-                )}
+                ),
+                'is_allowed_import': True}
 
     def test_get_with_authorized_user(self):
         user = UserFactory.create()
@@ -1158,7 +1166,8 @@ class ProjectEditPermissionsTest(ViewTestCase, UserTestCase, TestCase):
     def setup_template_context(self):
         return {'project': self.project,
                 'object': self.project,
-                'form': forms.ProjectEditPermissions(instance=self.project)}
+                'form': forms.ProjectEditPermissions(instance=self.project),
+                'is_allowed_import': True}
 
     def test_get_with_authorized_user(self):
         user = UserFactory.create()
@@ -1359,7 +1368,8 @@ class ProjectDataDownloadTest(ViewTestCase, UserTestCase, TestCase):
         return {'project': self.project,
                 'object': self.project,
                 'form': forms.DownloadForm(project=self.project,
-                                           user=self.user)}
+                                           user=self.user),
+                'is_allowed_import': True}
 
     def test_get_with_authorized_user(self):
         assign_policies(self.user)

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -167,10 +167,14 @@ class ProjectAdminCheckMixin(SuperUserCheckMixin):
         context = super().get_context_data(*args, **kwargs)
         context['is_administrator'] = self.is_administrator
         user = self.request.user
+
+        project = self.get_project()
         context['is_allowed_add_location'] = user.has_perm('spatial.create',
-                                                           self.get_project())
+                                                           project)
         context['is_allowed_add_resource'] = user.has_perm('resource.add',
-                                                           self.get_project())
+                                                           project)
+        context['is_allowed_import'] = user.has_perm('project.import',
+                                                     project)
         return context
 
 

--- a/cadasta/templates/organization/project_wrapper.html
+++ b/cadasta/templates/organization/project_wrapper.html
@@ -64,15 +64,15 @@
           <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Add location" %}
         </a>
         {% endif %}
-        {% if is_allowed_add_resource %}
+        {% if is_allowed_add_resource or is_allowed_import %}
         <button type="button" class="btn btn-primary btn-rt dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <span class="caret"></span>
           <span class="sr-only">{%trans "Toggle add" %}</span>
         </button>
         <ul class="dropdown-menu">
-          <li><a href="{% url 'resources:project_add_existing' object.organization.slug object.slug %}">{% trans "Add resource" %}</a></li>
-          <li role="separator" class="divider"></li>
-          <li><a href="{% url 'organization:project-import' object.organization.slug object.slug %}" data-toggle="modal">{% trans "Import data" %}</a></li>
+          {% if is_allowed_add_resource %}<li><a href="{% url 'resources:project_add_existing' object.organization.slug object.slug %}">{% trans "Add resource" %}</a></li>{% endif %}
+          {% if is_allowed_add_resource and is_allowed_import %}<li role="separator" class="divider"></li>{% endif %}
+          {% if is_allowed_import %}<li><a href="{% url 'organization:project-import' object.organization.slug object.slug %}" data-toggle="modal">{% trans "Import data" %}</a></li>{% endif %}
         </ul>
         {% endif %}
       </div>


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #960: Hides the import button from the dropdown menu for users who do not have permission to import data

### When should this PR be merged

Anytime

### Risks

None

### Follow up actions

None

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
