### PR TITLE
Added is_member to OrgAdminCheckMixin. Updated org_member permissions.

### DIFF
--- a/cadasta/config/permissions/org-member.json
+++ b/cadasta/config/permissions/org-member.json
@@ -10,6 +10,11 @@
                  "party.list", "party_rel.list",
                  "tenure_rel.list", "resource.list"],
       "object": ["project/$organization/*"]
+    },
+    {
+      "effect": "allow",
+      "action": ["org.users.list", "org.view"],
+      "object": ["organization/$organization"]
     }
   ]
 }

--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -184,7 +184,8 @@ class OrganizationDashboardTest(ViewTestCase, UserTestCase, TestCase):
             'projects': self.projs,
             'is_superuser': False,
             'add_allowed': False,
-            'is_administrator': False
+            'is_administrator': False,
+            'is_member': False,
         }
 
     def test_get_org_with_authorized_user(self):
@@ -206,7 +207,7 @@ class OrganizationDashboardTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 200
         assert response.content == self.render_content(
             projects=Project.objects.all(),
-            show_members=True)
+            is_member=True)
 
     def test_get_org_with_new_org(self):
         new_org = OrganizationFactory.create()
@@ -228,7 +229,7 @@ class OrganizationDashboardTest(ViewTestCase, UserTestCase, TestCase):
             is_superuser=True,
             is_administrator=True,
             add_allowed=True,
-            show_members=True,
+            is_member=True,
             projects=self.all_projects)
 
     def test_get_org_with_org_admin(self):
@@ -245,7 +246,7 @@ class OrganizationDashboardTest(ViewTestCase, UserTestCase, TestCase):
             is_superuser=False,
             is_administrator=True,
             add_allowed=True,
-            show_members=True,
+            is_member=True,
             projects=self.all_projects)
 
     def test_get_archived_org_with_unauthorized_user(self):
@@ -280,7 +281,7 @@ class OrganizationDashboardTest(ViewTestCase, UserTestCase, TestCase):
             is_superuser=False,
             is_administrator=True,
             add_allowed=True,
-            show_members=True,
+            is_member=True,
             projects=self.all_projects)
 
 
@@ -308,7 +309,7 @@ class OrganizationEditTest(ViewTestCase, UserTestCase, TestCase):
     def setup_template_context(self):
         return {
             'form': forms.OrganizationForm(instance=self.org),
-            'organization': self.org
+            'organization': self.org,
         }
 
     def test_get_with_authorized_user(self):
@@ -649,7 +650,8 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
             'project_role_form':
                 forms.EditOrganizationMemberProjectPermissionForm(
                 self.org, self.member, self.user, data=None),
-            'org_admin': False
+            'org_admin': False,
+            'is_member': False,
         }
 
     def test_get_with_authorized_user(self):
@@ -658,7 +660,7 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
         response = self.request(user=self.user)
 
         assert response.status_code == 200
-        assert response.content == self.expected_content
+        assert response.content == self.render_content(is_member=True)
 
     def test_get_with_unauthorized_user(self):
         response = self.request(user=self.user)
@@ -681,7 +683,8 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
         assert response.content == self.render_content(is_superuser=True,
                                                        is_administrator=True,
                                                        org_admin=False,
-                                                       add_allowed=True)
+                                                       add_allowed=True,
+                                                       is_member=True)
 
     def test_get_with_archived_organization(self):
         OrganizationRole.objects.create(organization=self.org, user=self.user)
@@ -782,7 +785,8 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
                 self.org, self.member, self.user, {'org_role': 'X'},)
         assert response.status_code == 200
         assert response.content == self.render_content(
-            org_role_form=form, project_role_form=prj_form)
+            org_role_form=form, project_role_form=prj_form,
+            is_member=True)
 
     def test_post_org_role_with_archived_organization(self):
         assign_policies(self.user)
@@ -840,7 +844,8 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
                 self.org, self.member, self.user, {self.prj.id: 'X'},)
         assert response.status_code == 200
         assert response.content == self.render_content(
-            project_role_form=form, org_role_form=org_form)
+            project_role_form=form, org_role_form=org_form,
+            is_member=True)
 
     def test_post_prj_role_with_archived_organization(self):
         assign_policies(self.user)

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -166,7 +166,7 @@ class OrganizationProjectList(PermissionsFilterMixin,
         if self.request.method == 'POST':
             return [self.get_organization()]
 
-        if self.is_administrator():
+        if self.is_administrator:
             return super().get_queryset().filter(
                 organization__slug=self.kwargs['organization']
             )

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -132,7 +132,7 @@ class UserAdminDetail(APIPermissionRequiredMixin,
 
 class OrganizationProjectList(PermissionsFilterMixin,
                               APIPermissionRequiredMixin,
-                              mixins.OrgAdminCheckMixin,
+                              mixins.OrgRoleCheckMixin,
                               mixins.ProjectQuerySetMixin,
                               generics.ListCreateAPIView):
     org_lookup = 'organization'
@@ -166,7 +166,7 @@ class OrganizationProjectList(PermissionsFilterMixin,
         if self.request.method == 'POST':
             return [self.get_organization()]
 
-        if self.is_administrator:
+        if self.is_administrator():
             return super().get_queryset().filter(
                 organization__slug=self.kwargs['organization']
             )

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -83,7 +83,6 @@ class OrganizationDashboard(PermissionRequiredMixin,
         context = self.get_context_data()
         if self.is_superuser:
             projects = self.object.all_projects()
-            show_members = True
         else:
             projects = self.object.public_projects()
             if hasattr(self.request.user, 'organizations'):
@@ -96,14 +95,7 @@ class OrganizationDashboard(PermissionRequiredMixin,
                             projects = self.object.all_projects().filter(
                                 archived=False)
 
-            if not self.request.user.is_anonymous():
-                show_members = OrganizationRole.objects.filter(
-                    user=self.request.user,
-                    organization=context['organization']).exists()
-            else:
-                show_members = False
         context['projects'] = projects
-        context['show_members'] = show_members
         return super(generic.DetailView, self).render_to_response(context)
 
 

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -89,7 +89,7 @@ class OrganizationDashboard(PermissionRequiredMixin,
                 orgs = self.request.user.organizations.all()
                 for org in orgs:
                     if org.slug == self.kwargs['slug']:
-                        if self.is_administrator():
+                        if self.is_administrator:
                             projects = self.object.all_projects()
                         else:
                             projects = self.object.all_projects().filter(

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -63,7 +63,7 @@ class OrganizationAdd(LoginPermissionRequiredMixin, generic.CreateView):
 
 
 class OrganizationDashboard(PermissionRequiredMixin,
-                            mixins.OrgAdminCheckMixin,
+                            mixins.OrgRoleCheckMixin,
                             mixins.ProjectCreateCheckMixin,
                             core_mixins.CacheObjectMixin,
                             generic.DetailView):
@@ -89,7 +89,7 @@ class OrganizationDashboard(PermissionRequiredMixin,
                 orgs = self.request.user.organizations.all()
                 for org in orgs:
                     if org.slug == self.kwargs['slug']:
-                        if self.is_administrator:
+                        if self.is_administrator():
                             projects = self.object.all_projects()
                         else:
                             projects = self.object.all_projects().filter(
@@ -144,7 +144,7 @@ class OrganizationUnarchive(OrgArchiveView):
 
 
 class OrganizationMembers(LoginPermissionRequiredMixin,
-                          mixins.OrgAdminCheckMixin,
+                          mixins.OrgRoleCheckMixin,
                           mixins.ProjectCreateCheckMixin,
                           core_mixins.CacheObjectMixin,
                           generic.DetailView):
@@ -186,7 +186,7 @@ class OrganizationMembersAdd(mixins.OrganizationMixin,
 
 class OrganizationMembersEdit(mixins.OrganizationMixin,
                               LoginPermissionRequiredMixin,
-                              mixins.OrgAdminCheckMixin,
+                              mixins.OrgRoleCheckMixin,
                               mixins.ProjectCreateCheckMixin,
                               core_mixins.CacheObjectMixin,
                               base_generic.edit.FormMixin,

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -231,7 +231,6 @@ class ProjectCreateCheckMixin:
 
 
 class OrgRoleCheckMixin(SuperUserCheckMixin):
-    @property
     def get_roles(self):
         if not hasattr(self, '_is_member') or not hasattr(self, '_is_admin'):
             self._is_member = False
@@ -262,16 +261,18 @@ class OrgRoleCheckMixin(SuperUserCheckMixin):
 
         return self._is_member, self._is_admin
 
+    @property
     def is_administrator(self):
-        _, admin = self.get_roles
+        _, admin = self.get_roles()
         return admin
 
+    @property
     def is_member(self):
-        member, _ = self.get_roles
+        member, _ = self.get_roles()
         return member
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context['is_member'] = self.is_member()
-        context['is_administrator'] = self.is_administrator()
+        context['is_member'] = self.is_member
+        context['is_administrator'] = self.is_administrator
         return context

--- a/cadasta/templates/organization/organization_dashboard.html
+++ b/cadasta/templates/organization/organization_dashboard.html
@@ -98,7 +98,7 @@
               </dl>
             {% endif %}
           
-            {% if show_members %}
+            {% if is_member %}
             <div class="divider-thick"></div>
             <div class="hidden-xs hidden-sm">
               <!-- Members list -->

--- a/cadasta/templates/organization/organization_wrapper.html
+++ b/cadasta/templates/organization/organization_wrapper.html
@@ -8,7 +8,7 @@
 
 {% block title %} | {% block page_title %}{% endblock %}{{ organization.name }} {% endblock %}
 
-{% block main-width %}{% if is_administrator %} show-sidebar{% endif %}{% endblock %}
+{% block main-width %}{% if is_member %} show-sidebar{% endif %}{% endblock %}
 
 {% block page-header %}
 
@@ -92,7 +92,7 @@
 
 {% block sub-nav %}
 
-{% if is_administrator %}
+{% if is_member %}
 <!-- Sidebar -->
 <div id="sidebar" class="{% block left-nav %}{% endblock %}">
   <ul class="nav nav-sidebar">


### PR DESCRIPTION
### Proposed changes in this pull request
- This is working under the assumptions that __organization members__, not just organization admins should be able to __view__ the list of organization members. They cannot edit/add/remove members if they are not an admin, they can only see the list.
- Fixes #1241 
- Added `is_member` to OrgAdminCheckMixin.
- Replaced `is_administrator` and `show_members` with `is_member` where appropriate.
- Updated `org_member` permissions to include `org.users.list`

### When should this PR be merged
- Whenever


### Risks
- This is based on my understanding of what permissions are expected to be as stated in the issue.

### Follow up actions
- Run `loadpolicies` management command.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
