### PR TITLE
Rename resources to avoid deletion during download process

### DIFF
--- a/cadasta/organization/download/resources.py
+++ b/cadasta/organization/download/resources.py
@@ -53,12 +53,23 @@ class ResourceExporter():
             project=self.project,
             archived=False)
         res_data = []
+        file_names = dict()
+        file_names['resources.xlsx'] = 1
 
         with ZipFile(path, 'a') as myzip:
             for r in resources:
-                res_data.append(self.pack_resource_data(r))
-                myzip.write(r.file.open().name, arcname=r.original_file)
+                if r.original_file not in file_names:
+                    zip_fname = r.original_file
+                    file_names[r.original_file] = 1
+                else:
+                    name, ext = os.path.splitext(r.original_file)
+                    counter = str(file_names[r.original_file])
+                    zip_fname = '{}_{}{}'.format(name, counter, ext)
+                    file_names[r.original_file] += 1
+                    r.original_file = zip_fname
 
+                res_data.append(self.pack_resource_data(r))
+                myzip.write(r.file.open().name, arcname=zip_fname)
             resources_xls = self.make_resource_worksheet(f_name, res_data)
             myzip.write(resources_xls, arcname='resources.xlsx')
             myzip.close()

--- a/cadasta/organization/tests/test_downloads.py
+++ b/cadasta/organization/tests/test_downloads.py
@@ -862,8 +862,11 @@ class ResourcesTest(UserTestCase, TestCase):
         ensure_dirs()
         project = ProjectFactory.create()
         exporter = ResourceExporter(project)
-        res = ResourceFactory.create(project=project)
-        res2 = ResourceFactory.create(
+
+        ResourceFactory.create(project=project, original_file='res.png')
+        ResourceFactory.create(project=project, original_file='res.png')
+        ResourceFactory.create(project=project, original_file='resources.xlsx')
+        deleted = ResourceFactory.create(
             project=project,
             original_file='image1.jpg',
             archived=True)
@@ -875,7 +878,9 @@ class ResourcesTest(UserTestCase, TestCase):
         assert mime == 'application/zip'
 
         with ZipFile(path, 'r') as testzip:
-            assert len(testzip.namelist()) == 2
-            assert res.original_file in testzip.namelist()
-            assert res2.original_file not in testzip.namelist()
+            assert len(testzip.namelist()) == 4
+            assert 'res.png' in testzip.namelist()
+            assert 'res_1.png' in testzip.namelist()
+            assert 'resources_1.xlsx' in testzip.namelist()
             assert 'resources.xlsx' in testzip.namelist()
+            assert deleted.original_file not in testzip.namelist()


### PR DESCRIPTION
### Proposed changes in this pull request

- This commit makes changes so that duplicate resources don't get removed
when resources are downloaded.

- See issue: https://github.com/Cadasta/cadasta-platform/issues/1303 & https://github.com/Cadasta/cadasta-platform/issues/1302

### When should this PR be merged

Anytime

### Risks

None

### Follow up actions

None


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature** has the manual testing spreadsheet been updated with instructions for manual testing?


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
