### PR TITLE
Fix #1223: Cap search results to 10000

### DIFF
--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -523,3 +523,4 @@ IMPORTERS = {
 ES_SCHEME = 'http'
 ES_HOST = 'localhost'
 ES_PORT = '9200'
+ES_MAX_RESULTS = 10000

--- a/cadasta/search/tests/test_views_default.py
+++ b/cadasta/search/tests/test_views_default.py
@@ -1,5 +1,7 @@
 import pytest
 import json
+
+from django.conf import settings
 from django.http import Http404
 from django.test import TestCase
 
@@ -40,6 +42,7 @@ class SearchTest(ViewTestCase, UserTestCase, TestCase):
     def setup_template_context(self):
         return {
             'object': self.project,
+            'max_num_results': settings.ES_MAX_RESULTS,
         }
 
     def setup_url_kwargs(self):

--- a/cadasta/search/views/async.py
+++ b/cadasta/search/views/async.py
@@ -51,7 +51,8 @@ class Search(APIPermissionRequiredMixin, ProjectMixin, APIView):
                     'error': 'unavailable',
                 })
 
-            num_hits = raw_results['hits']['total']
+            num_hits = min(raw_results['hits']['total'],
+                           settings.ES_MAX_RESULTS)
             results = raw_results['hits']['hits']
 
             if len(results) == 0:

--- a/cadasta/search/views/default.py
+++ b/cadasta/search/views/default.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from core.views.generic import TemplateView
 from core.mixins import LoginPermissionRequiredMixin
 from organization import messages as org_messages
@@ -15,6 +17,7 @@ class Search(LoginPermissionRequiredMixin,
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['object'] = self.get_object()
+        context['max_num_results'] = settings.ES_MAX_RESULTS
         return context
 
     def get_object(self, queryset=None):

--- a/cadasta/templates/search/search.html
+++ b/cadasta/templates/search/search.html
@@ -32,6 +32,7 @@
                   <ul>
                     <li>Review your wording, make sure that there aren’t any typos in your search query</li>
                     <li>If no results match your query, try removing some search terms (<kbd>John</kbd>, instead of <kbd>John White</kbd>)</li>
+                    <li>Search results are limited to a maximum of {{ max_num_results }} entries</li>
                   </ul>
                   {% endblocktrans%}
                 </div>


### PR DESCRIPTION
### Proposed changes in this pull request
- Fix #1223:
    - Add a new Django setting to match the maximum number of results ES will return
    - Use this new setting to cap the returned number of search results hits so that DataTables will know not to go over
    - Add a guideline advising the user of this limit
    - Add a unit tests and update other affected unit tests

### When should this PR be merged
For Sprint 14 release.

### Risks
None foreseen.

### Follow up actions
None.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
