### PR TITLE
Hide location action buttons unless user has permission to do the action

### DIFF
--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -186,10 +186,6 @@ class ProjectAdminCheckMixin(SuperUserCheckMixin):
         project = self.get_project()
         context['is_allowed_add_location'] = user.has_perm('spatial.create',
                                                            project)
-        context['is_allowed_update_location'] = user.has_perm('spatial.update',
-                                                              project)
-        context['is_allowed_delete_location'] = user.has_perm('spatial.delete',
-                                                              project)
         context['is_allowed_add_resource'] = user.has_perm('resource.add',
                                                            project)
         context['is_allowed_import'] = user.has_perm('project.import',

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -186,6 +186,10 @@ class ProjectAdminCheckMixin(SuperUserCheckMixin):
         project = self.get_project()
         context['is_allowed_add_location'] = user.has_perm('spatial.create',
                                                            project)
+        context['is_allowed_update_location'] = user.has_perm('spatial.update',
+                                                              project)
+        context['is_allowed_delete_location'] = user.has_perm('spatial.delete',
+                                                              project)
         context['is_allowed_add_resource'] = user.has_perm('resource.add',
                                                            project)
         context['is_allowed_import'] = user.has_perm('project.import',

--- a/cadasta/spatial/tests/test_views_default.py
+++ b/cadasta/spatial/tests/test_views_default.py
@@ -586,9 +586,7 @@ class LocationDeleteTest(ViewTestCase, UserTestCase, TestCase):
     def setup_template_context(self):
         return {'object': self.project,
                 'location': self.location,
-                'is_allowed_add_location': True,
-                'is_allowed_update_location': True,
-                'is_allowed_delete_location': True}
+                'is_allowed_add_location': True}
 
     def setup_url_kwargs(self):
         return {
@@ -702,9 +700,7 @@ class LocationResourceAddTest(ViewTestCase, UserTestCase, TestCase):
         return {'object': self.project,
                 'location': self.location,
                 'form': form,
-                'is_allowed_add_location': True,
-                'is_allowed_update_location': True,
-                'is_allowed_delete_location': True}
+                'is_allowed_add_location': True}
 
     def setup_url_kwargs(self):
         return {
@@ -826,9 +822,7 @@ class LocationResourceNewTest(ViewTestCase, UserTestCase,
         return {'object': self.project,
                 'location': self.location,
                 'form': form,
-                'is_allowed_add_location': True,
-                'is_allowed_update_location': True,
-                'is_allowed_delete_location': True}
+                'is_allowed_add_location': True}
 
     def setup_post_data(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
@@ -994,8 +988,6 @@ class TenureRelationshipAddTest(ViewTestCase, UserTestCase, TestCase):
                 },
             ),
             'is_allowed_add_location': True,
-            'is_allowed_update_location': True,
-            'is_allowed_delete_location': True,
         }
 
     def setup_url_kwargs(self):

--- a/cadasta/spatial/tests/test_views_default.py
+++ b/cadasta/spatial/tests/test_views_default.py
@@ -341,7 +341,9 @@ class LocationDetailTest(ViewTestCase, UserTestCase, TestCase):
             'attributes': (('Test field', 'test', ),
                            ('Test field 2', 'Choice 2', ),
                            ('Test field 3', 'Choice 1, Choice 3', )),
-            'is_allowed_add_location': True
+            'is_allowed_add_location': True,
+            'is_allowed_update_location': True,
+            'is_allowed_delete_location': True,
         }
 
     def setup_url_kwargs(self):
@@ -584,7 +586,9 @@ class LocationDeleteTest(ViewTestCase, UserTestCase, TestCase):
     def setup_template_context(self):
         return {'object': self.project,
                 'location': self.location,
-                'is_allowed_add_location': True}
+                'is_allowed_add_location': True,
+                'is_allowed_update_location': True,
+                'is_allowed_delete_location': True}
 
     def setup_url_kwargs(self):
         return {
@@ -698,7 +702,9 @@ class LocationResourceAddTest(ViewTestCase, UserTestCase, TestCase):
         return {'object': self.project,
                 'location': self.location,
                 'form': form,
-                'is_allowed_add_location': True}
+                'is_allowed_add_location': True,
+                'is_allowed_update_location': True,
+                'is_allowed_delete_location': True}
 
     def setup_url_kwargs(self):
         return {
@@ -820,7 +826,9 @@ class LocationResourceNewTest(ViewTestCase, UserTestCase,
         return {'object': self.project,
                 'location': self.location,
                 'form': form,
-                'is_allowed_add_location': True}
+                'is_allowed_add_location': True,
+                'is_allowed_update_location': True,
+                'is_allowed_delete_location': True}
 
     def setup_post_data(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
@@ -985,7 +993,9 @@ class TenureRelationshipAddTest(ViewTestCase, UserTestCase, TestCase):
                     'new_entity': not self.project.parties.exists(),
                 },
             ),
-            'is_allowed_add_location': True
+            'is_allowed_add_location': True,
+            'is_allowed_update_location': True,
+            'is_allowed_delete_location': True,
         }
 
     def setup_url_kwargs(self):

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -102,6 +102,13 @@ class LocationDetail(LoginPermissionRequiredMixin,
                 rel.type_labels = template_xlang_labels(
                     tenure_opts.get(rel.tenure_type_id))
 
+        location = context['location']
+        user = self.request.user
+        context['is_allowed_update_location'] = user.has_perm('spatial.update',
+                                                              location)
+        context['is_allowed_delete_location'] = user.has_perm('spatial.delete',
+                                                              location)
+
         return context
 
 

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -105,7 +105,7 @@ class LocationDetail(LoginPermissionRequiredMixin,
         location = context['location']
         user = self.request.user
         context['is_allowed_edit_location'] = user.has_perm('spatial.update',
-                                                              location)
+                                                            location)
         context['is_allowed_delete_location'] = user.has_perm('spatial.delete',
                                                               location)
 

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -104,7 +104,7 @@ class LocationDetail(LoginPermissionRequiredMixin,
 
         location = context['location']
         user = self.request.user
-        context['is_allowed_update_location'] = user.has_perm('spatial.update',
+        context['is_allowed_edit_location'] = user.has_perm('spatial.update',
                                                               location)
         context['is_allowed_delete_location'] = user.has_perm('spatial.delete',
                                                               location)

--- a/cadasta/templates/spatial/location_detail.html
+++ b/cadasta/templates/spatial/location_detail.html
@@ -12,8 +12,12 @@
       <h2 class="short"><span>{% trans "Location" %} </span>{{ location.name }}</h2>
       <div class="top-btn pull-right">
         <!-- Action buttons -->
-        <a class="btn btn-default btn-action btn-sm" href="{% url 'locations:edit' object.organization.slug object.slug location.id %}" title="{% trans 'Edit location' %}" aria-label="{% trans 'Edit location' %}"><span class="glyphicon glyphicon-pencil"></span></a>
-        <a class="btn btn-default btn-action btn-sm" href="{% url 'locations:delete' object.organization.slug object.slug location.id %}" title="{% trans 'Delete location' %}" aria-label="{% trans 'Delete location' %}"><span class="glyphicon glyphicon-trash"></span></a>
+        {% if is_allowed_update_location %}
+          <a class="btn btn-default btn-action btn-sm" href="{% url 'locations:edit' object.organization.slug object.slug location.id %}" title="{% trans 'Edit location' %}" aria-label="{% trans 'Edit location' %}"><span class="glyphicon glyphicon-pencil"></span></a>
+        {% endif %}
+        {% if is_allowed_delete_location %}
+          <a class="btn btn-default btn-action btn-sm" href="{% url 'locations:delete' object.organization.slug object.slug location.id %}" title="{% trans 'Delete location' %}" aria-label="{% trans 'Delete location' %}"><span class="glyphicon glyphicon-trash"></span></a>
+        {% endif %}
       </div>
     </div>
 

--- a/cadasta/templates/spatial/location_detail.html
+++ b/cadasta/templates/spatial/location_detail.html
@@ -12,7 +12,7 @@
       <h2 class="short"><span>{% trans "Location" %} </span>{{ location.name }}</h2>
       <div class="top-btn pull-right">
         <!-- Action buttons -->
-        {% if is_allowed_update_location %}
+        {% if is_allowed_edit_location %}
           <a class="btn btn-default btn-action btn-sm" href="{% url 'locations:edit' object.organization.slug object.slug location.id %}" title="{% trans 'Edit location' %}" aria-label="{% trans 'Edit location' %}"><span class="glyphicon glyphicon-pencil"></span></a>
         {% endif %}
         {% if is_allowed_delete_location %}


### PR DESCRIPTION
### Proposed changes in this pull request

Fix bug #1233: only show the location action buttons to users who have permission to do the action. 

Screenshot of location view for user without edit/delete permission: 
![user](https://cloud.githubusercontent.com/assets/16849118/23778332/8011fe3e-04ee-11e7-942f-515815ca8183.png)

Screenshot of location view for user with edit/delete permission: 
![admin](https://cloud.githubusercontent.com/assets/16849118/23778331/80113c7e-04ee-11e7-8683-2b2021a441ad.png)

### When should this PR be merged

No dependencies.

### Risks

None.

### Follow up actions

None.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
