### PR TITLE
Fix issue #1090

### DIFF
--- a/cadasta/templates/organization/project_defaults_import.html
+++ b/cadasta/templates/organization/project_defaults_import.html
@@ -30,15 +30,17 @@
                         {% blocktrans %}Select the <span class="highlight">Party type</span> field{% endblocktrans %}
                     </label>
                     <select id="party_type_field" class="form-control" name="select_defaults-party_type_field">
-                        {% for header in available_headers %}
-                        <option value="{{ header }}" {% if 'type' in header %} selected="selected" {% endif %}>
-                            {% if header == 'type' %}
-                                party_type
-                            {% else %}
-                                {{ header }}
-                            {% endif %}
-                        </option>
-                        {% endfor %}
+                      {% for header in available_headers %}
+                        {% if header == 'type' %}
+                           <option value="{{ header }}" selected="selected">
+                             party_type
+                           </option>
+                        {% else %}
+                           <option value="{{ header }}" {% if 'party_type' in header %} selected="selected" {% endif %}>
+                             {{ header }}
+                           </option>
+                        {% endif %}
+                      {% endfor %}
                     </select>
                 </div>
             </div>
@@ -69,15 +71,17 @@
                         {% blocktrans %}Select the <span class="highlight">Location type</span> field{% endblocktrans %}
                     </label>
                     <select id="location_type_field" class="form-control" name="select_defaults-location_type_field">
-                        {% for header in available_headers %}
-                        <option value="{{ header }}" {% if 'type' in header %} selected="selected" {% endif %}>
-                            {% if header == 'type' %}
-                                location_type
-                            {% else %}
-                                {{ header }}
-                            {% endif %}
-                        </option>
-                        {% endfor %}
+                      {% for header in available_headers %}
+                        {% if header == 'type' %}
+                           <option value="{{ header }}" selected="selected">
+                             location_type
+                           </option>
+                        {% else %}
+                           <option value="{{ header }}" {% if 'location_type' in header %} selected="selected" {% endif %}>
+                             {{ header }}
+                           </option>
+                        {% endif %}
+                      {% endfor %}
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
### Proposed changes in this pull request

This change matches Location_type field to 'location_type' and Party_type field to 'party_type', while importing project data
See issue : https://github.com/Cadasta/cadasta-platform/issues/1090

### When should this PR be merged

### Risks

- From issue discussion, export data maps/names location_type and party_type to both type. So when a file is being imported with type as one of its fields, it will not be displayed as default option.

### Follow up actions

- Probably, fix the export feature naming convention to  location_type and part_type 

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
