### PR TITLE
Fix #1104 -- Add PUT actions to API views

### DIFF
--- a/cadasta/organization/tests/test_views_api_organizations.py
+++ b/cadasta/organization/tests/test_views_api_organizations.py
@@ -253,9 +253,32 @@ class OrganizationDetailAPITest(APITestCase, UserTestCase, TestCase):
         self.org.refresh_from_db()
         assert self.org.name == data.get('name')
 
-    def test_update_with_unauthorized_user(self):
+    def test_PATCH_with_anonymous_user(self):
         data = {'name': 'Org Name'}
         response = self.request(method='PATCH', post_data=data)
+        assert response.status_code == 403
+        self.org.refresh_from_db()
+        assert self.org.name == 'Org'
+
+    def test_PATCH_with_unauthorized_user(self):
+        user = UserFactory.create()
+        data = {'name': 'Org Name'}
+        response = self.request(method='PATCH', post_data=data, user=user)
+        assert response.status_code == 403
+        self.org.refresh_from_db()
+        assert self.org.name == 'Org'
+
+    def test_PUT_with_anonymous_user(self):
+        data = {'name': 'Org Name'}
+        response = self.request(method='PUT', post_data=data)
+        assert response.status_code == 403
+        self.org.refresh_from_db()
+        assert self.org.name == 'Org'
+
+    def test_PUT_with_unauthorized_user(self):
+        user = UserFactory.create()
+        data = {'name': 'Org Name'}
+        response = self.request(method='PUT', post_data=data, user=user)
         assert response.status_code == 403
         self.org.refresh_from_db()
         assert self.org.name == 'Org'
@@ -456,6 +479,42 @@ class OrganizationUsersDetailAPITest(APITestCase, UserTestCase, TestCase):
         role = OrganizationRole.objects.get(organization=self.org,
                                             user=self.org_user)
         assert role.admin is True
+
+    def test_PATCH_user_with_unauthorized_user(self):
+        user = UserFactory.create()
+        response = self.request(user=user,
+                                method='PATCH',
+                                post_data={'admin': 'true'})
+        assert response.status_code == 403
+        role = OrganizationRole.objects.get(organization=self.org,
+                                            user=self.org_user)
+        assert role.admin is False
+
+    def test_PATCH_user_with_anonymous_user(self):
+        response = self.request(method='PATCH',
+                                post_data={'admin': 'true'})
+        assert response.status_code == 403
+        role = OrganizationRole.objects.get(organization=self.org,
+                                            user=self.org_user)
+        assert role.admin is False
+
+    def test_PUT_user_with_unauthorized_user(self):
+        user = UserFactory.create()
+        response = self.request(user=user,
+                                method='PUT',
+                                post_data={'admin': 'true'})
+        assert response.status_code == 403
+        role = OrganizationRole.objects.get(organization=self.org,
+                                            user=self.org_user)
+        assert role.admin is False
+
+    def test_PUT_user_with_anonymous_user(self):
+        response = self.request(method='PUT',
+                                post_data={'admin': 'true'})
+        assert response.status_code == 403
+        role = OrganizationRole.objects.get(organization=self.org,
+                                            user=self.org_user)
+        assert role.admin is False
 
     def test_update_admin_user(self):
         OrganizationRole.objects.create(organization=self.org,

--- a/cadasta/organization/tests/test_views_api_projects.py
+++ b/cadasta/organization/tests/test_views_api_projects.py
@@ -775,7 +775,7 @@ class ProjectDetailAPITest(APITestCase, UserTestCase, TestCase):
         assert self.project.name == 'Test Project'
 
     def test_PATCH_with_unauthorized_user(self):
-        response = self.request(method='PATCH')
+        response = self.request(method='PATCH', user=UserFactory.create())
         assert response.status_code == 403
         self.project.refresh_from_db()
         assert self.project.name == 'Test Project'
@@ -787,7 +787,7 @@ class ProjectDetailAPITest(APITestCase, UserTestCase, TestCase):
         assert self.project.name == 'Test Project'
 
     def test_PUT_with_unauthorized_user(self):
-        response = self.request(method='PUT')
+        response = self.request(method='PUT', user=UserFactory.create())
         assert response.status_code == 403
         self.project.refresh_from_db()
         assert self.project.name == 'Test Project'

--- a/cadasta/organization/tests/test_views_api_projects.py
+++ b/cadasta/organization/tests/test_views_api_projects.py
@@ -205,10 +205,42 @@ class ProjectUsersDetailAPITest(APITestCase, UserTestCase, TestCase):
                                        user=self.test_user)
         assert role.role == 'PM'
 
-    def test_update_user_with_unauthorized_user(self):
+    def test_PATCH_user_with_unauthorized_user(self):
+        user = UserFactory.create()
+        self.test_user = UserFactory.create()
+        self.project = ProjectFactory.create(add_users=[self.test_user])
+        response = self.request(method='PATCH', user=user)
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+        role = ProjectRole.objects.get(project=self.project,
+                                       user=self.test_user)
+        assert role.role == 'PU'
+
+    def test_PATCH_user_with_anonymous_user(self):
         self.test_user = UserFactory.create()
         self.project = ProjectFactory.create(add_users=[self.test_user])
         response = self.request(method='PATCH')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+        role = ProjectRole.objects.get(project=self.project,
+                                       user=self.test_user)
+        assert role.role == 'PU'
+
+    def test_PUT_user_with_unauthorized_user(self):
+        user = UserFactory.create()
+        self.test_user = UserFactory.create()
+        self.project = ProjectFactory.create(add_users=[self.test_user])
+        response = self.request(method='PUT', user=user)
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+        role = ProjectRole.objects.get(project=self.project,
+                                       user=self.test_user)
+        assert role.role == 'PU'
+
+    def test_PUT_user_with_anonymous_user(self):
+        self.test_user = UserFactory.create()
+        self.project = ProjectFactory.create(add_users=[self.test_user])
+        response = self.request(method='PUT')
         assert response.status_code == 403
         assert response.content['detail'] == PermissionDenied.default_detail
         role = ProjectRole.objects.get(project=self.project,
@@ -736,8 +768,26 @@ class ProjectDetailAPITest(APITestCase, UserTestCase, TestCase):
         self.project.refresh_from_db()
         assert self.project.name == 'OPDP'
 
-    def test_update_with_unauthorized_user(self):
+    def test_PATCH_with_anonymous_user(self):
         response = self.request(method='PATCH')
+        assert response.status_code == 403
+        self.project.refresh_from_db()
+        assert self.project.name == 'Test Project'
+
+    def test_PATCH_with_unauthorized_user(self):
+        response = self.request(method='PATCH')
+        assert response.status_code == 403
+        self.project.refresh_from_db()
+        assert self.project.name == 'Test Project'
+
+    def test_PUT_with_anonymous_user(self):
+        response = self.request(method='PUT')
+        assert response.status_code == 403
+        self.project.refresh_from_db()
+        assert self.project.name == 'Test Project'
+
+    def test_PUT_with_unauthorized_user(self):
+        response = self.request(method='PUT')
         assert response.status_code == 403
         self.project.refresh_from_db()
         assert self.project.name == 'Test Project'

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -62,6 +62,7 @@ class OrganizationDetail(APIPermissionRequiredMixin,
     permission_required = {
         'GET': view_actions,
         'PATCH': patch_actions,
+        'PUT': patch_actions
     }
 
 
@@ -83,7 +84,11 @@ class OrganizationUsersDetail(APIPermissionRequiredMixin,
                               generics.RetrieveUpdateDestroyAPIView):
 
     serializer_class = serializers.OrganizationUserSerializer
-    permission_required = update_permissions('org.users.remove')
+    permission_required = {
+        'PUT': update_permissions('org.users.edit'),
+        'PATCH': update_permissions('org.users.edit'),
+        'DELETE': update_permissions('org.users.remove')
+    }
 
     def destroy(self, request, *args, **kwargs):
         user = self.get_object()
@@ -115,7 +120,8 @@ class UserAdminDetail(APIPermissionRequiredMixin,
     lookup_field = 'username'
     permission_required = {
         'GET': 'user.list',
-        'PATCH': 'user.update'
+        'PATCH': 'user.update',
+        'PUT': 'user.update'
     }
 
 
@@ -221,6 +227,7 @@ class ProjectDetail(APIPermissionRequiredMixin,
     permission_required = {
         'GET': get_actions,
         'PATCH': patch_actions,
+        'PUT': patch_actions,
     }
 
     def get_perms_objects(self):
@@ -250,6 +257,7 @@ class ProjectUsersDetail(APIPermissionRequiredMixin,
     permission_required = {
         'GET': 'project.users.list',
         'PATCH': update_permissions('project.users.update'),
+        'PUT': update_permissions('project.users.update'),
         'DELETE': update_permissions('project.users.delete'),
     }
 

--- a/cadasta/party/tests/test_views_api_parties.py
+++ b/cadasta/party/tests/test_views_api_parties.py
@@ -214,6 +214,36 @@ class PartyDetailAPITest(APITestCase, UserTestCase, TestCase):
         self.party.refresh_from_db()
         assert self.party.name == response.content['name']
 
+    def test_PATCH_party_with_anonymous_user(self):
+        data = {'name': 'Test Party Patched'}
+        response = self.request(method='PATCH', post_data=data)
+        assert response.status_code == 403
+        self.party.refresh_from_db()
+        assert self.party.name != data['name']
+
+    def test_PATCH_party_with_unauthorized_user(self):
+        data = {'name': 'Test Party Patched'}
+        user = UserFactory.create()
+        response = self.request(method='PATCH', post_data=data, user=user)
+        assert response.status_code == 403
+        self.party.refresh_from_db()
+        assert self.party.name != data['name']
+
+    def test_PUT_party_with_anonymous_user(self):
+        data = {'name': 'Test Party Patched'}
+        response = self.request(method='PUT', post_data=data)
+        assert response.status_code == 403
+        self.party.refresh_from_db()
+        assert self.party.name != data['name']
+
+    def test_PUT_party_with_unauthorized_user(self):
+        data = {'name': 'Test Party Patched'}
+        user = UserFactory.create()
+        response = self.request(method='PUT', post_data=data, user=user)
+        assert response.status_code == 403
+        self.party.refresh_from_db()
+        assert self.party.name != data['name']
+
     def test_update_party_in_archived_project(self):
         self.prj.archived = True
         self.prj.save()
@@ -473,8 +503,26 @@ class PartyResourceUpdateAPITest(APITestCase, UserTestCase, TestCase):
         self.resource.refresh_from_db()
         assert self.resource.name == self.post_data['name']
 
-    def test_update_resource_with_unauthorized_user(self):
+    def test_PATCH_resource_with_unauthorized_user(self):
         response = self.request(method='PATCH', user=UserFactory.create())
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PATCH_resource_with_anonymous_user(self):
+        response = self.request(method='PATCH')
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PUT_resource_with_unauthorized_user(self):
+        response = self.request(method='PUT', user=UserFactory.create())
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PUT_resource_with_anonymous_user(self):
+        response = self.request(method='PUT')
         assert response.status_code == 403
         self.resource.refresh_from_db()
         assert self.resource.name != self.post_data['name']

--- a/cadasta/party/tests/test_views_api_party_relationships.py
+++ b/cadasta/party/tests/test_views_api_party_relationships.py
@@ -349,8 +349,35 @@ class PartyRelationshipUpdateAPITest(APITestCase, UserTestCase, TestCase):
         assert response.status_code == 404
         assert response.content['detail'] == "PartyRelationship not found."
 
-    def test_update_with_unauthorized_user(self):
+    def test_PATCH_with_anonymous_user(self):
         response = self.request(method='PATCH')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.party1 == self.party1
+        assert self.rel.party2 == self.party2
+
+    def test_PATCH_with_unauthorized_user(self):
+        response = self.request(method='PATCH', user=UserFactory.create())
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.party1 == self.party1
+        assert self.rel.party2 == self.party2
+
+    def test_PUT_with_anonymous_user(self):
+        response = self.request(method='PUT')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.party1 == self.party1
+        assert self.rel.party2 == self.party2
+
+    def test_PUT_with_unauthorized_user(self):
+        response = self.request(method='PUT', user=UserFactory.create())
         assert response.status_code == 403
         assert response.content['detail'] == PermissionDenied.default_detail
 

--- a/cadasta/party/tests/test_views_api_tenure_relationships.py
+++ b/cadasta/party/tests/test_views_api_tenure_relationships.py
@@ -333,8 +333,35 @@ class TenureRelationshipUpdateAPITest(APITestCase, UserTestCase, TestCase):
         assert response.status_code == 404
         assert response.content['detail'] == "TenureRelationship not found."
 
-    def test_update_with_unauthorized_user(self):
+    def test_PATCH_with_anonymous_user(self):
         response = self.request(method='PATCH')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.party == self.party
+        assert self.rel.spatial_unit == self.spatial_unit
+
+    def test_PATCH_with_unauthorized_user(self):
+        response = self.request(method='PATCH', user=UserFactory.create())
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.party == self.party
+        assert self.rel.spatial_unit == self.spatial_unit
+
+    def test_PUT_with_anonymous_user(self):
+        response = self.request(method='PUT')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.party == self.party
+        assert self.rel.spatial_unit == self.spatial_unit
+
+    def test_PUT_with_unauthorized_user(self):
+        response = self.request(method='PUT', user=UserFactory.create())
         assert response.status_code == 403
         assert response.content['detail'] == PermissionDenied.default_detail
 
@@ -831,8 +858,26 @@ class TenureRelationshipResourceUpdateAPITest(APITestCase, UserTestCase,
         self.resource.refresh_from_db()
         assert self.resource.name == self.post_data['name']
 
-    def test_update_resource_with_unauthorized_user(self):
+    def test_PATCH_resource_with_anonymous_user(self):
+        response = self.request(method='PATCH')
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PATCH_resource_with_unauthorized_user(self):
         response = self.request(method='PATCH', user=UserFactory.create())
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PUT_resource_with_anonymous_user(self):
+        response = self.request(method='PUT')
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PUT_resource_with_unauthorized_user(self):
+        response = self.request(method='PUT', user=UserFactory.create())
         assert response.status_code == 403
         self.resource.refresh_from_db()
         assert self.resource.name != self.post_data['name']

--- a/cadasta/party/views/api.py
+++ b/cadasta/party/views/api.py
@@ -47,6 +47,7 @@ class PartyDetail(APIPermissionRequiredMixin,
     lookup_field = 'id'
     permission_required = {
         'GET': 'party.view',
+        'PUT': update_permissions('party.update'),
         'PATCH': update_permissions('party.update'),
         'DELETE': update_permissions('party.delete'),
     }
@@ -87,6 +88,7 @@ class PartyResourceDetail(APIPermissionRequiredMixin,
     serializer_class = ResourceSerializer
     permission_required = {
         'GET': 'party.resources.view',
+        'PUT': patch_actions,
         'PATCH': patch_actions,
         'DELETE': patch_actions,
     }
@@ -176,6 +178,7 @@ class PartyRelationshipDetail(APIPermissionRequiredMixin,
     lookup_field = 'id'
     permission_required = {
         'GET': 'party_rel.view',
+        'PUT': update_permissions('party_rel.update'),
         'PATCH': update_permissions('party_rel.update'),
         'DELETE': update_permissions('party_rel.delete')
     }
@@ -210,6 +213,7 @@ class TenureRelationshipDetail(APIPermissionRequiredMixin,
     lookup_field = 'id'
     permission_required = {
         'GET': 'tenure_rel.view',
+        'PUT': update_permissions('tenure_rel.update'),
         'PATCH': update_permissions('tenure_rel.update'),
         'DELETE': update_permissions('tenure_rel.delete')
     }
@@ -261,6 +265,7 @@ class TenureRelationshipResourceDetail(APIPermissionRequiredMixin,
     serializer_class = ResourceSerializer
     permission_required = {
         'GET': 'tenure_rel.resources.view',
+        'PUT': patch_actions,
         'PATCH': patch_actions,
         'DELETE': patch_actions,
     }

--- a/cadasta/resources/tests/test_views_api.py
+++ b/cadasta/resources/tests/test_views_api.py
@@ -321,8 +321,26 @@ class ProjectResourcesDetailTest(APITestCase, UserTestCase, TestCase):
         self.resource.refresh_from_db()
         assert self.resource.name == self.post_data['name']
 
-    def test_update_resource_with_unauthorized_user(self):
+    def test_PATCH_resource_with_unauthorized_user(self):
         response = self.request(method='PATCH', user=UserFactory.create())
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PATCH_resource_with_anonymous_user(self):
+        response = self.request(method='PATCH')
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PUT_resource_with_unauthorized_user(self):
+        response = self.request(method='PUT', user=UserFactory.create())
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PUT_resource_with_anonymous_user(self):
+        response = self.request(method='PUT')
         assert response.status_code == 403
         self.resource.refresh_from_db()
         assert self.resource.name != self.post_data['name']
@@ -571,8 +589,26 @@ class ProjectSpatialResourcesDetailTest(APITestCase, UserTestCase,
         self.resource.refresh_from_db()
         assert self.resource.name == self.post_data['name']
 
-    def test_update_resource_with_unauthorized_user(self):
+    def test_PATCH_resource_with_unauthorized_user(self):
         response = self.request(method='PATCH', user=UserFactory.create())
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PATCH_resource_with_anonymous_user(self):
+        response = self.request(method='PATCH')
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PUT_resource_with_unauthorized_user(self):
+        response = self.request(method='PUT', user=UserFactory.create())
+        assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PUT_resource_with_anonymous_user(self):
+        response = self.request(method='PUT')
         assert response.status_code == 403
         self.resource.refresh_from_db()
         assert self.resource.name != self.post_data['name']

--- a/cadasta/resources/views/api.py
+++ b/cadasta/resources/views/api.py
@@ -49,6 +49,7 @@ class ProjectResourcesDetail(APIPermissionRequiredMixin,
     lookup_url_kwarg = 'resource'
     permission_required = {
         'GET': 'resource.view',
+        'PUT': patch_actions,
         'PATCH': patch_actions
     }
     use_resource_library_queryset = True
@@ -77,5 +78,6 @@ class ProjectSpatialResourcesDetail(APIPermissionRequiredMixin,
     lookup_url_kwarg = 'resource'
     permission_required = {
         'GET': 'resource.view',
+        'PUT': patch_actions,
         'PATCH': patch_actions,
     }

--- a/cadasta/spatial/tests/test_views_api_spatial_relationships.py
+++ b/cadasta/spatial/tests/test_views_api_spatial_relationships.py
@@ -337,8 +337,37 @@ class SpatialRelationshipUpdateAPITest(APITestCase, UserTestCase, TestCase):
         assert response.status_code == 404
         assert response.content['detail'] == "SpatialRelationship not found."
 
-    def test_update_with_unauthorized_user(self):
+    def test_PATCH_with_anonyous_user(self):
         response = self.request(method='PATCH')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.su1 == self.su1
+        assert self.rel.su2 == self.su2
+
+    def test_PATCH_with_unauthorized_user(self):
+        user = UserFactory.create()
+        response = self.request(method='PATCH', user=user)
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.su1 == self.su1
+        assert self.rel.su2 == self.su2
+
+    def test_PUT_with_anonyous_user(self):
+        response = self.request(method='PUT')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.rel.refresh_from_db()
+        assert self.rel.su1 == self.su1
+        assert self.rel.su2 == self.su2
+
+    def test_PUT_with_unauthorized_user(self):
+        user = UserFactory.create()
+        response = self.request(method='PUT', user=user)
         assert response.status_code == 403
         assert response.content['detail'] == PermissionDenied.default_detail
 

--- a/cadasta/spatial/tests/test_views_api_spatial_units.py
+++ b/cadasta/spatial/tests/test_views_api_spatial_units.py
@@ -497,8 +497,34 @@ class SpatialUnitUpdateAPITest(APITestCase, UserTestCase, TestCase):
         assert response.status_code == 404
         assert response.content['detail'] == "SpatialUnit not found."
 
-    def test_update_with_unauthorized_user(self):
+    def test_PATCH_with_anonymous_user(self):
         response = self.request(method='PATCH')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.su.refresh_from_db()
+        assert self.su.type == 'PA'
+
+    def test_PATCH_with_unauthorized_user(self):
+        user = UserFactory.create()
+        response = self.request(method='PATCH', user=user)
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.su.refresh_from_db()
+        assert self.su.type == 'PA'
+
+    def test_PUT_with_anonymous_user(self):
+        response = self.request(method='PUT')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.su.refresh_from_db()
+        assert self.su.type == 'PA'
+
+    def test_PUT_with_unauthorized_user(self):
+        user = UserFactory.create()
+        response = self.request(method='PUT', user=user)
         assert response.status_code == 403
         assert response.content['detail'] == PermissionDenied.default_detail
 
@@ -997,6 +1023,40 @@ class SpatialUnitResourceUpdateAPITest(APITestCase, UserTestCase, TestCase):
         self.prj.save()
         response = self.request(method='PATCH', user=UserFactory.create())
         assert response.status_code == 403
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PATCH_with_anonymous_user(self):
+        response = self.request(method='PATCH')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PATCH_with_unauthorized_user(self):
+        user = UserFactory.create()
+        response = self.request(method='PATCH', user=user)
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PUT_with_anonymous_user(self):
+        response = self.request(method='PUT')
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+        self.resource.refresh_from_db()
+        assert self.resource.name != self.post_data['name']
+
+    def test_PUT_with_unauthorized_user(self):
+        user = UserFactory.create()
+        response = self.request(method='PUT', user=user)
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
         self.resource.refresh_from_db()
         assert self.resource.name != self.post_data['name']
 

--- a/cadasta/spatial/views/api.py
+++ b/cadasta/spatial/views/api.py
@@ -43,6 +43,7 @@ class SpatialUnitDetail(APIPermissionRequiredMixin,
     lookup_field = 'id'
     permission_required = {
         'GET': 'spatial.view',
+        'PUT': update_permissions('spatial.update'),
         'PATCH': update_permissions('spatial.update'),
         'DELETE': update_permissions('spatial.delete')
     }
@@ -87,6 +88,7 @@ class SpatialUnitResourceDetail(APIPermissionRequiredMixin,
     serializer_class = ResourceSerializer
     permission_required = {
         'GET': 'spatial.resources.view',
+        'PUT': patch_actions,
         'PATCH': patch_actions,
         'DELETE': patch_actions,
     }
@@ -123,6 +125,7 @@ class SpatialRelationshipDetail(APIPermissionRequiredMixin,
     permission_required = {
         'GET': 'spatial_rel.view',
         'PATCH': update_permissions('spatial_rel.update'),
+        'PUT': update_permissions('spatial_rel.update'),
         'DELETE': update_permissions('spatial_rel.delete')
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes #1104. @linzjax used `HTTP PUT` to update the project and organization, permissions were not checked for `PUT` requests on any of the API view. This PR adds `PUT` actions to all API views I could think of along with tests for unauthorised and unauthenticated users for both `PATCH` and `PUT` updates. 

### When should this PR be merged

Soon

### Risks

No

### Follow up actions

None

### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [x] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [x] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [x] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [x] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [x] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [x] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [x] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [x] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [x] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [x] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [x] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [x] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
