### PR TITLE
Security/hardcoded s3

### DIFF
--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -350,7 +350,8 @@ ATTRIBUTE_GROUPS = {
     }
 }
 
-ICON_URL = ('https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/{}.png')
+ICON_URL = ('https://s3-us-west-2.amazonaws.com/cadasta-resources'
+            '/icons/{}.png')
 
 ICON_LOOKUPS = {
     'application/pdf': 'pdf',

--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -350,8 +350,7 @@ ATTRIBUTE_GROUPS = {
     }
 }
 
-ICON_URL = ('https://s3-us-west-2.amazonaws.com/cadasta-platformprod'
-            '-bucket/icons/{}.png')
+ICON_URL = ('https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/{}.png')
 
 ICON_LOOKUPS = {
     'application/pdf': 'pdf',

--- a/cadasta/resources/tests/test_migrations.py
+++ b/cadasta/resources/tests/test_migrations.py
@@ -73,7 +73,7 @@ class TestFixImportedResourceUrls(MigrationTestCase):
         project = Project.objects.create(name='Test Proj', organization=org)
 
         base_path = (
-            'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-bucket/'
+            'https://s3-us-west-2.amazonaws.com/cadasta-resources/'
         )
 
         # cannot call custom save methods on models in migrations
@@ -97,7 +97,7 @@ class TestFixImportedResourceUrls(MigrationTestCase):
         resources = Resource.objects.filter(mime_type='text/csv')
         assert len(resources) == 10
         base_path = (
-            'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-bucket/'
+            'https://s3-us-west-2.amazonaws.com/cadasta-resources/'
         )
         resource = Resource.objects.get(name='test-resource-0')
         assert resource.file.url == base_path + 'resources/test_0.csv'
@@ -118,7 +118,7 @@ class TestRandomizeImportedFilenames(MigrationTestCase):
         project = Project.objects.create(name='Test Proj', organization=org)
 
         base_path = (
-            'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-bucket/'
+            'https://s3-us-west-2.amazonaws.com/cadasta-resources/'
             'resources/'
         )
 

--- a/cadasta/resources/tests/test_models.py
+++ b/cadasta/resources/tests/test_models.py
@@ -64,7 +64,8 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             mime_type='application/pdf'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/pdf.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/pdf.png')
 
     def test_thumbnail_mp3(self):
         resource = ResourceFactory.build(
@@ -72,28 +73,32 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             mime_type='audio/mpeg3'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/mp3.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/mp3.png')
 
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.mp3',
             mime_type='audio/x-mpeg-3'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/mp3.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/mp3.png')
 
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.mp3',
             mime_type='video/mpeg'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/mp3.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/mp3.png')
 
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.mp3',
             mime_type='video/x-mpeg'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/mp3.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/mp3.png')
 
     def test_thumbnail_mp4(self):
         resource = ResourceFactory.build(
@@ -101,7 +106,8 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             mime_type='video/mp4'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/mp4.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/mp4.png')
 
     def test_thumbnail_doc(self):
         resource = ResourceFactory.build(
@@ -109,7 +115,8 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             mime_type='application/msword'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/doc.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/doc.png')
 
     def test_thumbnail_docx(self):
         resource = ResourceFactory.build(
@@ -118,7 +125,8 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
                        'wordprocessingml.document')
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/docx.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/docx.png')
 
     def test_thumbnail_xls(self):
         resource = ResourceFactory.build(
@@ -126,14 +134,16 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             mime_type='application/msexcel'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/xls.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/xls.png')
 
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.doc',
             mime_type='application/vnd.ms-excel'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/xls.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/xls.png')
 
     def test_thumbnail_xlsx(self):
         resource = ResourceFactory.build(
@@ -142,14 +152,16 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
                        '.spreadsheetml.sheet')
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/xlsx.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/xlsx.png')
 
     def test_thumbnail_xml(self):
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.gpx',
             mime_type=('text/xml'))
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/xml.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/xml.png')
 
     def test_thumbnail_other(self):
         resource = ResourceFactory.build(

--- a/cadasta/resources/tests/test_models.py
+++ b/cadasta/resources/tests/test_models.py
@@ -64,8 +64,7 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             mime_type='application/pdf'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/pdf.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/pdf.png')
 
     def test_thumbnail_mp3(self):
         resource = ResourceFactory.build(
@@ -73,32 +72,28 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             mime_type='audio/mpeg3'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/mp3.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/mp3.png')
 
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.mp3',
             mime_type='audio/x-mpeg-3'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/mp3.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/mp3.png')
 
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.mp3',
             mime_type='video/mpeg'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/mp3.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/mp3.png')
 
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.mp3',
             mime_type='video/x-mpeg'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/mp3.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/mp3.png')
 
     def test_thumbnail_mp4(self):
         resource = ResourceFactory.build(
@@ -106,8 +101,7 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             mime_type='video/mp4'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/mp4.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/mp4.png')
 
     def test_thumbnail_doc(self):
         resource = ResourceFactory.build(
@@ -115,8 +109,7 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             mime_type='application/msword'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/doc.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/doc.png')
 
     def test_thumbnail_docx(self):
         resource = ResourceFactory.build(
@@ -125,8 +118,7 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
                        'wordprocessingml.document')
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/docx.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/docx.png')
 
     def test_thumbnail_xls(self):
         resource = ResourceFactory.build(
@@ -134,16 +126,14 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             mime_type='application/msexcel'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/xls.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/xls.png')
 
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.doc',
             mime_type='application/vnd.ms-excel'
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/xls.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/xls.png')
 
     def test_thumbnail_xlsx(self):
         resource = ResourceFactory.build(
@@ -152,16 +142,14 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
                        '.spreadsheetml.sheet')
         )
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/xlsx.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/xlsx.png')
 
     def test_thumbnail_xml(self):
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.gpx',
             mime_type=('text/xml'))
         assert (resource.thumbnail ==
-                'https://s3-us-west-2.amazonaws.com/cadasta-platformprod-'
-                'bucket/icons/xml.png')
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/xml.png')
 
     def test_thumbnail_other(self):
         resource = ResourceFactory.build(


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes #1155 

Moves shared icons to the public resources bucket that already hosts other icons shared across environments, and updates resource tests for new icon paths. Also changes old migration test to test against the public resources bucket instead of active platform production bucket for consistency.

### When should this PR be merged

Anytime

### Risks

Very low; we already have an automated test for icon paths

### Follow up actions

Document and communicate appropriate storage locations for static assets shared across environments. Entire bucket structure will be modified as part of async i/o changes, so that platform project resource files are no longer publicly accessible (as path has been published).

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 