### PR TITLE
Add proxyconf settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,18 +9,24 @@ Install for development
 
 Install:
 
-- `VirtualBox <https://www.virtualbox.org/>`_
-- `Vagrant <https://www.vagrantup.com/>`_
-- `Ansible <http://www.ansible.com/>`_ (For Linux and Mac, install Ansible 2 via pip. For Windows(Windows isn’t supported for the control machine) go through `Ansible Documentation  <http://docs.ansible.com/ansible/intro_windows.html>`_ or this `Blog <https://www.jeffgeerling.com/blog/running-ansible-within-windows>`_.) 
+* `VirtualBox <https://www.virtualbox.org/>`_
+    * Version 5.0.x
+* `Vagrant <https://www.vagrantup.com/>`_
+    * Version 1.8.1
+    * If you are behind a proxy, you may need to install and configure the `vagrant-proxyconf <https://rubygems.org/gems/vagrant-proxyconf/versions/1.5.2>`_ plugin
+* `Ansible <http://www.ansible.com/>`_
+    * Version 2.1.3.0
+    * For Linux and Mac, install Ansible 2 via pip
+    * For Windows (unsupported), go through `Ansible Documentation <http://docs.ansible.com/ansible/intro_windows.html>`_ or this `blog <https://www.jeffgeerling.com/blog/running-ansible-within-windows>`_
 
-Clone the `repository <https://github.com/cadasta/cadasta-platform>`_ to your local machine and enter that directory.
-After cloning it go inside to cadasta-platform directory and run below command to provision the virtual machine.
+Clone the `repository <https://github.com/cadasta/cadasta-platform>`_ to your local machine and enter the cadasta-platform directory.
+Run the following commands to access the virtual machine.
+
 Provision the VM::
 
   vagrant up --provision
 
-SSH into to the VM (this automatically activates the Python virtual
-environment)::
+SSH into the VM (automatically activates the Python virtual environment)::
 
   vagrant ssh
   
@@ -29,7 +35,7 @@ Enter the cadasta directory and start the server::
   cd cadasta
   ./runserver
 
-Open ``http://localhost:8000/`` in your local machine's browser, this will forward you to the port on the VM and you should see the front page of the platform site.
+Open ``http://localhost:8000/`` in your local machine's browser. This will forward you to the web server port on the VM and you should see the front page of the platform site.
 
 See the wiki (`here <https://devwiki.corp.cadasta.org/Installation>`_ and `here <https://devwiki.corp.cadasta.org/Run%20for%20development>`_) for detailed instructions on installation and running the platform for development.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,20 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+      if ENV["http_proxy"]
+          puts "http_proxy: " + ENV["http_proxy"]
+          config.proxy.http     = ENV["http_proxy"]
+      end
+      if ENV["https_proxy"]
+          puts "https_proxy: " + ENV["https_proxy"]
+          config.proxy.https    = ENV["https_proxy"]
+      end
+      if ENV["no_proxy"]
+          config.proxy.no_proxy = ENV["no_proxy"]
+      end
+  end
+
   config.vm.box = "ubuntu/trusty64"
   config.vm.network "forwarded_port", guest: 8000, host: 8000
 
@@ -11,7 +25,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "ansible" do |ansible|
-#    ansible.verbose = "vvv"
+    # ansible.verbose = "vvv"
     ansible.playbook = "provision/vagrant.yml"
   end
 


### PR DESCRIPTION
### Proposed changes in this pull request

Adds proxyconf settings to Vagrantfile. Users behind proxies can install the `vagrant-proxyconf` plugin for provisioning the local dev VM. Users without proxies experience no changes.

### When should this PR be merged

Anytime

### Risks

None; users without proxies experience no changes. Only those with the `vagrant-proxyconf` plugin will obtain the new settings.

### Follow up actions

Document plugin option in readme.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
