### PR TITLE
WIP: Option to delete multiple resources at once.

### DIFF
--- a/cadasta/core/static/css/main.css
+++ b/cadasta/core/static/css/main.css
@@ -4847,6 +4847,9 @@ ul.resource-actions > li {
   ul.resource-actions > li + li {
     border-left: 1px solid #e7e8ea; }
 
+#delete_multiple_resources {
+  display: none; }
+
 /* =For styles only found in single project or organization pages
 -------------------------------------------------------------- */
 /* =Page header default
@@ -5381,6 +5384,9 @@ ul.resource-actions > li {
 
 #search-results.table h4 {
   margin-bottom: 12px; }
+
+#search-results.table img.thumb-60 {
+  margin-left: 24px; }
 
 #search-results.table img.thumb-60 ~ table {
   width: calc(100% - 100px); }

--- a/cadasta/core/static/css/resources.scss
+++ b/cadasta/core/static/css/resources.scss
@@ -26,3 +26,7 @@ ul.resource-actions > li {
     border-left: 1px solid $table-border-color;
   }
 }
+
+#delete_multiple_resources {
+  display: none;
+}

--- a/cadasta/resources/urls/default.py
+++ b/cadasta/resources/urls/default.py
@@ -29,6 +29,10 @@ urls = [
         default.ResourceArchive.as_view(),
         name='archive'),
     url(
+        r'^resources/(?P<resource>.+)/multiplearchive/$',
+        default.MultipleResourceArchive.as_view(),
+        name='archive'),
+    url(
         r'^resources/(?P<resource>[-\w]+)/unarchive/$',
         default.ResourceUnarchive.as_view(),
         name='unarchive'),

--- a/cadasta/resources/views/default.py
+++ b/cadasta/resources/views/default.py
@@ -145,6 +145,15 @@ class ResourceArchive(LoginPermissionRequiredMixin,
             return reverse('resources:project_list', kwargs=kwargs)
 
 
+class MultipleResourceArchive(LoginPermissionRequiredMixin,
+                      ArchiveMixin,
+                      mixins.ResourceObjectMixin,
+                      generic.UpdateView):
+    do_archive = True
+    permission_required = update_permissions('resource.archive')
+    permission_denied_message = error_messages.RESOURCE_ARCHIVE
+
+
 class ResourceUnarchive(LoginPermissionRequiredMixin,
                         ArchiveMixin,
                         mixins.ResourceObjectMixin,

--- a/cadasta/templates/resources/modal_archive_multiple.html
+++ b/cadasta/templates/resources/modal_archive_multiple.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+
+<div class="modal fade" id="delete_multiple_resource_confirm" tabindex="-1" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h3 class="modal-title">{% trans "Delete selected resources" %}</h3>
+      </div>
+      <div class="modal-body">
+        <p>
+          {% blocktrans %}
+          Are you sure you want to delete selected resources?
+          Once deleted, resources can only be restored by a system administrator.
+          Deleting will also detach the resource from everything it is attached to.
+          {% endblocktrans %}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <a href="" class="btn btn-danger archive-final pull-right" id="confirm_multiple_delete" role="button">
+          {% trans "Yes, delete resources" %}
+        </a>
+        <button type="button" class="btn btn-link cancel" data-dismiss="modal">
+          {% trans "Cancel" %}
+        </button>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->

--- a/cadasta/templates/resources/project_list.html
+++ b/cadasta/templates/resources/project_list.html
@@ -17,6 +17,7 @@
         <div class="panel-body">
           {% if is_allowed_add_resource %}
           <div class="top-btn pull-right top-add">
+            <a style="display: none;" class="btn btn-default btn-action btn-sm" id="delete_multiple_resources" href="#delete_multiple_resource_confirm" data-toggle="modal" title="{% trans 'Delete selected resources' %}" aria-label="{% trans 'Delete selected resource' %}"><span class="glyphicon glyphicon-trash"></span></a>
             {% if has_unattached_resources %}
             <a class="btn btn-primary btn-sm" href="{% url 'resources:project_add_existing' project=object.slug organization=object.organization.slug %}">
             {% else %}
@@ -35,5 +36,6 @@
 {% endblock %}
 
 {% block form_modal %}
-{% include 'resources/modal_unarchive.html' with unarchive_url="#" %}
+{% include 'resources/modal_archive_multiple.html' %}
+{% include 'resources/modal_unarchive.html' %}
 {% endblock %}

--- a/cadasta/templates/resources/table.html
+++ b/cadasta/templates/resources/table.html
@@ -4,7 +4,8 @@
 <table class="table table-hover datatable" data-paging-type="simple">
   <thead>
     <tr>
-      <th class="col-md-4">{% trans "Resource" %}</th>
+      <th class="col-md-1"></th>
+      <th class="col-md-3">{% trans "Resource" %}</th>
       <th class="col-md-1 hidden-xs hidden-sm">{% trans "Type" %}</th>
       <th class="col-md-2 hidden-xs hidden-sm">{% trans "Contributor" %}</th>
       <th class="col-md-2 hidden-xs hidden-sm">{% trans "Last updated" %}</th>
@@ -14,7 +15,10 @@
   </thead>
   <tbody>
   {% for resource in resource_list %}
-    <tr class="linked linked-resource" data-link-url="{% url 'resources:project_detail' project=object.slug organization=object.organization.slug resource=resource.id %}">
+    <tr>
+      <td>
+        <input type="checkbox" name="resources[]" onclick="showDelete()" value="{{ resource.id }}">
+      </td>
       <td>
         <div class="resource-60">
           <img src="{{ resource.thumbnail }}" class="thumb-60">
@@ -80,4 +84,24 @@ window.addEventListener('load', function() {
     $('#undelete_resource_confirm').modal();
   });
 });
+
+function showDelete() {
+  if ($("input:checked").length >= 1) {
+    $("#delete_multiple_resources").show();
+  } else {
+    $("#delete_multiple_resources").hide();
+  }
+  var resourceIDs = $("input:checked").map(function() {
+    return $(this).val();
+  }).get(); // <----
+  $('#confirm_multiple_delete').each(function() {
+    this.href = "";
+    this.href += resourceIDs.toString();
+    if ($("input:checked").length == 1) {
+      this.href += "/archive/"
+    } else if ($("input:checked").length > 1) {
+      this.href += "/multiplearchive/"
+    }
+  })
+}
 </script>


### PR DESCRIPTION
After the completion of this work, users will be able to delete more than one resources in one go. Before this, users were given the delete option only on the specific resource page.

Fixes #1117 
