### PR TITLE
Fix of bug #1107 *Possible to Create Duplicate Resource Entries*

### DIFF
--- a/cadasta/core/static/js/form_submit_once.js
+++ b/cadasta/core/static/js/form_submit_once.js
@@ -1,0 +1,13 @@
+$(document).ready(function() {
+    'use strict';
+    $("form [type=submit]").click(function(event) {
+        var button = event.target;
+        var $validator = $("[data-parsley-validate]").parsley();
+        var formIsValid = $validator.isValid();
+
+        if (formIsValid) {
+            button.form.submit();
+            button.disabled = true;
+        };
+    });
+});

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -191,10 +191,11 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
     <script src="{% static 'js/bootstrap.min.js' %}"></script>
-    <script src="{% static 'js/parsleyConfig.js' %}"></script>
-    <script src="{% static 'js/parsley.js' %}"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/r/bs-3.3.5/jqc-1.11.3,dt-1.10.8/datatables.min.js"></script>
     <script type="text/javascript" src="{% static 'js/dataTables.conditionalPaging.js' %}"></script>
+    <script src="{% static 'js/parsleyConfig.js' %}"></script>
+    <script src="{% static 'js/parsley.js' %}"></script>
+
     {% block extra_script %}{% endblock %}
     <script>
     $(document).ready(function () {

--- a/cadasta/templates/party/party_add.html
+++ b/cadasta/templates/party/party_add.html
@@ -12,6 +12,7 @@
 {% block extra_script %}
 {{ block.super }}
 <script src="{% static 'js/jquery-ui.min.js' %}"></script>
+<script src="{% static 'js/form_submit_once.js' %}"></script>
 {% if get_current_language != "en-us" %}
 {% get_current_language as LANGUAGE_CODE %}
 <script src="https://cdn.rawgit.com/jquery/jquery-ui/1.12.1/ui/i18n/datepicker-{{ LANGUAGE_CODE }}.js"></script>
@@ -41,7 +42,7 @@
 
             {% include "party/party_form.html" %}
 
-            <button type="submit" class="btn btn-primary" name="submit">
+            <button type="submit" class="btn btn-primary" name="submit-button">
               {% trans "Save" %}
             </button>
           </form>

--- a/cadasta/templates/party/party_edit.html
+++ b/cadasta/templates/party/party_edit.html
@@ -13,6 +13,7 @@
 {{ block.super }}
 {{ form.media }}
 <script src="{% static 'js/jquery-ui.min.js' %}"></script>
+<script src="{% static 'js/form_submit_once.js' %}"></script>
 {% if get_current_language != "en-us" %}
 {% get_current_language as LANGUAGE_CODE %}
 <script src="https://cdn.rawgit.com/jquery/jquery-ui/1.12.1/ui/i18n/datepicker-{{ LANGUAGE_CODE }}.js"></script>
@@ -47,7 +48,7 @@
           </div>
 
           <div class="modal-footer">
-            <button type="submit" class="btn btn-primary pull-right" name="submit">
+            <button type="submit" class="btn btn-primary pull-right" name="submit-button">
               {% trans "Save" %}
             </button>
             <a class="btn btn-link cancel"

--- a/cadasta/templates/party/relationship_resources_add.html
+++ b/cadasta/templates/party/relationship_resources_add.html
@@ -6,6 +6,7 @@
 
 {% block location_extra_script %}
 <script src="{% static 'js/dataTables.forms.js' %}"></script>
+<script src="{% static 'js/form_submit_once.js' %}"></script>
 {% include 'resources/script_add_lib.html' %}
 {% endblock %}
 

--- a/cadasta/templates/party/relationship_resources_new.html
+++ b/cadasta/templates/party/relationship_resources_new.html
@@ -1,10 +1,12 @@
 {% extends "party/relationship_detail.html" %}
 {% load i18n %}
+{% load staticfiles %}
 
 {% block page_title %}{% trans "Upload new resource for relationship" %} | {% endblock %}
 
 {% block location_extra_script %}
   {{ form.media }}
+  <script src="{% static 'js/form_submit_once.js' %}"></script>
 {% endblock %}
 
 {% block modals %}

--- a/cadasta/templates/party/resources_add.html
+++ b/cadasta/templates/party/resources_add.html
@@ -7,6 +7,7 @@
 {% block extra_script %}
 {{ block.super }}
 <script src="{% static 'js/dataTables.forms.js' %}"></script>
+<script src="{% static 'js/form_submit_once.js' %}"></script>
 {% include 'resources/script_add_lib.html' %}
 {% endblock %}
 

--- a/cadasta/templates/party/resources_new.html
+++ b/cadasta/templates/party/resources_new.html
@@ -1,11 +1,13 @@
 {% extends "party/party_detail.html" %}
 {% load i18n %}
+{% load staticfiles %}
 
 {% block page_title %}{% trans "Upload new resource for party" %} | {% endblock %}
 
-{% block extra_script %}  
+{% block extra_script %}
   {{ block.super }}
   {{ form.media }}
+  <script src="{% static 'js/form_submit_once.js' %}"></script>
 {% endblock %}
 
 {% block modals %}

--- a/cadasta/templates/resources/modal_add_lib.html
+++ b/cadasta/templates/resources/modal_add_lib.html
@@ -4,7 +4,7 @@
   <div class="modal show" data-backdrop="true">
     <div class="modal-dialog modal-lg">
       <div class="modal-content">
-        <form method="POST">
+        <form method="POST" data-parsley-validate>
           <div class="modal-header">
             <a class="close" href="{{ cancel_url }}{{ cancel_url_hash }}">
               <span aria-hidden="true">&times;</span>
@@ -21,7 +21,7 @@
           </div>
 
           <div class="modal-footer">
-            <button type="submit" class="btn btn-primary pull-right" name="submit">
+            <button type="submit" class="btn btn-primary pull-right" name="submit-button">
               {% trans "Save" %}
             </button>
              <a class="btn btn-link cancel" href="{{ cancel_url }}{{ cancel_url_hash }}">

--- a/cadasta/templates/resources/modal_upload.html
+++ b/cadasta/templates/resources/modal_upload.html
@@ -23,7 +23,7 @@
           </div>
 
           <div class="modal-footer">
-            <button type="submit" class="btn btn-primary pull-right" name="submit">
+            <button type="submit" class="btn btn-primary pull-right" name="submit-button">
               {% trans "Save" %}
             </button>
             <a class="btn btn-link cancel" href="{{ cancel_url }}{{ cancel_url_hash }}">
@@ -35,3 +35,4 @@
     </div>
   </div>
 </div>
+

--- a/cadasta/templates/resources/project_add_existing.html
+++ b/cadasta/templates/resources/project_add_existing.html
@@ -7,6 +7,7 @@
 {% block extra_script %}
 {{ block.super }}
 <script src="{% static 'js/dataTables.forms.js' %}"></script>
+<script src="{% static 'js/form_submit_once.js' %}"></script>
 {% include 'resources/script_add_lib.html' %}
 {% endblock %}
 

--- a/cadasta/templates/resources/project_add_new.html
+++ b/cadasta/templates/resources/project_add_new.html
@@ -1,11 +1,13 @@
 {% extends "resources/project_list.html" %}
 {% load i18n %}
+{% load staticfiles %}
 
 {% block page_title %}{% trans "Upload new resource for project" %} | {% endblock %}
 
 {% block extra_script %}
   {{ block.super }}
   {{ form.media }}
+  <script src="{% static 'js/form_submit_once.js' %}"></script>
 {% endblock %}
 
 {% block modals %}

--- a/cadasta/templates/spatial/location_add.html
+++ b/cadasta/templates/spatial/location_add.html
@@ -32,6 +32,7 @@
 <script src="https://cdn.rawgit.com/jquery/jquery-ui/1.12.1/ui/i18n/datepicker-{{ LANGUAGE_CODE }}.js"></script>
 {% endif %}
 <script src="{% static 'js/map_utils.js' %}"></script>
+<script src="{% static 'js/form_submit_once.js' %}"></script>
 <script>
   $(document).ready(function () {
     $(window).on('map:init', function(e) {

--- a/cadasta/templates/spatial/location_edit.html
+++ b/cadasta/templates/spatial/location_edit.html
@@ -29,6 +29,7 @@
 <script src="https://cdn.rawgit.com/jquery/jquery-ui/1.12.1/ui/i18n/datepicker-{{ LANGUAGE_CODE }}.js"></script>
 {% endif %}
 <script src="{% static 'js/map_utils.js' %}"></script>
+<script src="{% static 'js/form_submit_once.js' %}"></script>
 <script>
   $(document).ready(function () {
     $(window).on('map:init', function(e) {

--- a/cadasta/templates/spatial/relationship_add.html
+++ b/cadasta/templates/spatial/relationship_add.html
@@ -18,6 +18,7 @@
 {% block location_extra_script %}
   {{ form.media }}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
+  <script src="{% static 'js/form_submit_once.js' %}"></script>
   <script src="{% static 'js/jquery-ui.min.js' %}"></script>
   {% if get_current_language != "en-us" %}
   {% get_current_language as LANGUAGE_CODE %}
@@ -123,7 +124,7 @@ $(document).ready(function() {
           </div>
 
           <div class="modal-footer">
-            <button type="submit" class="btn btn-primary pull-right" name="submit">
+            <button type="submit" class="btn btn-primary pull-right" name="submit-button">
               {% trans "Save" %}
             </button>
             <a class="btn btn-link cancel"

--- a/cadasta/templates/spatial/resources_add.html
+++ b/cadasta/templates/spatial/resources_add.html
@@ -6,6 +6,7 @@
 
 {% block location_extra_script %}
 <script src="{% static 'js/dataTables.forms.js' %}"></script>
+<script src="{% static 'js/form_submit_once.js' %}"></script>
 {% include 'resources/script_add_lib.html' %}
 {% endblock %}
 

--- a/cadasta/templates/spatial/resources_new.html
+++ b/cadasta/templates/spatial/resources_new.html
@@ -1,10 +1,12 @@
 {% extends "spatial/location_detail.html" %}
 {% load i18n %}
+{% load staticfiles %}
 
 {% block page_title %}{% trans "Upload new resource for location" %} | {% endblock %}
 
 {% block location_extra_script %}
   {{ form.media }}
+  <script src="{% static 'js/form_submit_once.js' %}"></script>
 {% endblock %}
 
 {% block modals %}


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request fixes #1107. Following later suggestions, this PR has exported the handler into a static JS file instead of using onclick. In order to fully fix the issue, this PR also manually: 

1. validate the form using Parsley;
2. submit the form once;
3. disable the button after the form has been submitted. 

### When should this PR be merged

No dependecies.

### Risks

The submit button may stay disabled even if processing the submission in the backend failed. To fix this, we would need to change to submitting the form via ajax. A work-around is to refresh the page.

### Follow up actions

Although the Parsley validation itself works, I noticed that the first field of the form, where you upload a file as resource, does behaves as if it's always a valid field in the parsley validation test. On the contrary, the name field return false if empty. As a follow-up action I'm happy to look at this specific field validation so that the validation test of the form `returns false` also when: 

1. No file has been uploaded;
2. The file uploaded is of an unexpected extension.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
