### PR TITLE
[WIP] Fix #1216: Fix #1217: Fix error and focussing on register page.

### DIFF
--- a/cadasta/templates/allauth/account/signup.html
+++ b/cadasta/templates/allauth/account/signup.html
@@ -72,11 +72,11 @@
   <div class="form-group{% if form.password1.errors %} has-error{% endif %}">
     <label class="control-label" for="id_password1">{% trans "Password" %}</label>
     {% render_field form.password1 class+="form-control input-lg" data-parsley-minlength="10" data-parsley-character="3" data-parsley-userfield="1" data-parsley-emailfield="1" %}
-    <br>
-    <input type="checkbox" id="showHide"><label for="showHide">&nbsp;Show Password</label>
     <p class="help-block small hidden">{% trans "Passwords must have a minimum of 10 characters and contain at least 3 of the following: lowercase characters, uppercase characters, special characters, and/or numerical characters.  Passwords cannot contain the username or email address." %}</p>
     <div class="error-block">{{ form.password1.errors }}</div>
   </div>
+
+  <p><input type="checkbox" id="showHide"><label for="showHide">&nbsp;Show Password</label></p>
 
   <div class="form-group{% if form.password2.errors %} has-error{% endif %}">
     <label class="control-label" for="id_password2">{% trans "Confirm password" %}</label>


### PR DESCRIPTION
Fix #1216  
Fix #1217  

Moves the `Show Password` checkbox out of the form-group of the preceding form element. This allows parsley to add the `form-error` class to the form-group.

However, it introduces a gap before the checkbox.

![screen shot 2017-03-07 at 6 35 24 pm](https://cloud.githubusercontent.com/assets/26208050/23657728/93b1634c-0365-11e7-8631-a2bae64ded65.png)

How should I go about adding an exception to the `margin-bottom` CSS rule here?