### PR TITLE
Error response on mobile response string fix.

### DIFF
--- a/cadasta/templates/xforms/submission_response.xml
+++ b/cadasta/templates/xforms/submission_response.xml
@@ -1,3 +1,5 @@
 <OpenRosaResponse xmlns='http://openrosa.org/http/response'>
-  <message>{{ message }}</message>
+  {% autoescape off %}
+    <message>{{ message }}</message>
+  {% endautoescape %}
 </OpenRosaResponse>

--- a/cadasta/templates/xforms/submission_response.xml
+++ b/cadasta/templates/xforms/submission_response.xml
@@ -1,0 +1,3 @@
+<OpenRosaResponse xmlns='http://openrosa.org/http/response'>
+  <message>{{ message }}</message>
+</OpenRosaResponse>

--- a/cadasta/xforms/mixins/openrosa_headers_mixin.py
+++ b/cadasta/xforms/mixins/openrosa_headers_mixin.py
@@ -10,6 +10,8 @@ DEFAULT_CONTENT_LENGTH = getattr(settings, 'DEFAULT_CONTENT_LENGTH', 10000000)
 
 class OpenRosaHeadersMixin(object):
 
+    DEFAULT_CONTENT_TYPE = 'application/xml'
+
     def get_openrosa_headers(
             self, request, location=True, content_length=True):
 

--- a/cadasta/xforms/views/api.py
+++ b/cadasta/xforms/views/api.py
@@ -84,7 +84,11 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
             data.spatial_units.add(*locations)
             data.tenure_relationships.add(*tenure_relationships)
 
+            # This should be changed to be similor to how _sendErrorResponse works
+            successful_response_message = "Form was Successfully Received"
+            message = _(OPEN_ROSA_ENVELOPE.format(message=str(successful_response_message)))
             return Response(
+                message,
                 headers=self.get_openrosa_headers(request),
                 status=status.HTTP_201_CREATED,
                 content_type='application/xml'

--- a/cadasta/xforms/views/api.py
+++ b/cadasta/xforms/views/api.py
@@ -24,7 +24,9 @@ from ..renderers import XFormRenderer
 
 logger = logging.getLogger('xform.submissions')
 
-OPEN_ROSA_ENVELOPE = "<OpenRosaResponse xmlns='http://openrosa.org/http/response'><message>{message}</message></OpenRosaResponse>"
+OPEN_ROSA_ENVELOPE = "<OpenRosaResponse xmlns='http://openrosa.org/http/response'>\
+<message>{message}</message></OpenRosaResponse>"
+
 
 class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
     """
@@ -79,9 +81,8 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
             data.spatial_units.add(*locations)
             data.tenure_relationships.add(*tenure_relationships)
 
-            # This should be changed to be similor to how _sendErrorResponse works
-            successful_response_message = "Form was Successfully Received"
-            message = _(OPEN_ROSA_ENVELOPE.format(message=str(successful_response_message)))
+            success_msg = "Form was Successfully Received"
+            message = _(OPEN_ROSA_ENVELOPE.format(message=str(success_msg)))
             return Response(
                 message,
                 headers=self.get_openrosa_headers(request),

--- a/cadasta/xforms/views/api.py
+++ b/cadasta/xforms/views/api.py
@@ -80,9 +80,8 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
             data.parties.add(*parties)
             data.spatial_units.add(*locations)
             data.tenure_relationships.add(*tenure_relationships)
-
-            success_msg = "Form was Successfully Received"
-            message = _(OPEN_ROSA_ENVELOPE.format(message=str(success_msg)))
+            success_msg = _("Form was Successfully Received")
+            message = OPEN_ROSA_ENVELOPE.format(message=str(success_msg))
             return Response(
                 message,
                 headers=self.get_openrosa_headers(request),
@@ -91,7 +90,8 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
             )
 
     def _sendErrorResponse(self, request, e, status):
-        message = _(OPEN_ROSA_ENVELOPE.format(message=str(e)))
+        error_msg = e
+        message = OPEN_ROSA_ENVELOPE.format(message=str(error_msg))
         headers = self.get_openrosa_headers(
             request, location=False, content_length=False)
         return Response(

--- a/cadasta/xforms/views/api.py
+++ b/cadasta/xforms/views/api.py
@@ -24,12 +24,7 @@ from ..renderers import XFormRenderer
 
 logger = logging.getLogger('xform.submissions')
 
-OPEN_ROSA_ENVELOPE = """
-    <OpenRosaResponse xmlns="http://openrosa.org/http/response">
-        <message>{message}</message>
-    </OpenRosaResponse>
-"""
-
+OPEN_ROSA_ENVELOPE = "<OpenRosaResponse xmlns='http://openrosa.org/http/response'><message>{message}</message></OpenRosaResponse>"
 
 class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
     """


### PR DESCRIPTION
When a form is sent to the Cadasta platform from GeoODK the server is sending an OpenRosa formatted XML response. If there is an error or success a custom message can be sent. The javaXMLParser lib does not understand python  string = """ textexttext """.  So changed it to regular format.

I have also added a success message that is has been received. 

Small fixes but necessary to get custom responses displayed.
 