### PR TITLE
Fix #1221: Hide row filter dropdown when the search is one page long.

### DIFF
--- a/cadasta/core/static/js/dataTables.conditionalPaging.js
+++ b/cadasta/core/static/js/dataTables.conditionalPaging.js
@@ -40,6 +40,7 @@
                 speed = 'slow',
                 conditionalPaging = function(e) {
                     var $paging = $(api.table().container()).find('div.dataTables_paginate'),
+                        $dropdown = $(api.table().container()).find('div.dataTables_length'),
                         pages = api.page.info().pages;
 
                     if (e instanceof $.Event) {
@@ -63,9 +64,11 @@
                     else if (pages <= 1) {
                         if (config.style === 'fade') {
                             $paging.css('opacity', 0);
+                            $dropdown.css('opacity', 0);
                         }
                         else {
                             $paging.css('visibility', 'hidden');
+                            $dropdown.css('visibility', 'hidden');
                         }
                     }
                 };

--- a/cadasta/core/static/js/dataTables.conditionalPaging.js
+++ b/cadasta/core/static/js/dataTables.conditionalPaging.js
@@ -51,6 +51,9 @@
                             else {
                                 $paging.css('visibility', 'hidden');
                             }
+                            if (api.page.info().recordsDisplay < 10) {
+                                $dropdown.css('visibility', 'hidden');
+                            }
                         }
                         else {
                             if (config.style === 'fade') {
@@ -58,6 +61,7 @@
                             }
                             else {
                                 $paging.css('visibility', '');
+                                $dropdown.css('visibility', '');
                             }
                         }
                     }


### PR DESCRIPTION
### Proposed changes in this pull request

#### Fixes #1221
 
- Hide row filter dropdown when the search is one page long

### When should this PR be merged

Anytime

### Risks

- None

### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

- python manage.py collectstatic?


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
