### PR TITLE
Bugfix #1284: Assertion error at /api/v1/users/<user-name>/

### DIFF
--- a/cadasta/organization/tests/test_urls_api.py
+++ b/cadasta/organization/tests/test_urls_api.py
@@ -136,16 +136,19 @@ class ProjectUrlTest(TestCase):
 
 class UserUrlsTest(TestCase):
     def test_user_list(self):
-        assert (reverse(version_ns('user:list')) ==
-                version_url('/users/'))
+        actual = reverse(version_ns('user:list'))
+        expected = version_url('/users/')
+        assert actual == expected
 
         resolved = resolve(version_url('/users/'))
         assert resolved.func.__name__ == api.UserAdminList.__name__
 
     def test_user_detail(self):
-        assert (reverse(version_ns('user:detail'),
-                        kwargs={'username': 'user-name'}) ==
-                version_url('/users/user-name/'))
+        actual = reverse(version_ns('user:detail'),
+                        kwargs={'username': 'user-name'})
+
+        expected = version_url('/users/user-name/')
+        assert actual == expected
 
         resolved = resolve(version_url('/users/user-name/'))
         assert resolved.func.__name__ == api.UserAdminDetail.__name__

--- a/cadasta/organization/tests/test_urls_api.py
+++ b/cadasta/organization/tests/test_urls_api.py
@@ -132,3 +132,21 @@ class ProjectUrlTest(TestCase):
         assert resolved.kwargs['organization'] == 'habitat'
         assert resolved.kwargs['project'] == '123abc'
         assert resolved.kwargs['username'] == 'barbara-@+.'
+
+
+class UserUrlsTest(TestCase):
+    def test_user_list(self):
+        assert (reverse(version_ns('user:list')) ==
+                version_url('/users/'))
+
+        resolved = resolve(version_url('/users/'))
+        assert resolved.func.__name__ == api.UserAdminList.__name__
+
+    def test_user_detail(self):
+        assert (reverse(version_ns('user:detail'),
+                        kwargs={'username': 'user-name'}) ==
+                version_url('/users/user-name/'))
+
+        resolved = resolve(version_url('/users/user-name/'))
+        assert resolved.func.__name__ == api.UserAdminDetail.__name__
+        assert resolved.kwargs['username'] == 'user-name'

--- a/cadasta/organization/tests/test_urls_api.py
+++ b/cadasta/organization/tests/test_urls_api.py
@@ -145,7 +145,7 @@ class UserUrlsTest(TestCase):
 
     def test_user_detail(self):
         actual = reverse(version_ns('user:detail'),
-                        kwargs={'username': 'user-name'})
+                         kwargs={'username': 'user-name'})
 
         expected = version_url('/users/user-name/')
         assert actual == expected

--- a/cadasta/organization/urls/api/users.py
+++ b/cadasta/organization/urls/api/users.py
@@ -8,7 +8,7 @@ urlpatterns = [
         api.UserAdminList.as_view(),
         name='list'),
     url(
-        r'^(?P<slug>[-\w]+)/$',
+        r'^(?P<username>[-\w]+)/$',
         api.UserAdminDetail.as_view(),
         name='detail'),
 ]


### PR DESCRIPTION
### Proposed changes in this pull request

- Addressed Issue #1284 in this PR.
- Renamed url keyword of `organization/urls/api/users.py` from `slug` to `username`.

### When should this PR be merged

After reviews and passing of tests.

### Risks

- None

### Follow up actions

- None

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] ** Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] ** Are all UI and API inputs run through forms or serializers?** 
- [ ] ** Are all external inputs validated and sanitized appropriately?**
- [ ] ** Does all branching logic have a default case?**
- [ ] ** Does this solution handle outliers and edge cases gracefully?**
- [ ] ** Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
