### PR TITLE
'All data' export option: Remove records that occur twice.

### DIFF
--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -489,15 +489,19 @@ class DownloadForm(forms.Form):
             path, mime = e.make_download(file_name + '-res')
         elif type == 'all':
             res_exporter = ResourceExporter(self.project)
+            xls_exporter = XLSExporter(self.project)
             shp_exporter = ShapeExporter(self.project)
-            res_path, _ = res_exporter.make_download(file_name + '-res')
-            path, mime = shp_exporter.make_download(file_name + '-shp')
-
+            path, mime = res_exporter.make_download(file_name + '-res')
+            data_path, _ = xls_exporter.make_download(file_name + '-xls')
+            shp_path, _ = shp_exporter.make_download(file_name + '-shp')
+            duplicates = ['locations.csv', 'parties.csv', 'relationships.csv.']
             with ZipFile(path, 'a') as myzip:
-                with ZipFile(res_path, 'r') as res_zip:
-                    for name in res_zip.namelist():
-                        myzip.writestr(name, res_zip.read(name))
-                    res_zip.close()
+                myzip.write(data_path, arcname='data.xlsx')
+                with ZipFile(shp_path, 'r') as shp_zip:
+                    for name in shp_zip.namelist():
+                        if name not in duplicates:
+                            myzip.writestr(name, shp_zip.read(name))
+                    shp_zip.close()
                 myzip.close()
 
         return path, mime

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -494,7 +494,7 @@ class DownloadForm(forms.Form):
             path, mime = res_exporter.make_download(file_name + '-res')
             data_path, _ = xls_exporter.make_download(file_name + '-xls')
             shp_path, _ = shp_exporter.make_download(file_name + '-shp')
-            duplicates = ['locations.csv', 'parties.csv', 'relationships.csv.']
+            duplicates = ['locations.csv', 'parties.csv', 'relationships.csv']
             with ZipFile(path, 'a') as myzip:
                 myzip.write(data_path, arcname='data.xlsx')
                 with ZipFile(shp_path, 'r') as shp_zip:

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -489,15 +489,15 @@ class DownloadForm(forms.Form):
             path, mime = e.make_download(file_name + '-res')
         elif type == 'all':
             res_exporter = ResourceExporter(self.project)
-            xls_exporter = XLSExporter(self.project)
             shp_exporter = ShapeExporter(self.project)
-            path, mime = res_exporter.make_download(file_name + '-res')
-            data_path, _ = xls_exporter.make_download(file_name + '-xls')
-            shp_path, _ = shp_exporter.make_download(file_name + '-shp')
+            res_path, _ = res_exporter.make_download(file_name + '-res')
+            path, mime = shp_exporter.make_download(file_name + '-shp')
 
             with ZipFile(path, 'a') as myzip:
-                myzip.write(data_path, arcname='data.xlsx')
-                myzip.write(shp_path, arcname='data-shp.zip')
+                with ZipFile(res_path, 'r') as res_zip:
+                    for name in res_zip.namelist():
+                        myzip.writestr(name, res_zip.read(name))
+                    res_zip.close()
                 myzip.close()
 
         return path, mime

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -1240,11 +1240,16 @@ class DownloadFormTest(UserTestCase, TestCase):
         assert mime == 'application/zip'
 
         with ZipFile(path, 'r') as testzip:
-            assert len(testzip.namelist()) == 4
+            assert len(testzip.namelist()) == 8
+            print(testzip.namelist)
             assert res.original_file in testzip.namelist()
             assert 'resources.xlsx' in testzip.namelist()
-            assert 'data.xlsx' in testzip.namelist()
-            assert 'data-shp.zip' in testzip.namelist()
+            assert 'locations.csv' in testzip.namelist()
+            assert 'README.txt' in testzip.namelist()
+            assert 'point.shx' in testzip.namelist()
+            assert 'point.shp' in testzip.namelist()
+            assert 'point.prj' in testzip.namelist()
+            assert 'point.dbf' in testzip.namelist()
 
 
 class SelectImportFormTest(UserTestCase, FileStorageTestCase, TestCase):

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -1241,10 +1241,9 @@ class DownloadFormTest(UserTestCase, TestCase):
 
         with ZipFile(path, 'r') as testzip:
             assert len(testzip.namelist()) == 8
-            print(testzip.namelist)
             assert res.original_file in testzip.namelist()
             assert 'resources.xlsx' in testzip.namelist()
-            assert 'locations.csv' in testzip.namelist()
+            assert 'data.xlsx' in testzip.namelist()
             assert 'README.txt' in testzip.namelist()
             assert 'point.shx' in testzip.namelist()
             assert 'point.shp' in testzip.namelist()


### PR DESCRIPTION

### Proposed changes in this pull request


This commit removes extra duplicate files that are downloaded when 
'all data' is downloaded.
Fix bug https://github.com/Cadasta/cadasta-platform/issues/923

### When should this PR be merged

Anytime

### Risks
None

### Follow up actions
None


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
