### PR TITLE
Fix bug #1106

### DIFF
--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -706,7 +706,7 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
                                             user=self.member)
         assert role.admin is True
 
-    def test_post_org_role_downgraded(self):
+    def test_post_org_role_redirect(self):
         assign_policies(self.user)
         response = self.request(
             method='POST', user=self.user, post_data={'org_role': 'M'})
@@ -715,10 +715,10 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
         assert ('/organizations/{}/members/{}/'.format(
                   self.org.slug, self.member) in response.location)
 
-    def test_post_org_role_upgraded(self):
+    def test_post_prj_role_redirect(self):
         assign_policies(self.user)
         response = self.request(
-            method='POST', user=self.user, post_data={'org_role': 'A'})
+            method='POST', user=self.user, post_data={self.prj.id: 'DC'})
 
         assert response.status_code == 302
         assert ('/organizations/{}/members/'.format(self.org.slug)

--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -378,7 +378,6 @@ class OrganizationEditTest(ViewTestCase, UserTestCase, TestCase):
         assert self.org.name != 'Org'
         assert self.org.description != 'Some description'
 
-
 class OrganizationArchiveTest(ViewTestCase, UserTestCase, TestCase):
     view_class = default.OrganizationArchive
 
@@ -705,6 +704,24 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
         role = OrganizationRole.objects.get(organization=self.org,
                                             user=self.member)
         assert role.admin is True
+
+    def test_post_org_role_downgraded(self):
+        assign_policies(self.user)
+        response = self.request(
+            method = 'POST', user=self.user, post_data={'org_role': 'M'})
+
+        assert response.status_code == 302
+        assert ('/organizations/{}/members/{}/'.format(self.org.slug,self.member)
+               in response.location)
+
+    def test_post_org_role_upgraded(self):
+        assign_policies(self.user)
+        response = self.request(
+            method = 'POST', user=self.user, post_data={'org_role': 'A'})
+
+        assert response.status_code == 302
+        assert ('/organizations/{}/members/'.format(self.org.slug)
+               in response.location)
 
     def test_post_org_role_with_unauthorized_user(self):
         self.user = UserFactory.create()

--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -378,6 +378,7 @@ class OrganizationEditTest(ViewTestCase, UserTestCase, TestCase):
         assert self.org.name != 'Org'
         assert self.org.description != 'Some description'
 
+
 class OrganizationArchiveTest(ViewTestCase, UserTestCase, TestCase):
     view_class = default.OrganizationArchive
 
@@ -708,20 +709,20 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
     def test_post_org_role_downgraded(self):
         assign_policies(self.user)
         response = self.request(
-            method = 'POST', user=self.user, post_data={'org_role': 'M'})
+            method='POST', user=self.user, post_data={'org_role': 'M'})
 
         assert response.status_code == 302
-        assert ('/organizations/{}/members/{}/'.format(self.org.slug,self.member)
-               in response.location)
+        assert ('/organizations/{}/members/{}/'.format(
+                  self.org.slug, self.member) in response.location)
 
     def test_post_org_role_upgraded(self):
         assign_policies(self.user)
         response = self.request(
-            method = 'POST', user=self.user, post_data={'org_role': 'A'})
+            method='POST', user=self.user, post_data={'org_role': 'A'})
 
         assert response.status_code == 302
         assert ('/organizations/{}/members/'.format(self.org.slug)
-               in response.location)
+                in response.location)
 
     def test_post_org_role_with_unauthorized_user(self):
         self.user = UserFactory.create()

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -199,6 +199,7 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
                               core_mixins.CacheObjectMixin,
                               base_generic.edit.FormMixin,
                               generic.DetailView):
+    downgrade = None
     model = User
     slug_field = 'username'
     slug_url_kwarg = 'username'
@@ -209,6 +210,13 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
     permission_denied_message = error_messages.ORG_USERS_EDIT
 
     def get_success_url(self):
+        if self.downgrade:
+            return reverse(
+                 'organization:members_edit',
+                 kwargs={'slug': self.kwargs['slug'],
+                         'username': self.kwargs['username']},
+            )
+
         return reverse(
             'organization:members',
             kwargs={'slug': self.kwargs['slug']},
@@ -227,6 +235,9 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
                 self.get_object(),
                 self.request.user,
                 data=data)
+            if data:
+                if data.get('org_role') is 'M':
+                    self.downgrade = True
 
         return self.org_form
 

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -213,8 +213,7 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
         if self.downgrade:
             return reverse(
                  'organization:members_edit',
-                 kwargs={'slug': self.kwargs['slug'],
-                         'username': self.kwargs['username']},
+                 kwargs=self.kwargs,
             )
 
         return reverse(
@@ -235,8 +234,7 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
                 self.get_object(),
                 self.request.user,
                 data=data)
-            if data:
-                if data.get('org_role') is 'M':
+            if data and data.get('org_role') is 'M':
                     self.downgrade = True
 
         return self.org_form

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -199,7 +199,6 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
                               core_mixins.CacheObjectMixin,
                               base_generic.edit.FormMixin,
                               generic.DetailView):
-    rolechange = None
     model = User
     slug_field = 'username'
     slug_url_kwarg = 'username'
@@ -210,7 +209,7 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
     permission_denied_message = error_messages.ORG_USERS_EDIT
 
     def get_success_url(self):
-        if self.rolechange:
+        if self.request.POST and self.request.POST.get('org_role'):
             return reverse(
                  'organization:members_edit',
                  kwargs=self.kwargs,
@@ -234,8 +233,6 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
                 self.get_object(),
                 self.request.user,
                 data=data)
-            if data and data.get('org_role'):
-                    self.rolechange = True
 
         return self.org_form
 

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -199,7 +199,7 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
                               core_mixins.CacheObjectMixin,
                               base_generic.edit.FormMixin,
                               generic.DetailView):
-    downgrade = None
+    rolechange = None
     model = User
     slug_field = 'username'
     slug_url_kwarg = 'username'
@@ -210,7 +210,7 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
     permission_denied_message = error_messages.ORG_USERS_EDIT
 
     def get_success_url(self):
-        if self.downgrade:
+        if self.rolechange:
             return reverse(
                  'organization:members_edit',
                  kwargs=self.kwargs,
@@ -234,8 +234,8 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
                 self.get_object(),
                 self.request.user,
                 data=data)
-            if data and data.get('org_role') is 'M':
-                    self.downgrade = True
+            if data and data.get('org_role'):
+                    self.rolechange = True
 
         return self.org_form
 


### PR DESCRIPTION
### Proposed changes in this pull request

This change leaves the user at a individual member's page after role has been changed from 'Administrator' to 'Member'

See issue : https://github.com/Cadasta/cadasta-platform/issues/1106

-

### When should this PR be merged

### Risks
-

### Follow up actions

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [y ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ Y] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ Y] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
