### PR TITLE
Ensure translations are applied

### DIFF
--- a/cadasta/party/forms.py
+++ b/cadasta/party/forms.py
@@ -1,3 +1,5 @@
+from django.utils.translation import ugettext as _
+
 from core.form_mixins import AttributeModelForm
 from .models import Party, TenureRelationshipType, TenureRelationship
 
@@ -47,9 +49,10 @@ class TenureRelationshipEditForm(AttributeModelForm):
     def __init__(self, project=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.project = project
-        tenuretypes = sorted(
+        tenuretypes = sorted([
+            (choice[0], _(choice[1])) for choice in
             TenureRelationshipType.objects.values_list('id', 'label')
-        )
+        ])
         self.fields['tenure_type'].choices = tenuretypes
         self.add_attribute_fields()
 

--- a/cadasta/party/models.py
+++ b/cadasta/party/models.py
@@ -5,9 +5,9 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.contrib.gis.db import models
 from django.contrib.postgres.fields import JSONField
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
 from django.utils.encoding import iri_to_uri
+from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as __
 
 from jsonattrs.decorators import fix_model_for_attributes
 from jsonattrs.fields import JSONAttributeField
@@ -42,9 +42,9 @@ class Party(ResourceModelMixin, RandomIDModel):
     INDIVIDUAL = 'IN'
     CORPORATION = 'CO'
     GROUP = 'GR'
-    TYPE_CHOICES = ((INDIVIDUAL, _('Individual')),
-                    (CORPORATION, _('Corporation')),
-                    (GROUP, _('Group')))
+    TYPE_CHOICES = ((INDIVIDUAL, __('Individual')),
+                    (CORPORATION, __('Corporation')),
+                    (GROUP, __('Group')))
 
     # All parties are associated with a single project.
     project = models.ForeignKey(
@@ -308,7 +308,7 @@ class TenureRelationship(ResourceModelMixin, RandomIDModel):
         return "<{party}> {type} <{su}>".format(
             party=self.party.name,
             su=self.spatial_unit.name,
-            type=self.tenure_type.label,
+            type=self.tenure_type_label,
         )
 
     @property
@@ -325,6 +325,10 @@ class TenureRelationship(ResourceModelMixin, RandomIDModel):
             },
         ))
 
+    @property
+    def tenure_type_label(self):
+        return _(self.tenure_type.label)
+
 
 class TenureRelationshipType(models.Model):
     """Defines allowable tenure types."""
@@ -340,24 +344,24 @@ class TenureRelationshipType(models.Model):
 
 
 TENURE_RELATIONSHIP_TYPES = (
-    ('CR', ugettext_lazy('Carbon Rights')),
-    ('CO', ugettext_lazy('Concessionary Rights')),
-    ('CU', ugettext_lazy('Customary Rights')),
-    ('EA', ugettext_lazy('Easement')),
-    ('ES', ugettext_lazy('Equitable Servitude')),
-    ('FH', ugettext_lazy('Freehold')),
-    ('GR', ugettext_lazy('Grazing Rights')),
-    ('HR', ugettext_lazy('Hunting/Fishing/Harvest Rights')),
-    ('IN', ugettext_lazy('Indigenous Land Rights')),
-    ('JT', ugettext_lazy('Joint Tenancy')),
-    ('LH', ugettext_lazy('Leasehold')),
-    ('LL', ugettext_lazy('Longterm Leasehold')),
-    ('MR', ugettext_lazy('Mineral Rights')),
-    ('OC', ugettext_lazy('Occupancy (No Documented Rights)')),
-    ('TN', ugettext_lazy('Tenancy (Documented Sub-lease)')),
-    ('TC', ugettext_lazy('Tenancy In Common')),
-    ('UC', ugettext_lazy('Undivided Co-ownership')),
-    ('WR', ugettext_lazy('Water Rights'))
+    ('CR', __('Carbon Rights')),
+    ('CO', __('Concessionary Rights')),
+    ('CU', __('Customary Rights')),
+    ('EA', __('Easement')),
+    ('ES', __('Equitable Servitude')),
+    ('FH', __('Freehold')),
+    ('GR', __('Grazing Rights')),
+    ('HR', __('Hunting/Fishing/Harvest Rights')),
+    ('IN', __('Indigenous Land Rights')),
+    ('JT', __('Joint Tenancy')),
+    ('LH', __('Leasehold')),
+    ('LL', __('Longterm Leasehold')),
+    ('MR', __('Mineral Rights')),
+    ('OC', __('Occupancy (No Documented Rights)')),
+    ('TN', __('Tenancy (Documented Sub-lease)')),
+    ('TC', __('Tenancy In Common')),
+    ('UC', __('Undivided Co-ownership')),
+    ('WR', __('Water Rights'))
 )
 
 

--- a/cadasta/party/tests/test_models.py
+++ b/cadasta/party/tests/test_models.py
@@ -261,7 +261,7 @@ class TenureRelationshipTest(UserTestCase, TestCase):
         tenurerel = TenureRelationshipFactory.create()
         assert tenurerel.name == "<{party}> {type} <{su}>".format(
             party=tenurerel.party.name,
-            type=tenurerel.tenure_type.label,
+            type=tenurerel.tenure_type_label,
             su=tenurerel.spatial_unit.get_type_display())
 
     def test_ui_class_name(self):
@@ -275,6 +275,10 @@ class TenureRelationshipTest(UserTestCase, TestCase):
                 org=tenurerel.project.organization.slug,
                 prj=tenurerel.project.slug,
                 id=tenurerel.id))
+
+    def test_tenure_type_label(self):
+        tenurerel = TenureRelationshipFactory.create()
+        assert tenurerel.tenure_type_label == tenurerel.tenure_type.label
 
     def test_detach_tenure_relationship_resources(self):
         project = ProjectFactory.create()

--- a/cadasta/spatial/forms.py
+++ b/cadasta/spatial/forms.py
@@ -1,11 +1,13 @@
-from core.form_mixins import AttributeForm, AttributeModelForm
-from core.util import ID_FIELD_LENGTH
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis import forms as gisforms
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import ugettext_lazy as __
+
 from leaflet.forms.widgets import LeafletWidget
+
+from core.form_mixins import AttributeForm, AttributeModelForm
+from core.util import ID_FIELD_LENGTH
 from party.models import Party, TenureRelationship, TenureRelationshipType
 
 from .models import TYPE_CHOICES, SpatialUnit
@@ -18,13 +20,13 @@ class LocationForm(AttributeModelForm):
     geometry = gisforms.GeometryField(
         widget=LeafletWidget(),
         error_messages={
-            'required': _('No map location was provided. Please use the tools '
-                          'provided on the left side of the map to mark your '
-                          'new location.')}
+            'required': __('No map location was provided. Please use the '
+                           'tools provided on the left side of the map to '
+                           'mark your new location.')}
     )
     type = forms.ChoiceField(
         choices=filter(lambda c: c[0] != 'PX', (
-            [('', _('Please select a location type'))] +
+            [('', __('Please select a location type'))] +
             list(TYPE_CHOICES)
         ))
     )
@@ -43,13 +45,6 @@ class LocationForm(AttributeModelForm):
         kwargs['entity_type'] = entity_type
         kwargs['project_id'] = self.project.pk
         return super().save(*args, **kwargs)
-
-
-REL_TYPE_CHOICES = (
-    ('', ugettext_lazy('Please select')),
-    ('L', ugettext_lazy('Location')),
-    ('P', ugettext_lazy('Party'))
-)
 
 
 class TenureRelationshipForm(AttributeForm):
@@ -71,7 +66,9 @@ class TenureRelationshipForm(AttributeForm):
             list(Party.TYPE_CHOICES))
         self.fields['tenure_type'].choices = (
             [('', _("Please select a relationship type"))] +
-            sorted(TenureRelationshipType.objects.values_list('id', 'label')))
+            sorted([
+                (choice[0], _(choice[1])) for choice in
+                TenureRelationshipType.objects.values_list('id', 'label')]))
         self.project = project
         self.spatial_unit = spatial_unit
         self.party_ct = ContentType.objects.get(

--- a/cadasta/templates/party/relationship_detail.html
+++ b/cadasta/templates/party/relationship_detail.html
@@ -21,7 +21,7 @@
     <table class="table table-location">
       <tr>
         <td><label>{% trans "Type" %}</label></td>
-        <td>{{ relationship.tenure_type.label }}</td>
+        <td>{{ relationship.tenure_type_label }}</td>
       </tr>
       <tr>
         <td><label>{% trans "Party" %}</label></td>

--- a/cadasta/templates/spatial/location_detail.html
+++ b/cadasta/templates/spatial/location_detail.html
@@ -63,7 +63,7 @@
               {% for rel in relationships %}
               {% url 'parties:relationship_detail' object.organization.slug object.slug rel.id as relationship_url %}
               <tr class="linked" onclick="window.document.location='{{ relationship_url }}';">
-                <td><a href="{{ relationship_url }}">{{ rel.tenure_type.label }}</a></td>
+                <td><a href="{{ relationship_url }}">{{ rel.tenure_type_label }}</a></td>
                 <td><a href="{% url 'parties:detail' object.organization.slug object.slug rel.party.id %}">{{ rel.party.name }}</a></td>
               </tr>
               {% endfor %}


### PR DESCRIPTION
### Proposed changes in this pull request
- Several strings are marked for translation in the platform but aren't actually showing up as translated in the UI despite having translations. It turns out that some instances of `ugettext` should have been `ugettext_lazy` instead. This PR fixes this problem and introduces a double underscore as an alias for `ugettext_lazy`.
- `ChoiceField` labels for the types of parties, locations, and tenure relationships are marked for translation. However the labels for the default tenure relationship types are not showing up as translated in the UI despite the use of `ugettext_lazy`. This is because the translation happens when the platform is initialized and only English labels are stored in the database. The PR fixes this problem by ensuring that these labels pass through `ugettext` whenever they are retrieved from the database and by introducing the `tenure_type_label` pseudo-property on the tenure relationship model.
- Remove `REL_TYPE_CHOICES` because this is unused.

### When should this PR be merged
Anytime.

### Risks
None foreseen.

### Follow up actions
None.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts. 

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
