### PR TITLE
Single page map scaffolding view and html. Upgrade (kinda) to Leaflet1.0

### DIFF
--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -56,7 +56,6 @@ INSTALLED_APPS = (
     'parsley',
     'widget_tweaks',
     'django_countries',
-    'leaflet',
     'rest_framework',
     'rest_framework_gis',
     'rest_framework.authtoken',

--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -5350,27 +5350,34 @@ ul.resource-actions > li {
 
 /* =Map location details in right column
 -------------------------------------------------------------- */
-.content-single .detail h2 span {
-  font-size: 11px;
-  color: #a6a7a8;
-  display: block;
-  text-transform: uppercase;
-  padding-bottom: 2px; }
+.content-single.detail-hidden .detail {
+  display: none; }
 
-.content-single .detail .btn-group {
-  margin-left: auto;
-  margin-right: auto; }
+.content-single.detail-hidden #project-map {
+  width: 151%; }
 
-.content-single .detail .top-add {
-  margin-bottom: -30px; }
+.content-single.detail-display .detail {
+  transition: all 0.5s ease-in-out; }
+  .content-single.detail-display .detail h2 span {
+    font-size: 11px;
+    color: #a6a7a8;
+    display: block;
+    text-transform: uppercase;
+    padding-bottom: 2px; }
+  .content-single.detail-display .detail .btn-group {
+    margin-left: auto;
+    margin-right: auto; }
+  .content-single.detail-display .detail .top-add {
+    margin-bottom: -30px; }
 
-#project-map h2 {
-  padding-bottom: 0; }
-
-#project-map .btn-wrap {
-  padding: 4px 4px 5px; }
-  #project-map .btn-wrap .btn-block {
-    margin: 0 auto; }
+#project-map {
+  transition: all 0.5s ease-in-out; }
+  #project-map h2 {
+    padding-bottom: 0; }
+  #project-map .btn-wrap {
+    padding: 4px 4px 5px; }
+    #project-map .btn-wrap .btn-block {
+      margin: 0 auto; }
 
 /* =Forms
 -------------------------------------------------------------- */
@@ -5522,11 +5529,14 @@ textarea.form-control {
 .well {
   margin-bottom: 10px; }
 
+#mapid {
+  height: 100%;
+  z-index: 1; }
+
 /* =Leaflet popups
 -------------------------------------------------------------- */
 .leaflet-container {
-  font-family: "Roboto", Helvetica, Arial, "Noto Sans Bengali", sans-serif !important;
-  z-index: 1; }
+  font-family: "Roboto", Helvetica, Arial, "Noto Sans Bengali", sans-serif !important; }
 
 .leaflet-popup-content-wrapper {
   border-radius: 4px !important;
@@ -5596,9 +5606,6 @@ textarea.form-control {
 
 /* =Map controls
 -------------------------------------------------------------- */
-.leaflet-top, .leaflet-bottom {
-  z-index: 200; }
-
 /* =Labels
 -------------------------------------------------------------- */
 div#id_extents_location_map {

--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -5351,32 +5351,34 @@ ul.resource-actions > li {
 /* =Map location details in right column
 -------------------------------------------------------------- */
 .content-single.detail-hidden .detail {
-  display: none; }
+  left: 500px;
+  transition: all 0.5s ease-in-out; }
 
 .content-single.detail-hidden #project-map {
-  width: 151%; }
+  width: 100%; }
 
-.content-single.detail-display .detail {
+.content-single .detail {
+  left: 0px;
   transition: all 0.5s ease-in-out; }
-  .content-single.detail-display .detail h2 span {
+  .content-single .detail h2 span {
     font-size: 11px;
     color: #a6a7a8;
     display: block;
     text-transform: uppercase;
     padding-bottom: 2px; }
-  .content-single.detail-display .detail .btn-group {
+  .content-single .detail .btn-group {
     margin-left: auto;
     margin-right: auto; }
-  .content-single.detail-display .detail .top-add {
+  .content-single .detail .top-add {
     margin-bottom: -30px; }
 
-#project-map {
+.content-single #project-map {
   transition: all 0.5s ease-in-out; }
-  #project-map h2 {
+  .content-single #project-map h2 {
     padding-bottom: 0; }
-  #project-map .btn-wrap {
+  .content-single #project-map .btn-wrap {
     padding: 4px 4px 5px; }
-    #project-map .btn-wrap .btn-block {
+    .content-single #project-map .btn-wrap .btn-block {
       margin: 0 auto; }
 
 /* =Forms

--- a/cadasta/core/static/css/maps.scss
+++ b/cadasta/core/static/css/maps.scss
@@ -1,9 +1,14 @@
+#mapid { 
+  height: 100%; 
+  z-index: 1;
+}
+
 /* =Leaflet popups
 -------------------------------------------------------------- */
 
 .leaflet-container {
   font-family: $font-family-sans-serif !important;
-  z-index: 1;
+  // z-index: 1;
 }
 
 .leaflet-popup-content-wrapper {
@@ -97,7 +102,7 @@
 -------------------------------------------------------------- */
 
 .leaflet-top, .leaflet-bottom {
-  z-index: 200;
+  // z-index: 200;
 }
 
 /* =Labels

--- a/cadasta/core/static/css/single.scss
+++ b/cadasta/core/static/css/single.scss
@@ -418,17 +418,19 @@
 
 .content-single.detail-hidden {
   .detail {
-    display: none;
+    left: 500px;
+    transition: all 0.5s ease-in-out;
   }
 
   #project-map {
-    width: 151%;
+    width: 100%;
   }
 }
 
 
-.content-single.detail-display {
+.content-single {
   .detail {
+    left: 0px;
     h2 {
       span {
         font-size: 11px;
@@ -447,17 +449,18 @@
     }
     transition: all 0.5s ease-in-out;
   }
+  #project-map {
+    // width: 100%;
+    h2 {
+    padding-bottom: 0;
+    }
+    .btn-wrap { // button
+      padding: 4px 4px 5px;
+      .btn-block {
+        margin: 0 auto;
+      }
+    }
+    transition: all 0.5s ease-in-out;
+  }
 }
 
-#project-map {
-  h2 {
-  padding-bottom: 0;
-  }
-  .btn-wrap { // button
-    padding: 4px 4px 5px;
-    .btn-block {
-      margin: 0 auto;
-    }
-  }
-  transition: all 0.5s ease-in-out;
-}

--- a/cadasta/core/static/css/single.scss
+++ b/cadasta/core/static/css/single.scss
@@ -416,22 +416,36 @@
 /* =Map location details in right column
 -------------------------------------------------------------- */
 
-.content-single .detail {
-  h2 {
-    span {
-      font-size: 11px;
-      color: $gray-medium;
-      display: block;
-      text-transform: uppercase; 
-      padding-bottom: 2px;
+.content-single.detail-hidden {
+  .detail {
+    display: none;
+  }
+
+  #project-map {
+    width: 151%;
+  }
+}
+
+
+.content-single.detail-display {
+  .detail {
+    h2 {
+      span {
+        font-size: 11px;
+        color: $gray-medium;
+        display: block;
+        text-transform: uppercase; 
+        padding-bottom: 2px;
+      }
     }
-  }
-  .btn-group {
-    margin-left: auto;
-    margin-right: auto;
-  }
-  .top-add {
-    margin-bottom: -30px;
+    .btn-group {
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .top-add {
+      margin-bottom: -30px;
+    }
+    transition: all 0.5s ease-in-out;
   }
 }
 
@@ -445,4 +459,5 @@
       margin: 0 auto;
     }
   }
+  transition: all 0.5s ease-in-out;
 }

--- a/cadasta/core/static/js/map_utils.js
+++ b/cadasta/core/static/js/map_utils.js
@@ -63,9 +63,10 @@ function renderFeatures(map, featuresUrl, options) {
       } else {
         $('#messages #loading').addClass('hidden');
         if (options.fitBounds === 'locations') {
-          var bounds = markers.getBounds();
+          // var bounds = markers.getBounds();
+          var bounds = geoJson.getBounds();
           if (bounds.isValid()) {
-            map.fitBounds(bounds);  
+            map.fitBounds(bounds);
           }
         }
       }
@@ -96,7 +97,7 @@ function renderFeatures(map, featuresUrl, options) {
   } else {
     map.fitBounds([[-45.0, -180.0], [45.0, 180.0]]);
   }
-  
+
   var geoJson = L.geoJson(null, {
     style: { weight: 2 },
     onEachFeature: function(feature, layer) {
@@ -105,18 +106,17 @@ function renderFeatures(map, featuresUrl, options) {
                       "<h2><span>Location</span>" +
                       feature.properties.type + "</h2></div>" +
                       "<div class=\"btn-wrap\"><a href='" + feature.properties.url + "' class=\"btn btn-primary btn-sm btn-block\">" + options.trans['open'] + "</a>"  +
-                      "</div>");  
+                      "</div>");
       }
     }
   });
-
-  var markers = L.Deflate({minSize: 20, layerGroup: geoJson});
-  markers.addTo(map);
+  // var markers = L.Deflate({minSize: 20, layerGroup: geoJson});
+  // markers.addTo(map);
   geoJson.addTo(map);
 
   if (options.location) {
     options.location.addTo(map);
-    map.fitBounds(options.location.getBounds());  
+    map.fitBounds(options.location.getBounds());
   } else if (projectBounds) {
     map.fitBounds(projectBounds);
   }
@@ -142,7 +142,7 @@ function switch_layer_controls(map, options){
   var groupedOptions = {
     groupCheckboxes: false
   };
-  map.removeControl(map.layerscontrol);
+  // map.removeControl(map.layerscontrol);
   map.layerscontrol = L.control.groupedLayers(
     baseLayers, groupedOptions).addTo(map);
 }
@@ -186,3 +186,28 @@ function saveOnMapEditMode() {
     saveButton.dispatchEvent(clickEvent);
   }
 }
+
+function addTileLayers(map, layers) {
+  // modified from django-leaflet
+  layerscontrol = L.control.layers().addTo(map);
+  for (var i = 0, n = layers.length; i < n; i++) {
+    var layer = l2d(layers[i]);
+    l = L.tileLayer(layer.url, layer.options);
+    layerscontrol.addBaseLayer(l, layer.name);
+    // Show first one as default
+    if (i === 0) l.addTo(map);
+  }
+
+  function l2d(l) {
+      options = L.Util.extend(l['attrs']);
+      return {name: l['label'], url: l['url'], options: options};
+  }
+};
+
+function importMap(layers){
+  var mymap = L.map('mapid');
+  addTileLayers(mymap, layers)
+  return mymap;
+};
+
+

--- a/cadasta/core/static/js/map_utils.js
+++ b/cadasta/core/static/js/map_utils.js
@@ -187,27 +187,6 @@ function saveOnMapEditMode() {
   }
 }
 
-function addTileLayers(map, layers) {
-  // modified from django-leaflet
-  layerscontrol = L.control.layers().addTo(map);
-  for (var i = 0, n = layers.length; i < n; i++) {
-    var layer = l2d(layers[i]);
-    l = L.tileLayer(layer.url, layer.options);
-    layerscontrol.addBaseLayer(l, layer.name);
-    // Show first one as default
-    if (i === 0) l.addTo(map);
-  }
 
-  function l2d(l) {
-      options = L.Util.extend(l['attrs']);
-      return {name: l['label'], url: l['url'], options: options};
-  }
-};
-
-function importMap(layers){
-  var mymap = L.map('mapid');
-  addTileLayers(mymap, layers)
-  return mymap;
-};
 
 

--- a/cadasta/core/static/js/smap/index.js
+++ b/cadasta/core/static/js/smap/index.js
@@ -1,0 +1,7 @@
+$(window).load(function () {
+  var js_files = ['map.js']
+  var body = $('body')
+  for (i in js_files) {
+    body.append($('<script src="/static/js/smap/' + js_files[i] + '"></script>'));
+  }
+});

--- a/cadasta/core/static/js/smap/map.js
+++ b/cadasta/core/static/js/smap/map.js
@@ -1,0 +1,127 @@
+var SMap = (function() {
+    var map = L.map('mapid');
+    var layerscontrol = L.control.layers().addTo(map);
+
+    function add_tile_layers() {
+      for (var i = 0, n = layers.length; i < n; i++) {
+        var options = L.Util.extend(layers[i]['attrs']);
+        var layer = {name: layers[i]['label'], url: layers[i]['url'], options: options};
+
+        var l = L.tileLayer(layer.url, layer.options);
+        layerscontrol.addBaseLayer(l, layer.name);
+
+        if (i === 0) {
+          l.addTo(map); 
+        }
+      }
+    }
+
+    add_tile_layers();
+
+    function load_project_extent() {
+      if (options.projectExtent) {
+          var boundary = L.geoJson(
+            options.projectExtent, {
+              style: {
+              stroke: true,
+              color: "#0e305e",
+              weight: 2,
+              dashArray: "5, 5",
+              opacity: 1,
+              fill: false,
+              clickable: false,
+            }
+          }
+        );
+        boundary.addTo(map);
+        projectBounds = boundary.getBounds();
+      }
+      if (options.fitBounds === 'project') {
+        map.fitBounds(projectBounds);
+      } else if (options.fitBounds !== 'locations') {
+        map.fitBounds([[-45.0, -180.0], [45.0, 180.0]]);
+      }
+    }
+
+    load_project_extent()
+
+    function render_features(){
+      var geoJson = L.geoJson(null, {
+        style: { weight: 2 },
+        onEachFeature: function(feature, layer) {
+          if (options.trans) {
+            layer.bindPopup("<div class=\"text-wrap\">" +
+                          "<h2><span>Location</span>" +
+                          feature.properties.type + "</h2></div>" +
+                          "<div class=\"btn-wrap\"><a href='" + feature.properties.url + "' class=\"btn btn-primary btn-sm btn-block\">" + options.trans['open'] + "</a>"  +
+                          "</div>");
+          }
+        }
+      });
+
+      function load_features(request_url) {
+        $('#messages #loading').removeClass('hidden');
+        $.get(request_url, function(response) {
+          geoJson.addData(response);
+          if (response.next) {
+            load_features(response.next);
+          } else {
+            $('#messages #loading').addClass('hidden');
+            if (options.fitBounds === 'locations') {
+              var bounds = geoJson.getBounds();
+              if (bounds.isValid()) {
+                map.fitBounds(bounds);
+              }
+            }
+          }
+        });
+      }
+
+      geoJson.addTo(map);
+      load_features(url);
+  }
+
+  render_features()
+
+  function render_spatial_resource(){
+    $.ajax(fetch_spatial_resources).done(function(data){
+      if (data.length == 0) return;
+      var spatialResources = {};
+      $.each(data, function(idx, resource){
+        var name = resource.name;
+        var layers = {};
+        var group = new L.LayerGroup();
+        $.each(resource.spatial_resources, function(i, spatial_resource){
+          var layer = L.geoJson(spatial_resource.geom).addTo(group);
+          layers['name'] = spatial_resource.name;
+          layers['group'] = group;
+        });
+        spatialResources[name] = layers;
+      });
+      $.each(spatialResources, function(sr){
+        var layer = spatialResources[sr];
+        layerscontrol.addOverlay(layer['group'], layer['name'], sr);
+      })
+    });
+  }
+
+  render_spatial_resource();
+
+  function geoLocate() {
+    return function(event) {
+      map.locate({ setView: true });
+    }
+  }
+
+  $(window).on('hashchange', function() {
+    if (window.location.hash === '#overview')
+      $('.content-single').removeClass('detail-hidden')
+    else {
+        $('.content-single').addClass('detail-hidden')
+    }
+
+    window.setTimeout(function() {
+      map.invalidateSize();
+    }, 400);
+  })
+})();

--- a/cadasta/core/views/default.py
+++ b/cadasta/core/views/default.py
@@ -1,7 +1,9 @@
 import json
 
+from config.settings.default import LEAFLET_CONFIG
 from core.views.generic import TemplateView
 from django.shortcuts import redirect
+from django.utils.encoding import force_text
 from organization.models import Organization, Project
 from organization.serializers import ProjectGeometrySerializer
 
@@ -21,6 +23,12 @@ class Dashboard(TemplateView):
         context['geojson'] = json.dumps(
             ProjectGeometrySerializer(projects, many=True).data
         )
+        context['leaflet_tiles'] = [
+            {
+              'label': force_text(label),
+              'url': url,
+              'attrs': force_text(attrs)
+            } for (label, url, attrs) in LEAFLET_CONFIG.get('TILES')]
         return context
 
     def get(self, request, *args, **kwargs):

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -8,13 +8,13 @@ from core.form_mixins import SuperUserCheck
 from core.util import slugify
 from django import forms
 from django.conf import settings
-from django.contrib.gis import forms as gisforms
+# from django.contrib.gis import forms as gisforms
 from django.contrib.postgres import forms as pg_forms
 from django.db import transaction
 from django.forms import ValidationError
 from django.forms.utils import ErrorDict
 from django.utils.translation import ugettext as _
-from leaflet.forms.widgets import LeafletWidget
+# from leaflet.forms.widgets import LeafletWidget
 from questionnaires.models import Questionnaire
 from tutelary.models import check_perms
 
@@ -251,7 +251,7 @@ class EditOrganizationMemberProjectPermissionForm(forms.Form):
 
 
 class ProjectAddExtents(forms.ModelForm):
-    extent = gisforms.PolygonField(widget=LeafletWidget(), required=False)
+    # extent = gisforms.PolygonField(widget=LeafletWidget(), required=False)
 
     class Meta:
         model = Project

--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -6,6 +6,7 @@ import pytest
 from accounts.tests.factories import UserFactory
 from core.tests.utils.cases import FileStorageTestCase, UserTestCase
 from core.tests.utils.files import make_dirs  # noqa
+from config.settings.default import LEAFLET_CONFIG
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.gis.geos import Point
@@ -15,6 +16,7 @@ from django.core.urlresolvers import reverse
 from django.http import Http404, HttpRequest
 from django.template.loader import render_to_string
 from django.test import TestCase
+from django.utils.encoding import force_text
 from jsonattrs.models import Attribute, Schema
 from skivvy import remove_csrf
 from organization.models import OrganizationRole, Project, ProjectRole
@@ -181,6 +183,241 @@ class ProjectListTest(ViewTestCase, UserTestCase, TestCase):
             object_list=sorted(Project.objects.all(), key=self.sort_key),
             add_allowed=True,
             is_superuser=True)
+
+
+class ProjectMapTest(ViewTestCase, UserTestCase, TestCase):
+    view_class = default.ProjectMap
+    template = 'organization/project_map.html'
+
+    def setup_models(self):
+        self.project = ProjectFactory.create()
+        clauses = {
+            'clause': [
+                clause('allow',
+                       ['project.list'],
+                       ['organization/*']),
+                clause('allow',
+                       ['project.view', 'project.view_private'],
+                       ['project/*/*'])
+            ]
+        }
+        self.policy = Policy.objects.create(
+            name='allow',
+            body=json.dumps(clauses))
+
+        self.user = UserFactory.create()
+        self.user.assign_policies(self.policy)
+
+    def setup_template_context(self):
+        return {
+            'object': self.project,
+            'project': self.project,
+            'is_superuser': False,
+            'is_administrator': False,
+            'is_allowed_add_location': False,
+            'is_allowed_add_resource': False,
+            'is_project_member': False,
+            'is_allowed_add_resource': False,
+            'leaflet_tiles': [
+                {
+                  'label': force_text(label),
+                  'url': url,
+                  'attrs': force_text(attrs)
+                } for (label, url, attrs) in LEAFLET_CONFIG.get('TILES')]
+        }
+
+    def setup_url_kwargs(self):
+        return {
+            'organization': self.project.organization.slug,
+            'project': self.project.slug
+        }
+
+    def test_get_with_authorized_user(self):
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        assert response.content == self.expected_content
+
+    def test_get_with_unauthorized_user(self):
+        response = self.request(user=UserFactory.create())
+        assert response.status_code == 200
+        assert response.content == self.expected_content
+
+    def test_get_with_unauthenticated_user(self):
+        response = self.request()
+        assert response.status_code == 200
+        assert response.content == self.expected_content
+
+    def test_get_with_superuser(self):
+        superuser_role = Role.objects.get(name='superuser')
+        self.user.assign_policies(superuser_role)
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        expected = self.render_content(is_superuser=True,
+                                       is_administrator=True,
+                                       is_allowed_add_location=True,
+                                       is_allowed_add_resource=True,
+                                       is_project_member=True,
+                                       is_allowed_import=True)
+        assert response.content == expected
+
+    def test_get_with_org_admin(self):
+        OrganizationRole.objects.create(
+            organization=self.project.organization,
+            user=self.user,
+            admin=True
+        )
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        expected = self.render_content(is_administrator=True,
+                                       is_allowed_add_location=True,
+                                       is_allowed_add_resource=True,
+                                       is_project_member=True,
+                                       is_allowed_import=True)
+        assert response.content == expected
+
+    def test_get_with_project_manager(self):
+        ProjectRole.objects.create(
+            project=self.project,
+            user=self.user,
+            role='PM',
+        )
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        expected = self.render_content(is_administrator=True,
+                                       is_allowed_add_location=True,
+                                       is_allowed_add_resource=True,
+                                       is_project_member=True,
+                                       is_allowed_import=True)
+        assert response.content == expected
+
+    def test_get_non_existent_project(self):
+        with pytest.raises(Http404):
+            self.request(
+                user=self.user,
+                url_kwargs={'organization': 'some-org', 'project': 'some=prj'})
+
+    def test_get_with_project_extent(self):
+        self.project.extent = (
+            'SRID=4326;'
+            'POLYGON ((-5.1031494140625000 8.1299292850467957, '
+            '-5.0482177734375000 7.6837733211111425, '
+            '-4.6746826171875000 7.8252894725496338, '
+            '-4.8641967773437491 8.2278005261522775, '
+            '-5.1031494140625000 8.1299292850467957))')
+        self.project.save()
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        assert response.content == self.expected_content
+
+    def test_get_private_project(self):
+        self.project.access = 'private'
+        self.project.save()
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        assert response.content == self.expected_content
+
+    def test_get_private_project_with_unauthenticated_user(self):
+        self.project.access = 'private'
+        self.project.save()
+        response = self.request()
+        assert response.status_code == 302
+        assert ("You don't have permission to access this project"
+                in response.messages)
+
+    def test_get_private_project_without_permission(self):
+        # Note, no project.view_private!
+        restricted_clauses = {
+            'clause': [
+                clause('allow', ['org.list']),
+                clause('allow', ['org.view'], ['organization/*']),
+                clause('allow', ['project.list'], ['organization/*']),
+                clause('allow', ['project.view'], ['project/*/*'])
+            ]
+        }
+        restricted_policy = Policy.objects.create(
+            name='restricted',
+            body=json.dumps(restricted_clauses))
+        self.user.assign_policies(restricted_policy)
+
+        self.project.access = 'private'
+        self.project.save()
+        response = self.request()
+        assert response.status_code == 302
+        assert ("You don't have permission to access this project"
+                in response.messages)
+
+    def test_get_private_project_based_on_org_membership(self):
+        OrganizationRole.objects.create(organization=self.project.organization,
+                                        user=self.user)
+        self.project.access = 'private'
+        self.project.save()
+
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        assert response.content == self.expected_content
+
+    def test_get_private_project_with_other_org_membership(self):
+        org = OrganizationFactory.create()
+        OrganizationRole.objects.create(organization=org, user=self.user)
+        self.project.access = 'private'
+        self.project.save()
+
+        response = self.request(user=UserFactory.create())
+        assert response.status_code == 302
+        assert ("You don't have permission to access this project"
+                in response.messages)
+
+    def test_get_private_project_with_superuser(self):
+        self.project.access = 'private'
+        self.project.save()
+
+        self.superuser_role = Role.objects.get(name='superuser')
+        self.user.assign_policies(self.superuser_role)
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        expected = self.render_content(is_superuser=True,
+                                       is_administrator=True,
+                                       is_allowed_add_location=True,
+                                       is_allowed_add_resource=True,
+                                       is_project_member=True,
+                                       is_allowed_import=True)
+        assert response.content == expected
+
+    def test_get_archived_project_with_unauthorized_user(self):
+        self.project.archived = True
+        self.project.save()
+
+        response = self.request()
+        assert response.status_code == 302
+        assert ("You don't have permission to access this project"
+                in response.messages)
+
+    def test_get_archived_project_with_unauthentic_user(self):
+        self.project.archived = True
+        self.project.save()
+
+        response = self.request(user=AnonymousUser())
+        assert response.status_code == 302
+        assert ("You don't have permission to access this project"
+                in response.messages)
+
+    def test_get_archived_project_with_org_admin(self):
+        org_admin = UserFactory.create()
+        OrganizationRole.objects.create(
+            organization=self.project.organization,
+            user=org_admin,
+            admin=True
+        )
+        self.project.archived = True
+        self.project.save()
+        response = self.request(user=org_admin)
+        assert response.status_code == 200
+        expected = self.render_content(is_administrator=True,
+                                       is_allowed_add_location=True,
+                                       is_allowed_add_resource=True,
+                                       is_allowed_import=True,
+                                       is_project_member=True)
+        assert response.content == expected
 
 
 class ProjectDashboardTest(ViewTestCase, UserTestCase, TestCase):

--- a/cadasta/organization/urls/default/organizations.py
+++ b/cadasta/organization/urls/default/organizations.py
@@ -36,12 +36,12 @@ urlpatterns = [
         name='project-add'),
     url(
         r'^(?P<organization>[-\w]+)/projects/(?P<project>[-\w]+)/$',
-        default.ProjectDashboard.as_view(),
-        name='project-dashboard'),
-    url(
-        r'^(?P<organization>[-\w]+)/projects/(?P<project>[-\w]+)/map/$',
         default.ProjectMap.as_view(),
-        name='project-map'),
+        name='project-dashboard'),
+    # url(
+    #     r'^(?P<organization>[-\w]+)/projects/(?P<project>[-\w]+)/map/$',
+    #     default.ProjectMap.as_view(),
+    #     name='project-map'),
     url(
         r'^(?P<organization>[-\w]+)/projects/(?P<project>[-\w]+)/edit/'
         'geometry/$',

--- a/cadasta/organization/urls/default/organizations.py
+++ b/cadasta/organization/urls/default/organizations.py
@@ -39,6 +39,10 @@ urlpatterns = [
         default.ProjectDashboard.as_view(),
         name='project-dashboard'),
     url(
+        r'^(?P<organization>[-\w]+)/projects/(?P<project>[-\w]+)/map/$',
+        default.ProjectMap.as_view(),
+        name='project-map'),
+    url(
         r'^(?P<organization>[-\w]+)/projects/(?P<project>[-\w]+)/edit/'
         'geometry/$',
         default.ProjectEditGeometry.as_view(),

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -434,6 +434,10 @@ class ProjectMap(PermissionRequiredMixin,
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        if self.prj.spatial_units.count() > 0:
+            context['boundary'] = 'locations'
+        else:
+            context['boundary'] = 'project'
         context['leaflet_tiles'] = [
             {
               'label': force_text(label),

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -2,8 +2,10 @@ import importlib
 import os
 from collections import OrderedDict
 
+from config.settings.default import LEAFLET_CONFIG
 import core.views.generic as generic
 import django.views.generic as base_generic
+from django.utils.encoding import force_text
 import formtools.wizard.views as wizard
 from accounts.models import User
 from core.mixins import (LoginPermissionRequiredMixin, PermissionRequiredMixin,
@@ -406,6 +408,38 @@ class ProjectDashboard(PermissionRequiredMixin,
         context['num_parties'] = num_parties
         context['num_resources'] = num_resources
 
+        return context
+
+    def get_object(self, queryset=None):
+        return self.get_project()
+
+
+class ProjectMap(PermissionRequiredMixin,
+                 mixins.ProjectAdminCheckMixin,
+                 mixins.ProjectMixin,
+                 generic.DetailView):
+
+    def get_actions(self, view):
+        if self.prj.archived:
+            return 'project.view_archived'
+        if self.prj.public():
+            return 'project.view'
+        else:
+            return 'project.view_private'
+
+    model = Project
+    template_name = 'organization/project_map.html'
+    permission_required = {'GET': get_actions}
+    permission_denied_message = error_messages.PROJ_VIEW
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['leaflet_tiles'] = [
+            {
+              'label': force_text(label),
+              'url': url,
+              'attrs': force_text(attrs)
+            } for (label, url, attrs) in LEAFLET_CONFIG.get('TILES')]
         return context
 
     def get_object(self, queryset=None):

--- a/cadasta/spatial/forms.py
+++ b/cadasta/spatial/forms.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from jsonattrs.models import Schema, compose_schemas
 from jsonattrs.forms import form_field_from_name, AttributeModelForm
 
-from leaflet.forms.widgets import LeafletWidget
+# from leaflet.forms.widgets import LeafletWidget
 from core.util import ID_FIELD_LENGTH
 from party.models import Party, TenureRelationship, TenureRelationshipType
 from .models import SpatialUnit, TYPE_CHOICES
@@ -16,7 +16,7 @@ from .widgets import SelectPartyWidget, NewEntityWidget
 
 class LocationForm(AttributeModelForm):
     geometry = gisforms.GeometryField(
-        widget=LeafletWidget(),
+        # widget=LeafletWidget(),
         error_messages={
             'required': _('No map location was provided. Please use the tools '
                           'provided on the left side of the map to mark your '

--- a/cadasta/templates/core/dashboard.html
+++ b/cadasta/templates/core/dashboard.html
@@ -2,7 +2,6 @@
 
 {% load staticfiles %}
 {% load i18n %}
-{% load leaflet_tags %}
 
 {% block top-nav %}dashboard{% endblock %}
 {% block body-class %} map{% endblock %}
@@ -10,24 +9,24 @@
 {% block title %} | {% trans "Dashboard" %}{% endblock %}
 
 {% block extra_head %}
-{% leaflet_css %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.2/dist/leaflet.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.css">
-<link rel="stylesheet" href="{% static 'css/MarkerCluster.css' %}">
-<link rel="stylesheet" href="{% static 'css/MarkerCluster.Default.css' %}">
+<!-- <link rel="stylesheet" href="{% static 'css/MarkerCluster.css' %}"> -->
+<!-- <link rel="stylesheet" href="{% static 'css/MarkerCluster.Default.css' %}"> -->
 {% endblock %}
 
 {% block extra_script %}
-{% leaflet_js %}
+<script src="https://unpkg.com/leaflet@1.0.2/dist/leaflet.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.js"></script>
-<script src="{% static 'js/leaflet.markercluster.js' %}"></script>
-<script src="{% static 'js/L.Map.Deflate.js' %}"></script>
-<script src="{% static 'js/map_utils.js' %}"></script>
+<!-- <script src="{% static 'js/leaflet.markercluster.js' %}"></script> -->
+<!-- <script src="{% static 'js/L.Map.Deflate.js' %}"></script> -->
+<!-- <script src="{% static 'js/smap/index.js' %}"></script> -->
 <script>
   function project_map_init(map, options) {
     var data = {{ geojson|safe }};
     map.fitBounds([[-45.0, -180.0], [45.0, 180.0]]);
 
-    add_map_controls(map);
+    // add_map_controls(map);
 
     var geoJson = L.geoJson(null, {
       onEachFeature: function(feature, layer) {
@@ -39,16 +38,49 @@
       }
     });
 
-    L.Deflate({minSize: 20, layerGroup: geoJson}).addTo(map);
     geoJson.addData(data);
+    geoJson.addTo(map);
   }
+
+  function add_tile_layers() {
+    for (var i = 0, n = layers.length; i < n; i++) {
+      var options = L.Util.extend(layers[i]['attrs']);
+      var layer = {name: layers[i]['label'], url: layers[i]['url'], options: options};
+
+      var l = L.tileLayer(layer.url, layer.options);
+      layerscontrol.addBaseLayer(l, layer.name);
+
+      if (i === 0) {
+        l.addTo(map); 
+      }
+    }
+  }
+
+  var map = L.map('mapid');
+  var layers = {{ leaflet_tiles|safe }}
+  var layerscontrol = L.control.layers().addTo(map);
+  add_tile_layers()
+  project_map_init(map)
+
+  // {% if project.extent %}
+  //   var projectExtent = {{ project.extent.geojson|safe }};
+  // {% else %}
+  //   var projectExtent = null;
+  // {% endif %}
+
+  // var options = {
+  //   projectExtent: projectExtent,
+  //   trans: trans,
+  //   fitBounds: '{{ boundary }}'
+  // }
+
 </script>
 {% endblock %}
 
 {% block content %}
 
-<div class="dashboard-map">
-  {% leaflet_map "dashboard-map" callback="project_map_init" %}
+<div id="dashboard-map">
+  <div id='mapid'></div>
 </div>
 
 {% endblock %}

--- a/cadasta/templates/organization/project_add_extents.html
+++ b/cadasta/templates/organization/project_add_extents.html
@@ -1,19 +1,19 @@
 {% extends "organization/project_add_wrapper.html" %}
 
 {% load staticfiles %}
-{% load leaflet_tags %}
+<!-- {% load leaflet_tags %} -->
 {% load i18n %}
 
 {% block page_title %}| {% trans "Draw map" %}{% endblock %}
 {% block body-class %} map{% endblock %}
 
 {% block extra_head %}
-{% leaflet_css plugins="draw,forms" %}
+<!-- {% leaflet_css plugins="draw,forms" %} -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.css">
 {% endblock %}
 
 {% block extra_script %}
-{% leaflet_js plugins="draw,forms" %}
+<!-- {% leaflet_js plugins="draw,forms" %} -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.js"></script>
 <script src="{% static 'js/map_utils.js' %}"></script>
 <script>

--- a/cadasta/templates/organization/project_dashboard.html
+++ b/cadasta/templates/organization/project_dashboard.html
@@ -1,17 +1,17 @@
 {% extends "organization/project_wrapper.html" %}
 
 {% load i18n %}
-{% load leaflet_tags %}
+<!-- {% load leaflet_tags %} -->
 {% load staticfiles %}
 
 {% block extra_head %}
-{% leaflet_css plugins="groupedlayercontrol"%}
+<!-- {% leaflet_css plugins="groupedlayercontrol"%} -->
 <link rel="stylesheet" href="{% static 'css/MarkerCluster.css' %}">
 <link rel="stylesheet" href="{% static 'css/MarkerCluster.Default.css' %}">
 {% endblock %}
 
 {% block extra_script %}
-{% leaflet_js plugins="groupedlayercontrol"%}
+<!-- {% leaflet_js plugins="groupedlayercontrol"%} -->
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>
 <script src="{% static 'js/map_utils.js' %}"></script>

--- a/cadasta/templates/organization/project_edit_geometry.html
+++ b/cadasta/templates/organization/project_edit_geometry.html
@@ -2,19 +2,19 @@
 
 {% load staticfiles %}
 {% load i18n %}
-{% load leaflet_tags %}
+<!-- {% load leaflet_tags %} -->
 
 {% block page_title %}{% trans "Edit project boundary" %} | {% endblock %}
 {% block body-class %} map{% endblock %}
 
 
 {% block extra_head %}
-{% leaflet_css plugins="draw,forms" %}
+<!-- {% leaflet_css plugins="draw,forms" %} -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.css">
 {% endblock %}
 
 {% block extra_script %}
-{% leaflet_js plugins="draw,forms" %}
+<!-- {% leaflet_js plugins="draw,forms" %} -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.js"></script>
 <script src="{% static 'js/map_utils.js' %}"></script>
 <script>

--- a/cadasta/templates/organization/project_map.html
+++ b/cadasta/templates/organization/project_map.html
@@ -1,0 +1,72 @@
+{% extends "organization/project_wrapper.html" %}
+
+{% load i18n %}
+
+{% load staticfiles %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.2/dist/leaflet.css" />
+<link rel="stylesheet" href="{% static 'css/leaflet.groupedlayercontrol.min.css' %}">
+<link rel="stylesheet" href="{% static 'css/MarkerCluster.css' %}">
+<link rel="stylesheet" href="{% static 'css/MarkerCluster.Default.css' %}">
+{% endblock %}
+
+{% block extra_script %}
+<script src="https://unpkg.com/leaflet@1.0.2/dist/leaflet.js"></script>
+<script src="{% static '/js/leaflet.groupedlayercontrol.min.js' %}"></script>
+<!-- <script src="{% static 'js/leaflet.markercluster.js' %}"></script> -->
+<!-- <script src="{% static 'js/L.Map.Deflate.js' %}"></script> -->
+<script src="{% static 'js/map_utils.js' %}"></script>
+
+<script>
+  function project_map_init(map) {
+    var trans = {
+      open: "{% trans 'Open location' %}"
+    };
+
+    {% if project.extent %}
+    var projectExtent = {{ project.extent.geojson|safe }};
+    {% else %}
+    var projectExtent = null;
+    {% endif %}
+
+    renderFeatures(map,
+                   '{% url "async:spatial:list" project.organization.slug project.slug %}',
+                   {projectExtent: projectExtent, trans: trans, fitBounds: 'locations'});
+
+    var orgSlug = '{{ project.organization.slug }}';
+    var projectSlug = '{{ project.slug }}';
+    var url = '/api/v1/organizations/'
+            + orgSlug + '/projects/' + projectSlug + '/spatialresources/';
+    add_spatial_resources(map, url);
+  };
+
+  var layers = {{ leaflet_tiles|safe }}
+  map = importMap(layers)
+  project_map_init(map)
+
+</script>
+{% endblock %}
+
+{% block page_title %}{% trans "Overview" %} | {% endblock %}
+{% block body-class %} map{% endblock %}
+{% block left-nav %}overview{% endblock %}
+
+{% block content %}
+<div class="col-md-12 content-single detail-display">
+  <div class="row">
+    <!-- Start overview map  -->
+    <div class="col-md-8 map">
+      <div id="mapid"></div>
+    </div>
+    <!-- / end overview map -->
+    <!-- Overview detail  -->
+    <div class='col-md-4 detail'>
+    <!-- THIS IS WHERE THE NEW SIDE MENU DETAILS GO -->
+    </div>
+  </div>
+  <!-- / overview detail -->
+</div>
+
+<script src="{% static 'js/map_page.js' %}"></script>
+{% endblock %}

--- a/cadasta/templates/organization/project_map.html
+++ b/cadasta/templates/organization/project_map.html
@@ -16,34 +16,27 @@
 <script src="{% static '/js/leaflet.groupedlayercontrol.min.js' %}"></script>
 <!-- <script src="{% static 'js/leaflet.markercluster.js' %}"></script> -->
 <!-- <script src="{% static 'js/L.Map.Deflate.js' %}"></script> -->
-<script src="{% static 'js/map_utils.js' %}"></script>
+<script src="{% static 'js/smap/index.js' %}"></script>
 
 <script>
-  function project_map_init(map) {
-    var trans = {
-      open: "{% trans 'Open location' %}"
-    };
+  var url = '{% url "async:spatial:list" project.organization.slug project.slug %}'
+  var fetch_spatial_resources = '/api/v1/organizations/' +
+      '{{ project.organization.slug }}/projects/{{ project.slug }}/spatialresources/';
+  var trans = {open: "{% trans 'Open location' %}"};
 
-    {% if project.extent %}
+  {% if project.extent %}
     var projectExtent = {{ project.extent.geojson|safe }};
-    {% else %}
+  {% else %}
     var projectExtent = null;
-    {% endif %}
+  {% endif %}
 
-    renderFeatures(map,
-                   '{% url "async:spatial:list" project.organization.slug project.slug %}',
-                   {projectExtent: projectExtent, trans: trans, fitBounds: 'locations'});
-
-    var orgSlug = '{{ project.organization.slug }}';
-    var projectSlug = '{{ project.slug }}';
-    var url = '/api/v1/organizations/'
-            + orgSlug + '/projects/' + projectSlug + '/spatialresources/';
-    add_spatial_resources(map, url);
-  };
+  var options = {
+    projectExtent: projectExtent,
+    trans: trans,
+    fitBounds: '{{ boundary }}'
+  }
 
   var layers = {{ leaflet_tiles|safe }}
-  map = importMap(layers)
-  project_map_init(map)
 
 </script>
 {% endblock %}
@@ -53,10 +46,10 @@
 {% block left-nav %}overview{% endblock %}
 
 {% block content %}
-<div class="col-md-12 content-single detail-display">
+<div class="col-md-12 content-single">
   <div class="row">
     <!-- Start overview map  -->
-    <div class="col-md-8 map">
+    <div class="col-md-8 map" id="project-map">
       <div id="mapid"></div>
     </div>
     <!-- / end overview map -->
@@ -67,6 +60,4 @@
   </div>
   <!-- / overview detail -->
 </div>
-
-<script src="{% static 'js/map_page.js' %}"></script>
 {% endblock %}

--- a/cadasta/templates/organization/project_wrapper.html
+++ b/cadasta/templates/organization/project_wrapper.html
@@ -108,13 +108,14 @@
 <div id="sidebar" class="{% block left-nav %}{% endblock %}">
   <ul class="nav nav-sidebar">
     <li class="overview">
-      <a href="{% url 'organization:project-dashboard' object.organization.slug object.slug %}">
+      <a href="{% url 'organization:project-dashboard' object.organization.slug object.slug %}#overview">
         <span class="icon"></span>
         <span class="title">{% trans "Overview" %}</span>
       </a>
     </li><!-- needed to eliminate spacing issue on horizontal menus
     --><li class="map">
-      <a href="{% url 'locations:list' object.organization.slug object.slug %}">
+      <!-- <a href="{% url 'locations:list' object.organization.slug object.slug %}"> -->
+      <a href="#">
         <span class="icon map"></span>
         <span class="title">{% trans "Map" %}</span>
       </a>

--- a/cadasta/templates/spatial/location_add.html
+++ b/cadasta/templates/spatial/location_add.html
@@ -6,12 +6,10 @@
 {% block left-nav %}map{% endblock %}
 
 {% load staticfiles %}
-{% load leaflet_tags %}
 
 {% block page_title %}{% trans "Add location" %} | {% endblock %}
 
 {% block extra_head %}
-{% leaflet_css plugins="draw,forms,groupedlayercontrol" %}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.css">
 <link rel="stylesheet" href="{% static 'css/MarkerCluster.css' %}">
 <link rel="stylesheet" href="{% static 'css/MarkerCluster.Default.css' %}">
@@ -21,7 +19,6 @@
 {% endblock %}
 
 {% block extra_script %}
-{% leaflet_js plugins="draw,forms,groupedlayercontrol" %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.js"></script>
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>

--- a/cadasta/templates/spatial/location_edit.html
+++ b/cadasta/templates/spatial/location_edit.html
@@ -1,6 +1,5 @@
 {% extends "spatial/location_detail.html" %}
 {% load i18n %}
-{% load leaflet_tags %}
 {% load widget_tweaks %}
 {% load staticfiles %}
 
@@ -8,7 +7,6 @@
 {% block body-class %} map{% endblock %}
 
 {% block extra_head %}
-{% leaflet_css plugins="draw,forms,groupedlayercontrol" %}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.css">
 <link rel="stylesheet" href="{% static 'css/MarkerCluster.css' %}">
 <link rel="stylesheet" href="{% static 'css/MarkerCluster.Default.css' %}">
@@ -18,7 +16,6 @@
 {% endblock %}
 
 {% block extra_script %}
-{% leaflet_js plugins="draw,forms,groupedlayercontrol" %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.js"></script>
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>

--- a/cadasta/templates/spatial/location_form.html
+++ b/cadasta/templates/spatial/location_form.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load leaflet_tags %}
 {% load widget_tweaks %}
 
 <form method="POST" id="location-wizard" class="col-sm-12 content-single" data-parsley-validate data-parsley-excluded=":hidden">

--- a/cadasta/templates/spatial/location_map.html
+++ b/cadasta/templates/spatial/location_map.html
@@ -5,11 +5,9 @@
 {% block body-class %} map{% endblock %}
 {% block left-nav %}map{% endblock %}
 
-{% load leaflet_tags %}
 {% load staticfiles %}
 
 {% block extra_script %}
-{% leaflet_js plugins="groupedlayercontrol"%}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.js"></script>
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>
@@ -44,7 +42,7 @@
 {% endblock %}
 
 {% block extra_head %}
-{% leaflet_css plugins="groupedlayercontrol"%}
+
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.0/leaflet-geocoder-mapzen.css">
 <link rel="stylesheet" href="{% static 'css/MarkerCluster.css' %}">
 <link rel="stylesheet" href="{% static 'css/MarkerCluster.Default.css' %}">
@@ -61,7 +59,7 @@
   <div class="row">
     <!-- Start overview map  -->
     <div class="col-sm-12 map">
-      {% leaflet_map "project-map" callback="locations_map_init" %}
+      
     </div>
   </div>
 </div>

--- a/cadasta/templates/spatial/location_wrapper.html
+++ b/cadasta/templates/spatial/location_wrapper.html
@@ -4,17 +4,14 @@
 {% block body-class %} map{% endblock %}
 {% block left-nav %}map{% endblock %}
 
-{% load leaflet_tags %}
 {% load staticfiles %}
 
 {% block extra_head %}
-{% leaflet_css plugins="groupedlayercontrol"%}
 <link rel="stylesheet" href="{% static 'css/MarkerCluster.css' %}">
 <link rel="stylesheet" href="{% static 'css/MarkerCluster.Default.css' %}">
 {% endblock %}
 
 {% block extra_script %}
-{% leaflet_js plugins="groupedlayercontrol" %}
 <script src="{% static 'js/leaflet.markercluster.js' %}"></script>
 <script src="{% static 'js/L.Map.Deflate.js' %}"></script>
 <script src="{% static 'js/map_utils.js' %}"></script>
@@ -77,7 +74,6 @@
   <div class="row">
     <!-- Start overview map  -->
     <div class="col-md-8 map">
-      {% leaflet_map "project-map" callback="locations_map_init" %}
     </div>
     <!-- / end overview map -->
     <!-- Overview detail  -->

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -9,7 +9,6 @@ django-crispy-forms==1.6.0
 django-parsley==0.6
 django-formtools==1.0
 django-countries==3.4.1
-django-leaflet==0.18.1
 django-sass-processor==0.3.4
 djangorestframework-gis==0.10.1
 jsonschema==2.5.1


### PR DESCRIPTION
__NOTE__: This is not being merged into master. Opening this PR as the first step towards SMAP. It's caused some oddities across the platform because of Leaflet 1.0, but those will be dealt with, so pardon the mess.

### Proposed changes in this pull request
- Addresses #1057 
- ProjectMap will serve as the main view for all project pages (found at `/organization/{org-slug}/projects/{project-slug}/map/` for now)
- Side panel can be displayed or hidden by switching between `detail-hidden` and `detail-display`. Currently doesn't display anything.
- Upgraded _just_ project_map.html to Leaflet 1.0. Since other pages will be absorbed by this one, I am putting off the full upgrade until the other views have been reworked.
    - Note: the other maps will have some odd ticks until then.
- Currently only standard tests for ProjectMapView. Will add more as more functionality is added.
- Removed L.Deflate temporarily. Running into leaflet 1.0 compatibility issues.

### When should this PR be merged
Whenever

### Risks
None (not being merged into master)

### Follow up actions
- Continue the epic SMAP journey
- Finish the full upgrade to Leaflet 1.0 for other pages that remain intact after SMAP is completed.

---
### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
