### PR TITLE
Bugfix/1303 Handling resources with same filename while exporting data

### DIFF
--- a/cadasta/organization/download/resources.py
+++ b/cadasta/organization/download/resources.py
@@ -56,7 +56,6 @@ class ResourceExporter():
 
         with ZipFile(path, 'a') as myzip:
             for r in resources:
-                res_data.append(self.pack_resource_data(r))
                 resource_name = r.original_file
                 filename, file_ext = os.path.splitext(resource_name)
                 if resource_name in files:
@@ -65,7 +64,9 @@ class ResourceExporter():
                 else:
                     files[resource_name] = 1
 
-                myzip.write(r.file.open().name, arcname=filename+file_ext)
+                r.original_file = filename + file_ext
+                res_data.append(self.pack_resource_data(r))
+                myzip.write(r.file.open().name, arcname=r.original_file)
 
             resources_xls = self.make_resource_worksheet(f_name, res_data)
             myzip.write(resources_xls, arcname='resources.xlsx')

--- a/cadasta/organization/download/resources.py
+++ b/cadasta/organization/download/resources.py
@@ -58,14 +58,14 @@ class ResourceExporter():
             for r in resources:
                 res_data.append(self.pack_resource_data(r))
                 resource_name = r.original_file
-                filename, file_extension = os.path.splitext(resource_name)
+                filename, file_ext = os.path.splitext(resource_name)
                 if resource_name in files:
                     filename += "_" + str(files[resource_name])
                     files[resource_name] += 1
                 else:
                     files[resource_name] = 1
 
-                myzip.write(r.file.open().name, arcname=filename+file_extension)
+                myzip.write(r.file.open().name, arcname=filename+file_ext)
 
             resources_xls = self.make_resource_worksheet(f_name, res_data)
             myzip.write(resources_xls, arcname='resources.xlsx')

--- a/cadasta/organization/download/resources.py
+++ b/cadasta/organization/download/resources.py
@@ -52,10 +52,20 @@ class ResourceExporter():
         resources = Resource.objects.filter(project=self.project)
         res_data = []
 
+        files = {}
+
         with ZipFile(path, 'a') as myzip:
             for r in resources:
                 res_data.append(self.pack_resource_data(r))
-                myzip.write(r.file.open().name, arcname=r.original_file)
+                resource_name = r.original_file
+                filename, file_extension = os.path.splitext(resource_name)
+                if resource_name in files:
+                    filename += "_" + str(files[resource_name])
+                    files[resource_name] += 1
+                else:
+                    files[resource_name] = 1
+
+                myzip.write(r.file.open().name, arcname=filename+file_extension)
 
             resources_xls = self.make_resource_worksheet(f_name, res_data)
             myzip.write(resources_xls, arcname='resources.xlsx')

--- a/cadasta/organization/tests/test_downloads.py
+++ b/cadasta/organization/tests/test_downloads.py
@@ -849,14 +849,19 @@ class ResourcesTest(UserTestCase, TestCase):
         project = ProjectFactory.create()
         exporter = ResourceExporter(project)
         res = ResourceFactory.create(project=project)
+        res2 = ResourceFactory.create(project=project)
 
         t = round(time.time() * 1000)
         path, mime = exporter.make_download('res-test-' + str(t))
         assert path == os.path.join(settings.MEDIA_ROOT,
                                     'temp/res-test-{}.zip'.format(t))
         assert mime == 'application/zip'
-
         with ZipFile(path, 'r') as testzip:
-            assert len(testzip.namelist()) == 2
-            assert res.original_file in testzip.namelist()
+            assert len(testzip.namelist()) == 3
+            assert res.original_file == res2.original_file
+            filename, file_ext = os.path.splitext(res.original_file)
+            original_name = "{}{}".format(filename, file_ext)
+            modified_dup_name = "{}_1{}".format(filename, file_ext)
+            assert original_name in testzip.namelist()
+            assert modified_dup_name in testzip.namelist()
             assert 'resources.xlsx' in testzip.namelist()


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #1303 
- Added incremental counter to file with duplicate names while exporting resources.
- Modified test case to validate the change works as expected.
![image](https://cloud.githubusercontent.com/assets/1060179/24067024/e990dadc-0b4d-11e7-8e2e-fa036c4aa2b7.png)

- Testing with input:
![image](https://cloud.githubusercontent.com/assets/1060179/24067070/7680c13c-0b4e-11e7-84ef-d3417ccad2c3.png)

- Ouput: Zip file contains resources with duplicate names with an incremental counter appened.
![image](https://cloud.githubusercontent.com/assets/1060179/24067061/614d0474-0b4e-11e7-8950-413277ce85c4.png)





### When should this PR be merged

- When possible

### Risks

- None

### Follow up actions

- None


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
