### PR TITLE
Search: Clear search textbox.

### DIFF
--- a/cadasta/core/static/css/single.scss
+++ b/cadasta/core/static/css/single.scss
@@ -550,3 +550,27 @@
     }
   }
 }
+
+/* =clear search box related
+-------------------------------------------------------------- */
+
+#search-clear {
+  position: relative;
+  right: 20px;
+  top: 4px;
+  bottom: 30px;
+  height: 14px;
+  margin: 0px;
+  font-size: 14px;
+  cursor: pointer;
+  color: gray;
+  z-index: -1;
+}
+
+.search-clear-show{
+  z-index: 1 !important;
+}
+
+#search-form input {
+    margin-right: -5px;
+}

--- a/cadasta/templates/search/search.html
+++ b/cadasta/templates/search/search.html
@@ -21,7 +21,8 @@
               <div class="form-group col-md-9">
                 <label class="control-label sr-only">{% trans "Search within project for" %}</label>
                 <input type="search" id="search-input" class="form-control input-lg pull-left" value="{{ search_query }}">
-                <button class="btn btn-primary btn-lg"><span class="glyphicon glyphicon-search" aria-hidden="true"></span></button>
+                <span id="search-clear" class="glyphicon glyphicon-remove-circle"></span>
+                <button class="btn btn-primary btn-lg" id="search-button"><span class="glyphicon glyphicon-search"></span></button>
                 <p class="small help-block">
                   {% blocktrans %}
                   e.g., <kbd>Parcel</kbd>, <kbd>John White</kbd>; <a id="search-guidelines-link">more search guidelines</a>
@@ -178,7 +179,11 @@ window.addEventListener('load', function () {
   query = query && decodeURIComponent(query[1].replace(/\+/g, ' '));
   if (query) {
     $('#search-input')[0].value = query;
+    $('#search-clear').addClass('search-clear-show');
     performSearch(query, false);
+  } else {
+    $('#search-clear').removeClass('search-clear-show');
+    $("#search-input").focus();
   }
 
   // Perform search when the search form is submitted
@@ -186,6 +191,25 @@ window.addEventListener('load', function () {
     var query = $('#search-input')[0].value;
     performSearch(query, true);
     return false;
+  });
+
+  // Update display of search-box clear option
+  $(document).on('input', function() {
+    if ($('#search-input').val()) {
+      $('#search-clear').addClass('search-clear-show');
+    } else {
+      $('#search-clear').removeClass('search-clear-show');
+    }
+  });
+  $('#search-clear').click(function(){
+    $('#search-input').val('');
+    $('#search-clear').removeClass('search-clear-show');
+  });
+  // Focusing search-input on search-button click if it is empty
+  $('#search-button').click(function(){
+    if ($('#search-input').val().length === 0) {
+      $("#search-input").focus();
+    }
   });
 });
 


### PR DESCRIPTION
Search: Clear search textbox.

By overriding bootstrap, we now leverage the clear search textbox feature offered by HTML5 to meet our requirements of having clear search textbox in all search options.

Fixes #1147 