### PR TITLE
Fix #1264: Add thumbnail preview to edit resources page.

### DIFF
--- a/cadasta/core/static/css/forms.scss
+++ b/cadasta/core/static/css/forms.scss
@@ -249,3 +249,7 @@ textarea.form-control {
 .well {
   margin-bottom: 10px;
 }
+
+.no-well {
+  margin-bottom: 60px;
+}

--- a/cadasta/templates/resources/form.html
+++ b/cadasta/templates/resources/form.html
@@ -5,10 +5,15 @@
   <div class="col-md-6">
     {% csrf_token %}
     <div class="form-group{% if form.file.errors %} has-error{% endif %}">
-      <label class="control-label required" for="{{ form.file.id_for_label }}">{% trans "Select the file to upload" %}</label>
-      <div class="well file-well">
-        {{ form.file }}
-        <p class="help-block">{% trans "Accepted file types: pdf, mp3, mp4, doc, docx, jpg, png, gpx, csv, xls, xlsx, gif, tiff" %}</p>
+      <div class="resource-60">
+        <img src="{{ resource.thumbnail }}" class="thumb-128">
+      </div>
+      <div class="resource-text">
+        <label class="control-label required" id="form_file_label" style="display: none;" for="{{ form.file.id_for_label }}">{% trans "Select the file to upload" %}</label>
+        <div class="no-well file-well" id="file_well">
+          {{ form.file }}
+          <p class="help-block" style="display: none;">{% trans "Accepted file types: pdf, mp3, mp4, doc, docx, jpg, png, gpx, csv" %}</p>
+        </div>
       </div>
       <div class="error-block">{{ form.file.errors }}</div>
     </div>
@@ -27,3 +32,19 @@
     <input type="hidden" name="mime_type" value="{{ form.mime_type.value }}">
   </div>
 </div>
+
+<script>
+
+window.addEventListener('load', function () {
+
+  $(".file-remove").click(function() {
+    $("#file_well").removeClass("no-well");
+    $("#file_well").addClass("well");
+    $(".resource-60").hide();
+    $(".form_file_label").show();
+    $(".help-block").show();
+  });
+  
+});
+
+</script>


### PR DESCRIPTION
### Proposed changes in this pull request

Fix #1264 

- Added thumbnail preview to edit resources page, like the one we already have on resource detail page.

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]

No preconditions.



### Risks

[List any risks that could arise from merging your pull request.]

- None

### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

- None


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
