### PR TITLE
Fixes #1042: Only authenticated users can view an org's users

### DIFF
--- a/cadasta/organization/tests/test_views_api_organizations.py
+++ b/cadasta/organization/tests/test_views_api_organizations.py
@@ -221,7 +221,7 @@ class OrganizationDetailAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request()
         assert response.status_code == 200
         assert response.content['id'] == self.org.id
-        assert 'users' in response.content
+        assert 'users' not in response.content
 
     def test_get_organization_that_does_not_exist(self):
         response = self.request(user=self.user,

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -65,6 +65,11 @@ class OrganizationDetail(APIPermissionRequiredMixin,
         'PUT': patch_actions
     }
 
+    def get_serializer(self, *args, **kwargs):
+        if not self.request.user.is_authenticated:
+            kwargs['hide_detail'] = True
+        return super().get_serializer(*args, **kwargs)
+
 
 class OrganizationUsers(APIPermissionRequiredMixin,
                         mixins.OrganizationRoles,


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #1042
- Removes `users` from the API response for unauthenticated users.

### When should this PR be merged

Anytime

### Risks

None that I can think of.

### Follow up actions

None.

### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [x] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [x] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [x] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [x] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [x] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [x] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [x] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [x] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [x] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [x] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [x] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
