### PR TITLE
Fix: #1102 Remove IntegrityError when using a released email to register

### DIFF
--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -93,6 +93,11 @@ class ProfileForm(forms.ModelForm):
             if User.objects.filter(email=email).exists():
                 raise forms.ValidationError(
                     _("Another user with this email already exists"))
+
+            current_email_set = self.instance.emailaddress_set.all()
+            if current_email_set.exists():
+                current_email_set.delete()
+
         return email
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
### Proposed changes in this pull request

#### Fixes #1102 

Bug Description: Registering with an email that is no longer associated with an account throws an error.

Cause: When a new user registers, an EmailAddress (Model class in allauth.account.models) object is created and an email confirmation mail is sent.  When the same user updates his/her email in the profile, the EmailAddress object associated with his User model was not being deleted which caused IntegrityError.

Solution: In clean_email method of ProfileForm class, delete any old instances of EmailAddress model for the current user if email is being updated.

### When should this PR be merged

PR can be merged without any preconditions.

### Risks

There are no risks from merging this pull request.

### Follow up actions

No extra actions required.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 