### PR TITLE
Make usernames case insensitive on registration and update profile

### DIFF
--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext as _
 from django.contrib.auth.password_validation import validate_password
 from allauth.account.utils import send_email_confirmation
 from allauth.account import forms as allauth_forms
+from django.db.models.functions import Lower
 
 from .models import User, now_plus_48_hours
 from parsley.decorators import parsleyfy
@@ -23,7 +24,12 @@ class RegisterForm(forms.ModelForm):
 
     def clean_username(self):
         username = self.data.get('username')
-        if username.lower() in settings.CADASTA_INVALID_ENTITY_NAMES:
+        if (self.instance.username.casefold() != username.casefold() and
+                User.objects.annotate(username_lower=Lower('username'))
+                .filter(username_lower=username.casefold()).exists()):
+            raise forms.ValidationError(
+                _("A user with that username already exists."))
+        if username.casefold() in settings.CADASTA_INVALID_ENTITY_NAMES:
             raise forms.ValidationError(
                 _("Username cannot be “add” or “new”."))
         return username
@@ -75,11 +81,12 @@ class ProfileForm(forms.ModelForm):
 
     def clean_username(self):
         username = self.data.get('username')
-        if (self.instance.username != username and
-                User.objects.filter(username=username).exists()):
+        if (self.instance.username.casefold() != username.casefold() and
+                User.objects.annotate(username_lower=Lower('username'))
+                .filter(username_lower=username.casefold()).exists()):
             raise forms.ValidationError(
                 _("Another user with this username already exists"))
-        if username.lower() in settings.CADASTA_INVALID_ENTITY_NAMES:
+        if username.casefold() in settings.CADASTA_INVALID_ENTITY_NAMES:
             raise forms.ValidationError(
                 _("Username cannot be “add” or “new”."))
         return username

--- a/cadasta/accounts/manager.py
+++ b/cadasta/accounts/manager.py
@@ -1,11 +1,13 @@
 from django.db.models import Q
+from django.db.models.functions import Lower
 from django.contrib.auth.models import UserManager as DjangoUserManager
 from django.utils.translation import ugettext as _
 
 
 class UserManager(DjangoUserManager):
     def get_from_username_or_email(self, identifier=None):
-        users = self.filter(Q(username=identifier) | Q(email=identifier))
+        q = self.annotate(username_lower=Lower('username'))
+        users = q.filter(Q(username_lower=identifier) | Q(email=identifier))
         users_count = len(users)
 
         if users_count == 1:

--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -35,7 +35,7 @@ class RegistrationSerializer(djoser_serializers.UserRegistrationSerializer):
         }
 
     def validate_username(self, username):
-        if username.lower() in settings.CADASTA_INVALID_ENTITY_NAMES:
+        if username.casefold() in settings.CADASTA_INVALID_ENTITY_NAMES:
             raise ValidationError(
                 _("Username cannot be “add” or “new”."))
         return username
@@ -86,10 +86,10 @@ class UserSerializer(djoser_serializers.UserSerializer):
         instance = self.instance
         if instance is not None:
             if (username is not None and
-               username != instance.username and
+               username.casefold() != instance.username.casefold() and
                self.context['request'].user != instance):
                 raise ValidationError('Cannot update username')
-        if username.lower() in settings.CADASTA_INVALID_ENTITY_NAMES:
+        if username.casefold() in settings.CADASTA_INVALID_ENTITY_NAMES:
             raise ValidationError(
                 _("Username cannot be “add” or “new”."))
         return username

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -158,6 +158,22 @@ class RegisterFormTest(UserTestCase, TestCase):
                 in form.errors.get('username'))
         assert User.objects.count() == 0
 
+    def test_signup_with_existing_username(self):
+        UserFactory.create(username='dee')
+        data = {
+            'username': 'DEE',
+            'email': 'dee@firstpr.com',
+            'password1': 'Iloveyoko68!',
+            'password2': 'Iloveyoko68!',
+            'full_name': 'Delight Mawoyo',
+        }
+
+        form = forms.RegisterForm(data)
+        assert form.is_valid() is False
+        assert User.objects.count() == 1
+        assert (_("A user with that username already exists.")
+                in form.errors.get('username'))
+
 
 class ProfileFormTest(UserTestCase, TestCase):
     def test_update_user(self):
@@ -165,7 +181,7 @@ class ProfileFormTest(UserTestCase, TestCase):
                                   email='john@beatles.uk',
                                   email_verified=True)
         data = {
-            'username': 'imagine71',
+            'username': 'IMAGINE71',
             'email': 'john2@beatles.uk',
             'full_name': 'John Lennon',
         }
@@ -181,6 +197,7 @@ class ProfileFormTest(UserTestCase, TestCase):
         form.save()
 
         user.refresh_from_db()
+        assert user.username == 'IMAGINE71'
         assert user.full_name == 'John Lennon'
         assert user.email_verified is False
         assert len(mail.outbox) == 1
@@ -207,6 +224,18 @@ class ProfileFormTest(UserTestCase, TestCase):
                                   email='john@beatles.uk')
         data = {
             'username': 'existing',
+            'email': 'john@beatles.uk',
+            'full_name': 'John Lennon',
+        }
+        form = forms.ProfileForm(data, instance=user)
+        assert form.is_valid() is False
+
+    def test_update_user_with_existing_username_case_insensitive(self):
+        UserFactory.create(username='existing')
+        user = UserFactory.create(username='imagine71',
+                                  email='john@beatles.uk')
+        data = {
+            'username': 'Existing',
             'email': 'john@beatles.uk',
             'full_name': 'John Lennon',
         }

--- a/cadasta/accounts/tests/test_views_default.py
+++ b/cadasta/accounts/tests/test_views_default.py
@@ -102,6 +102,12 @@ class LoginTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 302
         assert 'dashboard' in response.location
 
+    def test_successful_login_username_case_insensitive(self):
+        data = {'login': 'IMAGINE71', 'password': 'iloveyoko79'}
+        response = self.request(method='POST', post_data=data)
+        assert response.status_code == 302
+        assert 'dashboard' in response.location
+
     def test_successful_login_with_unverified_user(self):
         self.user.verify_email_by = datetime.datetime.now()
         self.user.save()


### PR DESCRIPTION
### Proposed changes in this pull request
Makes usernames case insensitive. This prevents having two users with the same username in different cases
Fixes #946 
### When should this PR be merged
As soon as possible, this is a critical bug
### Risks
Usernames are now all stored in lowercase, this could have some effect
