### PR TITLE
Fix #935: Conditional attributes not exported during download process

### DIFF
--- a/cadasta/core/mixins.py
+++ b/cadasta/core/mixins.py
@@ -114,6 +114,14 @@ class SchemaSelectorMixin():
         attributes_for_models = self.get_attributes(project)
         return attributes_for_models[content_type]
 
+    def get_conditional_selector(self, content_type):
+        content_type_to_selectors = self._get_content_types_to_selectors()
+        selectors = list(content_type_to_selectors[content_type])
+        if '.' in selectors[-1]:
+            return None
+        else:
+            return selectors[-1]
+
     def _get_content_types_to_selectors(self):
         content_type_to_selectors = dict()
         for k, v in settings.JSONATTRS_SCHEMA_SELECTORS.items():

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -11,6 +11,7 @@ from core.tests.utils.files import make_dirs  # noqa
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.forms.utils import ErrorDict
 from django.test import TestCase
+from party.tests.factories import PartyFactory, TenureRelationshipFactory
 from questionnaires.exceptions import InvalidXLSForm
 from questionnaires.tests.factories import QuestionnaireFactory
 from resources.tests.factories import ResourceFactory
@@ -215,6 +216,7 @@ class AddOrganizationMemberFormTest(UserTestCase, TestCase):
 
 
 class EditOrganizationMemberFormTest(UserTestCase, TestCase):
+
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create()
@@ -385,6 +387,7 @@ class EditOrganizationMemberFormTest(UserTestCase, TestCase):
 
 
 class EditOrganizationMemberProjectPermissionForm(UserTestCase, TestCase):
+
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create()
@@ -412,7 +415,7 @@ class EditOrganizationMemberProjectPermissionForm(UserTestCase, TestCase):
             self.prj_2.id: 'PU',
             self.prj_3.id: 'Pb',
             self.prj_4.id: 'Pb'
-            }
+        }
 
         form = forms.EditOrganizationMemberProjectPermissionForm(
             self.org, self.org_member, self.user, data,)
@@ -1146,6 +1149,11 @@ class DownloadFormTest(UserTestCase, TestCase):
         data = {'type': 'shp'}
         user = UserFactory.create()
         project = ProjectFactory.create()
+        geometry = 'SRID=4326;POINT (30 10)'
+        su = SpatialUnitFactory.create(project=project, geometry=geometry)
+        party = PartyFactory.create(project=project)
+        TenureRelationshipFactory.create(
+            spatial_unit=su, party=party, project=project)
         form = forms.DownloadForm(project, user, data=data)
         assert form.is_valid() is True
         path, mime = form.get_file()

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,7 +25,7 @@ pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.4.2
 django-jsonattrs==0.1.22a3
-openpyxl==2.3.5
+openpyxl==2.4.1
 pytz==2016.4
 shapely==1.5.16
 gdal==1.10.0


### PR DESCRIPTION
### Proposed changes in this pull request

#### Fix #935: Conditional attributes not exported during download process

This PR adds support for the export of conditional attributes. It makes use of the `SchemaSelectorMixin` added in PR #1076. 

- Upgraded `openpyxl` to version `2.4.1`
- Refactored the `write_items` methods of `ShapeExporter` and `XLSExporter` to export all attributes
- Refactored the `make_download` method of `XLSExporter` to use a streaming `WriteOnlyWorksheet` which streams rows to the spreadsheet rather than holding all data in memory before writing. This should help with improvements proposed in the [Asynchronous Import/Export DR](https://github.com/Cadasta/decision-records/pull/7)
- Refactored the `get_values` method of the base `Exporter` to return a dict of values instead of a list
- Added a method `get_conditional_selector` to the `SchemaSelectorMixin` to return the conditional selector for a particular `ContentType` if one exists

### When should this PR be merged

This has been rebased from #1076 so should be merged after this.

### Risks

Low risk.

### Follow up actions

Reprovision VM's to pull in updates to dependencies.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
