### PR TITLE
Fix #1001 -- Add relationships to party detail page

### DIFF
--- a/cadasta/party/views/mixins.py
+++ b/cadasta/party/views/mixins.py
@@ -73,7 +73,7 @@ class PartyResourceMixin(ResourceViewMixin, PartyObjectMixin):
     def get_success_url(self):
         kwargs = self.kwargs
         kwargs['party'] = self.get_object().id
-        return reverse('parties:detail', kwargs=kwargs)
+        return reverse('parties:detail', kwargs=kwargs) + '#resources'
 
     def get_party(self):
         if not hasattr(self, 'party_object'):

--- a/cadasta/templates/party/party_detail.html
+++ b/cadasta/templates/party/party_detail.html
@@ -18,11 +18,19 @@
         </div>
       </div>
       <div class="panel panel-default">
-        <div class="panel-body">
-          <!-- Party information -->
-          <h3>{% trans "Details" %}</h3>
-          <div class="row">
-            <div class="col-md-6">
+        <div class="panel-body detail">
+
+          <h2><span>{% trans "Party" %} </span>{{ party.name }}</h2>
+
+          <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active"><a href="#overview" aria-controls="overview" role="tab" data-toggle="tab">{% trans "Overview" %}</a></li>
+            <li role="presentation"><a href="#relationships" aria-controls="relationships" role="tab" data-toggle="tab">{% trans "Relationships" %}</a></li>
+            <li role="presentation"><a  href="#resources" aria-controls="resources" role="tab" data-toggle="tab">{% trans "Resources" %}</a></li>
+          </ul>
+
+          <div class="tab-content">
+            <!-- Party information -->
+            <div role="tabpanel" class="tab-pane active" id="overview">
               <table class="table table-location">
                 <tbody>
                   <tr>
@@ -42,38 +50,86 @@
                 </tbody>
               </table>
             </div>
-          </div>
-          <!-- /party information -->
-          <!-- Party resources -->
-          <h3>{% trans "Resources" %}</h3>
-          {% if resource_list %}
-            <div class="top-btn pull-right top-add">
-              {% if has_unattached_resources %}
-              <a class="btn btn-primary btn-sm" href="{% url 'parties:resource_add' object.organization.slug object.slug party.id %}">
-              {% else %}
-              <a class="btn btn-primary btn-sm" href="{% url 'parties:resource_new' object.organization.slug object.slug party.id %}">
-              {% endif %}
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Attach" %}</a>
+            <!-- /party information -->
+
+            <!-- Party relationships -->
+            <div role="tabpanel" class="tab-pane" id="relationships">
+              {% if relationships %}
+              <table class="table table-hover datatable" data-paging-type="simple">
+                <thead>
+                  <tr>
+                    <th>{% trans "Relationship" %}</th>
+                    <th>{% trans "Location Type" %}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for rel in relationships %}
+                  {% url 'parties:relationship_detail' object.organization.slug object.slug rel.id as relationship_url %}
+                  <tr class="linked" onclick="window.document.location='{{ relationship_url }}';">
+                    <td><a href="{{ relationship_url }}" {{ rel.type_labels|safe }}>{{ rel.tenure_type_label }}</a></td>
+                    <td><a href="{% url 'locations:detail' object.organization.slug object.slug rel.spatial_unit.id %}" {{ rel.location_labels|safe }}>{{ rel.spatial_unit.get_type_display }}</a></td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            {% else %}
+              <div>
+                <p>{% trans "This party does not have any relationships and is not connected to any locations." %}</p>
+              </div>
+            {% endif %}
             </div>
-            {% include 'resources/table.html' %}
-          {% else %}
-            <div>
-              <p>{% trans "This party does not have any attached resources. To attach a resource, select the button below." %}</p>
-              <div class="btn-full">
+            <!-- /party relationships -->
+
+            <!-- Party resources -->
+            <div role="tabpanel" class="tab-pane" id="resources">
+            {% if resource_list %}
+              <div class="top-btn pull-right top-add">
                 {% if has_unattached_resources %}
-                <a class="btn btn-primary" href="{% url 'parties:resource_add' object.organization.slug object.slug party.id %}">
+                <a class="btn btn-primary btn-sm" href="{% url 'parties:resource_add' object.organization.slug object.slug party.id %}">
                 {% else %}
-                <a class="btn btn-primary" href="{% url 'parties:resource_new' object.organization.slug object.slug party.id %}">
+                <a class="btn btn-primary btn-sm" href="{% url 'parties:resource_new' object.organization.slug object.slug party.id %}">
                 {% endif %}
                   <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Attach" %}</a>
               </div>
+              {% include 'resources/table.html' %}
+            {% else %}
+              <div>
+                <p>{% trans "This party does not have any attached resources. To attach a resource, select the button below." %}</p>
+                <div class="btn-full">
+                  {% if has_unattached_resources %}
+                  <a class="btn btn-primary" href="{% url 'parties:resource_add' object.organization.slug object.slug party.id %}">
+                  {% else %}
+                  <a class="btn btn-primary" href="{% url 'parties:resource_new' object.organization.slug object.slug party.id %}">
+                  {% endif %}
+                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans "Attach" %}</a>
+                </div>
+              </div>
+            {% endif %}
             </div>
-          {% endif %}
-          <!-- /party resources -->
+            <!-- /party resources -->
+          </div>
         </div>
       </div>
     </div>
   </div>
 </div>
 
+{% endblock %}
+
+{% block extra_script %}
+{{ block.super }}
+<script type="text/javascript">
+  $(document).ready(function() {
+    if(location.hash) {
+      $('a[href=' + location.hash + ']').tab('show');
+    }
+    $(document.body).on("click", "a[data-toggle]", function(event) {
+      location.hash = this.getAttribute("href");
+    });
+  });
+  $(window).on('popstate', function() {
+      var anchor = location.hash || $("a[data-toggle=tab]").first().attr("href");
+      $('a[href=' + anchor + ']').tab('show');
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
### Proposed changes in this pull request

- Implements #1001: Adds relationships to party detail page. Functionality and layout are similar to the location detail pages. There are three tabs, one for party details, one for relationships and one for resources. 
- The changes _do not_ include a workflow to add relationships to a party as this requires designing an appropriate workflow beforehand. 
- Translations for language dropdown are included as well

@clash99 Can you please check if the layout of the page is ok?

### When should this PR be merged

Whenever.

### Risks

None

### Follow up actions

None

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
