### PR TITLE
Change of email process security updates #1140

### DIFF
--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -41,7 +41,7 @@ class RegisterForm(forms.ModelForm):
             errors.append(_("Passwords cannot contain your email."))
 
         username = self.data.get('username')
-        if len(username) and username.casefold() in password.casefold():
+        if len(username) and username in password:
             errors.append(
                 _("The password is too similar to the username."))
 

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -211,7 +211,7 @@ class ProfileFormTest(UserTestCase, TestCase):
         user.refresh_from_db()
         assert user.full_name == 'John Lennon'
         assert user.email_verified is False
-        assert len(mail.outbox) == 1
+        assert len(mail.outbox) == 2
 
     def test_display_name(self):
         user = UserFactory.create(username='imagine71',

--- a/cadasta/templates/allauth/account/email/email_confirmation_message.txt
+++ b/cadasta/templates/allauth/account/email/email_confirmation_message.txt
@@ -1,6 +1,6 @@
-{% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans %}
+{% load account %}{% load i18n %}{% autoescape off %}{% blocktrans %}
 
-You're receiving this email because user {{ user_display }} at Cadasta Platform has given yours as an email address to connect their account.
+You're receiving this email because user at Cadasta Platform has given yours email-id as an email address to connect their account.
 
 To confirm this is correct, go to {{ activate_url }}
 {% endblocktrans %}{% endautoescape %}


### PR DESCRIPTION
### Proposed changes in this pull request

Fixed(#1140) except "user's email address should not be updated until verification"

- The confirmation email sent to the new email address does not include the username as mentioned for security purposes.

/cadasta/templates/allauth/account/email/email_confirmation_message.txt 

User Display is removed which was displaying username in verification mail sent to new email id.

-  A separate notification email is sent to the old address. If the event of unauthorized changes occurs, this will alert the user to the change.The notification email to the old email addresses advise the user to let us know immediately if this change was not authorized, and contact method is provided in email itself.

/cadasta/accounts/forms.py --> clean_email() method 

- Added  new test method in /cadasta/accounts/tests/test_forms.py where I assign assert len(mail.outbox) == 2 in  "test_update_user" method  because we are sending mails to old user account as well as new user account.

### When should this PR be merged

I have run './runtests.py' in vagrant directory, and the all tests had ran successfully. So once it's been reviewed there will not be any conflict hence it can be merged.

I have manually tried different email updates and everytime it gives expected behavior as mentioned above.


### Checklist (for reviewing)
@oliverroick @wonderchook 
#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
