### PR TITLE
Show password option-issue-1087

### DIFF
--- a/cadasta/templates/allauth/account/signup.html
+++ b/cadasta/templates/allauth/account/signup.html
@@ -19,7 +19,7 @@
 </script>
 <script type="text/javascript">
   $(document).ready(function () {
-    $("#showHide1").click(function () {
+    $("#showHide").click(function () {
        if ($("#id_password1").attr("type")=="password") {
          $("#id_password1").attr("type", "text");
         }
@@ -27,7 +27,7 @@
         $("#id_password1").attr("type", "password");
        }
    });
-   $("#showHide2").click(function () {
+   $("#showHide").click(function () {
        if ($("#id_password2").attr("type")=="password") {
          $("#id_password2").attr("type", "text");
         }
@@ -79,7 +79,7 @@
     <label class="control-label" for="id_password1">{% trans "Password" %}</label>
     {% render_field form.password1 class+="form-control input-lg" data-parsley-minlength="10" data-parsley-character="3" data-parsley-userfield="1" data-parsley-emailfield="1" %}
     <br>
-    <input type="checkbox" id="showHide1"><label>Show Password</label>
+    <input type="checkbox" id="showHide"><label for="showHide">&nbsp;Show Password</label>
     <p class="help-block small hidden">{% trans "Passwords must have a minimum of 10 characters and contain at least 3 of the following: lowercase characters, uppercase characters, special characters, and/or numerical characters.  Passwords cannot contain the username or email address." %}</p>
     <div class="error-block">{{ form.password1.errors }}</div>
   </div>
@@ -87,8 +87,6 @@
   <div class="form-group{% if form.password2.errors %} has-error{% endif %}">
     <label class="control-label" for="id_password2">{% trans "Confirm password" %}</label>
     {% render_field form.password2 class+="form-control input-lg" data-parsley-equalto="#id_password1" %}
-    <br>
-    <input type="checkbox" id="showHide2"><label>Show Password</label>
     <div class="error-block">{{ form.password2.errors }}</div>
   </div>
 

--- a/cadasta/templates/allauth/account/signup.html
+++ b/cadasta/templates/allauth/account/signup.html
@@ -19,22 +19,16 @@
 </script>
 <script type="text/javascript">
   $(document).ready(function () {
-    $("#showHide").click(function () {
-       if ($("#id_password1").attr("type")=="password") {
-         $("#id_password1").attr("type", "text");
-        }
-      else{
-        $("#id_password1").attr("type", "password");
-       }
-   });
-   $("#showHide").click(function () {
-       if ($("#id_password2").attr("type")=="password") {
-         $("#id_password2").attr("type", "text");
-        }
-      else{
-        $("#id_password2").attr("type", "password");
-       }
-   });
+     $('input[type="checkbox"]').click(function() {
+         if($(this). prop("checked") == true) {
+           $("#id_password1").attr("type", "text");
+           $("#id_password2").attr("type", "text");
+         }
+         else if($(this). prop("checked") == false) {
+          $("#id_password1").attr("type", "password");
+          $("#id_password2").attr("type", "password");
+         }
+    });
  });
 </script>
 <script src="{% static 'js/parsleyAddValidator.js' %}"></script>

--- a/cadasta/templates/allauth/account/signup.html
+++ b/cadasta/templates/allauth/account/signup.html
@@ -20,11 +20,11 @@
 <script type="text/javascript">
   $(document).ready(function () {
      $('input[type="checkbox"]').click(function() {
-         if($(this). prop("checked") == true) {
+         if($(this).prop("checked")) {
            $("#id_password1").attr("type", "text");
            $("#id_password2").attr("type", "text");
          }
-         else if($(this). prop("checked") == false) {
+         else {
           $("#id_password1").attr("type", "password");
           $("#id_password2").attr("type", "password");
          }

--- a/cadasta/templates/allauth/account/signup.html
+++ b/cadasta/templates/allauth/account/signup.html
@@ -17,6 +17,18 @@
     });
   });
 </script>
+<script type="text/javascript">
+  $(document).ready(function () {
+    $("#showHide").click(function () {
+       if ($("#id_password1").attr("type")=="password") {
+         $("#id_password1").attr("type", "text");
+        }
+      else{
+        $("#id_password1").attr("type", "password");
+       }
+   });
+ });
+</script>
 <script src="{% static 'js/parsleyAddValidator.js' %}"></script>
 {% endblock %}
 
@@ -58,6 +70,8 @@
   <div class="form-group{% if form.password1.errors %} has-error{% endif %}">
     <label class="control-label" for="id_password1">{% trans "Password" %}</label>
     {% render_field form.password1 class+="form-control input-lg" data-parsley-minlength="10" data-parsley-character="3" data-parsley-userfield="1" data-parsley-emailfield="1" %}
+    <br>
+    <input type="checkbox" id="showHide"><label>Show Password</label>
     <p class="help-block small hidden">{% trans "Passwords must have a minimum of 10 characters and contain at least 3 of the following: lowercase characters, uppercase characters, special characters, and/or numerical characters.  Passwords cannot contain the username or email address." %}</p>
     <div class="error-block">{{ form.password1.errors }}</div>
   </div>

--- a/cadasta/templates/allauth/account/signup.html
+++ b/cadasta/templates/allauth/account/signup.html
@@ -19,12 +19,20 @@
 </script>
 <script type="text/javascript">
   $(document).ready(function () {
-    $("#showHide").click(function () {
+    $("#showHide1").click(function () {
        if ($("#id_password1").attr("type")=="password") {
          $("#id_password1").attr("type", "text");
         }
       else{
         $("#id_password1").attr("type", "password");
+       }
+   });
+   $("#showHide2").click(function () {
+       if ($("#id_password2").attr("type")=="password") {
+         $("#id_password2").attr("type", "text");
+        }
+      else{
+        $("#id_password2").attr("type", "password");
        }
    });
  });
@@ -71,7 +79,7 @@
     <label class="control-label" for="id_password1">{% trans "Password" %}</label>
     {% render_field form.password1 class+="form-control input-lg" data-parsley-minlength="10" data-parsley-character="3" data-parsley-userfield="1" data-parsley-emailfield="1" %}
     <br>
-    <input type="checkbox" id="showHide"><label>Show Password</label>
+    <input type="checkbox" id="showHide1"><label>Show Password</label>
     <p class="help-block small hidden">{% trans "Passwords must have a minimum of 10 characters and contain at least 3 of the following: lowercase characters, uppercase characters, special characters, and/or numerical characters.  Passwords cannot contain the username or email address." %}</p>
     <div class="error-block">{{ form.password1.errors }}</div>
   </div>
@@ -79,6 +87,8 @@
   <div class="form-group{% if form.password2.errors %} has-error{% endif %}">
     <label class="control-label" for="id_password2">{% trans "Confirm password" %}</label>
     {% render_field form.password2 class+="form-control input-lg" data-parsley-equalto="#id_password1" %}
+    <br>
+    <input type="checkbox" id="showHide2"><label>Show Password</label>
     <div class="error-block">{{ form.password2.errors }}</div>
   </div>
 


### PR DESCRIPTION
### Proposed changes in this pull request

1.As mentioned in issue-1087-we should implement an option to toggle the view of the password input when registering.I entered a checkbox to toggle the view of the password.

2.File that is changed here is -cadasta/templates/allauth/account/signup.html

### When should this PR be merged





### Risks


-

### Follow up actions

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
