### PR TITLE
Add ElasticSearch host to production override of defaults

### DIFF
--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -50,6 +50,8 @@ CACHES = {
     }
 }
 
+ES_HOST = os.environ['ES_HOST']
+
 OPBEAT = {
     'ORGANIZATION_ID': os.environ['OPBEAT_ORGID'],
     'APP_ID': os.environ['OPBEAT_APPID'],

--- a/provision/roles/cadasta/install/tasks/main.yml
+++ b/provision/roles/cadasta/install/tasks/main.yml
@@ -33,6 +33,7 @@
       S3_SECRET_KEY="{{ s3_secret_key }}"
       DJANGO_SETTINGS_MODULE="{{ django_settings }}"
       MEMCACHED_HOST="{{ memcached_host }}"
+      ES_HOST="{{ es_host }}"
       OPBEAT_ORGID="{{ opbeat_orgID }}"
       OPBEAT_APPID="{{ opbeat_appID }}"
       OPBEAT_TOKEN="{{ opbeat_token }}"
@@ -57,6 +58,7 @@
       Defaults  env_keep += S3_ACCESS_KEY
       Defaults  env_keep += S3_SECRET_KEY
       Defaults  env_keep += MEMCACHED_HOST
+      Defaults  env_keep += ES_HOST
       Defaults  env_keep += OPBEAT_ORGID
       Defaults  env_keep += OPBEAT_APPID
       Defaults  env_keep += OPBEAT_TOKEN


### PR DESCRIPTION
### Proposed changes in this pull request

Provisioning only changes; adds Ansible support for ElasticSearch host production environment variable to override defaults.

### When should this PR be merged

Anytime

### Risks

None

### Follow up actions

None

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
