### PR TITLE
Fix #946: Make usernames case insensitive

### DIFF
--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -8,6 +8,7 @@ from rest_framework.validators import UniqueValidator
 from djoser import serializers as djoser_serializers
 
 from .models import User
+from .validators import check_username_case_insensitive
 from .exceptions import EmailNotVerifiedError
 
 
@@ -35,6 +36,7 @@ class RegistrationSerializer(djoser_serializers.UserRegistrationSerializer):
         }
 
     def validate_username(self, username):
+        check_username_case_insensitive(username)
         if username.lower() in settings.CADASTA_INVALID_ENTITY_NAMES:
             raise ValidationError(
                 _("Username cannot be “add” or “new”."))
@@ -90,6 +92,8 @@ class UserSerializer(djoser_serializers.UserSerializer):
                 username != instance.username and
                     self.context['request'].user != instance):
                 raise ValidationError('Cannot update username')
+            if instance.username.casefold() != username.casefold():
+                check_username_case_insensitive(username)
         if username.lower() in settings.CADASTA_INVALID_ENTITY_NAMES:
             raise ValidationError(
                 _("Username cannot be “add” or “new”."))

--- a/cadasta/accounts/validators.py
+++ b/cadasta/accounts/validators.py
@@ -2,6 +2,7 @@ import string
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
+from .models import User
 
 DEFAULT_CHARACTER_TYPES = [
     string.ascii_lowercase,
@@ -47,3 +48,14 @@ class EmailSimilarityValidator(object):
         if len(email[0]) and email[0].casefold() in password.casefold():
             raise ValidationError(
                 _("Passwords cannot contain your email."))
+
+
+def check_username_case_insensitive(username):
+    usernames = [
+        u.casefold() for u in
+        User.objects.values_list('username', flat=True)
+    ]
+    if username.casefold() in usernames:
+        raise ValidationError(
+            _("A user with that username already exists")
+        )


### PR DESCRIPTION
### Proposed changes in this pull request

#### Fixes #946: Make usernames case insensitive

Currently, usernames are case sensitive. This PR makes username comparisons for account registration and profile updates case insensitive for both default and api views. New usernames and updates to existing usernames are checked for uniqueness against the full set of usernames using the `casefold` algorithm. Existing mixed-case usernames in the database remain untouched. 

- Add username comparisons using `casefold` to `RegisterForm` and `ProfileForm`.

- Add username comparisons using `casefold` to `RegistrationSerializer` and `UserSerializer`. 

- Added tests for the above changes.

### When should this PR be merged

Anytime.

### Risks

Low.

### Follow up actions

None required.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
