### PR TITLE
Fix #1115: Add missing mixin to search default view

### DIFF
--- a/cadasta/search/tests/test_views_default.py
+++ b/cadasta/search/tests/test_views_default.py
@@ -7,6 +7,7 @@ from tutelary.models import Policy, assign_user_policies
 from skivvy import ViewTestCase
 
 from accounts.tests.factories import UserFactory
+from organization.models import ProjectRole
 from organization.tests.factories import ProjectFactory
 from core.tests.utils.cases import UserTestCase
 
@@ -53,6 +54,23 @@ class SearchTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(user=user)
         assert response.status_code == 200
         assert response.content == self.expected_content
+
+    def test_get_with_pm_user(self):
+        user = UserFactory.create()
+        assign_policies(user)
+        ProjectRole.objects.create(
+            project=self.project,
+            user=user,
+            role='PM',
+        )
+        response = self.request(user=user)
+        assert response.status_code == 200
+        expected_content = self.render_content(is_administrator=True,
+                                               is_allowed_add_location=True,
+                                               is_allowed_add_resource=True,
+                                               is_project_member=True,
+                                               is_allowed_import=True)
+        assert response.content == expected_content
 
     def test_get_from_non_existent_project(self):
         user = UserFactory.create()

--- a/cadasta/search/views/default.py
+++ b/cadasta/search/views/default.py
@@ -1,10 +1,13 @@
 from core.views.generic import TemplateView
 from core.mixins import LoginPermissionRequiredMixin
 from organization import messages as org_messages
-from organization.views.mixins import ProjectMixin
+from organization.views import mixins as org_mixins
 
 
-class Search(LoginPermissionRequiredMixin, ProjectMixin, TemplateView):
+class Search(LoginPermissionRequiredMixin,
+             org_mixins.ProjectMixin,
+             org_mixins.ProjectAdminCheckMixin,
+             TemplateView):
     template_name = 'search/search.html'
     permission_required = 'project.view_private'
     permission_denied_message = org_messages.PROJ_VIEW


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #1115:
    - Add the missing `ProjectAdminCheckMixin` to the search default view.
    - Add a unit test to catch this bug.

### When should this PR be merged
Before Sprint 13 release.

### Risks
None foreseen.

### Follow up actions
None.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
