### PR TITLE
Remove confirm password fields (resolves #1242)

### DIFF
--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -20,8 +20,7 @@ class RegisterFormTest(UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'password1': 'iloveyoko79!',
-            'password2': 'iloveyoko79!',
+            'password': 'iloveyoko79!',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
@@ -42,8 +41,7 @@ class RegisterFormTest(UserTestCase, TestCase):
             data = {
                 'username': user.username.lower(),
                 'email': '%s@beatles.uk' % user.username,
-                'password1': 'iloveyoko79!',
-                'password2': 'iloveyoko79!',
+                'password': 'iloveyoko79!',
                 'full_name': 'John Lennon',
             }
             form = forms.RegisterForm(data)
@@ -55,8 +53,7 @@ class RegisterFormTest(UserTestCase, TestCase):
         data = {
             'username': 'johnLennon',
             'email': 'john@beatles.uk',
-            'password1': 'iloveyoko79!',
-            'password2': 'iloveyoko79!',
+            'password': 'iloveyoko79!',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
@@ -64,99 +61,79 @@ class RegisterFormTest(UserTestCase, TestCase):
         assert (_("A user with that username already exists") in
                 form.errors.get('username'))
 
-    def test_passwords_do_not_match(self):
-        data = {
-            'username': 'imagine71',
-            'email': 'john@beatles.uk',
-            'password1': 'Iloveyoko79!',
-            'password2': 'Iloveyoko68!',
-            'full_name': 'John Lennon',
-        }
-        form = forms.RegisterForm(data)
-
-        assert form.is_valid() is False
-        assert _("Passwords do not match") in form.errors.get('password1')
-        assert User.objects.count() == 0
-
     def test_password_contains_username(self):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'password1': 'Letsimagine71things?',
-            'password2': 'Letsimagine71things?',
+            'password': 'Letsimagine71things?',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
 
         assert form.is_valid() is False
         assert (_("The password is too similar to the username.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
         assert User.objects.count() == 0
 
     def test_password_contains_username_case_insensitive(self):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'password1': 'LetsIMAGINE71things?',
-            'password2': 'LetsIMAGINE71things?',
+            'password': 'LetsIMAGINE71things?',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
 
         assert form.is_valid() is False
         assert (_("The password is too similar to the username.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
         assert User.objects.count() == 0
 
     def test_password_contains_blank_username(self):
         data = {
             'username': '',
             'email': 'john@beatles.uk',
-            'password1': 'Letsimagine71things?',
-            'password2': 'Letsimagine71things?',
+            'password': 'Letsimagine71things?',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
 
         assert form.is_valid() is False
-        assert (form.errors.get('password1') is None)
+        assert (form.errors.get('password') is None)
         assert User.objects.count() == 0
 
     def test_password_contains_email(self):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'password1': 'IsJOHNreallythebest34?',
-            'password2': 'IsJOHNreallythebest34?',
+            'password': 'IsJOHNreallythebest34?',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
 
         assert form.is_valid() is False
         assert (_("Passwords cannot contain your email.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
         assert User.objects.count() == 0
 
     def test_password_contains_blank_email(self):
         data = {
             'username': 'imagine71',
             'email': '',
-            'password1': 'Isjohnreallythebest34?',
-            'password2': 'Isjohnreallythebest34?',
+            'password': 'Isjohnreallythebest34?',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
 
         assert form.is_valid() is False
-        assert (form.errors.get('password1') is None)
+        assert (form.errors.get('password') is None)
         assert User.objects.count() == 0
 
     def test_password_contains_less_than_min_characters(self):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'password1': '<3yoko',
-            'password2': '<3yoko',
+            'password': '<3yoko',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
@@ -164,15 +141,14 @@ class RegisterFormTest(UserTestCase, TestCase):
         assert form.is_valid() is False
         assert (_("This password is too short."
                   " It must contain at least 10 characters.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
         assert User.objects.count() == 0
 
     def test_password_does_not_meet_unique_character_requirements(self):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'password1': 'yokoisjustthebest',
-            'password2': 'yokoisjustthebest',
+            'password': 'yokoisjustthebest',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
@@ -188,8 +164,7 @@ class RegisterFormTest(UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'password1': 'YOKOISJUSTTHEBEST',
-            'password2': 'YOKOISJUSTTHEBEST',
+            'password': 'YOKOISJUSTTHEBEST',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
@@ -207,8 +182,7 @@ class RegisterFormTest(UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'password1': 'iloveyoko79',
-            'password2': 'iloveyoko79',
+            'password': 'iloveyoko79',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
@@ -223,8 +197,7 @@ class RegisterFormTest(UserTestCase, TestCase):
         data = {
             'username': random.choice(invalid_usernames),
             'email': 'john@beatles.uk',
-            'password1': 'Iloveyoko68!',
-            'password2': 'Iloveyoko68!',
+            'password': 'Iloveyoko68!',
             'full_name': 'John Lennon',
         }
         form = forms.RegisterForm(data)
@@ -384,8 +357,7 @@ class ChangePasswordFormTest(UserTestCase, TestCase):
 
         data = {
             'oldpassword': 'beatles4Lyfe!',
-            'password1': 'iloveyoko79!',
-            'password2': 'iloveyoko79!',
+            'password': 'iloveyoko79!',
         }
 
         form = forms.ChangePasswordForm(user, data)
@@ -396,19 +368,19 @@ class ChangePasswordFormTest(UserTestCase, TestCase):
 
         assert user.check_password('iloveyoko79!') is True
 
-    def test_passwords_do_not_match(self):
-        user = UserFactory.create(password='beatles4Lyfe!')
+    def test_password_incorrect(self):
+        user = UserFactory.create(
+            password='beatles4Lyfe!', username='imagine71')
 
         data = {
-            'oldpassword': 'beatles4Lyfe!',
-            'password1': 'Iloveyoko79!',
-            'password2': 'Iloveyoko68!',
+            'oldpassword': 'th3m0nkeesRule!!',
+            'password': 'l3titb3333!',
         }
         form = forms.ChangePasswordForm(user, data)
 
         assert form.is_valid() is False
-        assert (_('You must type the same password each time.') in
-                form.errors.get('password2'))
+        assert (_("Please type your current password.") in
+                form.errors.get('oldpassword'))
 
     def test_password_contains_username(self):
         user = UserFactory.create(
@@ -416,14 +388,13 @@ class ChangePasswordFormTest(UserTestCase, TestCase):
 
         data = {
             'oldpassword': 'beatles4Lyfe!',
-            'password1': 'Letsimagine71?1234567890',
-            'password2': 'Letsimagine71?1234567890',
+            'password': 'Letsimagine71?1234567890',
         }
         form = forms.ChangePasswordForm(user, data)
 
         assert form.is_valid() is False
         assert (_("The password is too similar to the username.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
 
     def test_password_contains_username_case_insensitive(self):
         user = UserFactory.create(
@@ -431,14 +402,13 @@ class ChangePasswordFormTest(UserTestCase, TestCase):
 
         data = {
             'oldpassword': 'beatles4Lyfe!',
-            'password1': 'LetsIMAGINE71?1234567890',
-            'password2': 'LetsIMAGINE71?1234567890',
+            'password': 'LetsIMAGINE71?1234567890',
         }
         form = forms.ChangePasswordForm(user, data)
 
         assert form.is_valid() is False
         assert (_("The password is too similar to the username.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
 
     def test_password_contains_email(self):
         user = UserFactory.create(
@@ -446,37 +416,34 @@ class ChangePasswordFormTest(UserTestCase, TestCase):
 
         data = {
             'oldpassword': 'beatles4Lyfe!',
-            'password1': 'IsJOHNreallythebest34?',
-            'password2': 'IsJOHNreallythebest34?',
+            'password': 'IsJOHNreallythebest34?',
         }
         form = forms.ChangePasswordForm(user, data)
 
         assert form.is_valid() is False
         assert (_("Passwords cannot contain your email.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
 
     def test_password_contains_less_than_min_characters(self):
         user = UserFactory.create(password='beatles4Lyfe!')
 
         data = {
             'oldpassword': 'beatles4Lyfe!',
-            'password1': '<3yoko',
-            'password2': '<3yoko',
+            'password': '<3yoko',
         }
         form = forms.ChangePasswordForm(user, data)
 
         assert form.is_valid() is False
         assert (_("This password is too short."
                   " It must contain at least 10 characters.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
 
     def test_password_does_not_meet_unique_character_requirements(self):
         user = UserFactory.create(password='beatles4Lyfe!')
 
         data = {
             'oldpassword': 'beatles4Lyfe!',
-            'password1': 'YOKOISJUSTTHEBEST',
-            'password2': 'YOKOISJUSTTHEBEST',
+            'password': 'YOKOISJUSTTHEBEST',
         }
         form = forms.ChangePasswordForm(user, data)
 
@@ -491,14 +458,13 @@ class ChangePasswordFormTest(UserTestCase, TestCase):
         user = UserFactory.create(password='beatles4Lyfe!', change_pw=False)
         data = {
             'oldpassword': 'beatles4Lyfe!',
-            'password1': 'iloveyoko79!',
-            'password2': 'iloveyoko79!',
+            'password': 'iloveyoko79!',
         }
         form = forms.ChangePasswordForm(user, data)
 
         assert form.is_valid() is False
         assert (_("The password for this user can not be changed.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
 
 
 class ResetPasswordKeyFormTest(UserTestCase, TestCase):
@@ -506,8 +472,7 @@ class ResetPasswordKeyFormTest(UserTestCase, TestCase):
         user = UserFactory.create(password='beatles4Lyfe!')
 
         data = {
-            'password1': 'iloveyoko79!',
-            'password2': 'iloveyoko79!',
+            'password': 'iloveyoko79!',
         }
 
         form = forms.ResetPasswordKeyForm(data, user=user)
@@ -519,81 +484,63 @@ class ResetPasswordKeyFormTest(UserTestCase, TestCase):
 
         assert user.check_password('iloveyoko79!') is True
 
-    def test_passwords_do_not_match(self):
-        user = UserFactory.create(password='beatles4Lyfe!')
-
-        data = {
-            'password1': 'Iloveyoko79!',
-            'password2': 'Iloveyoko68!',
-        }
-        form = forms.ResetPasswordKeyForm(data, user=user)
-
-        assert form.is_valid() is False
-        assert (_('You must type the same password each time.') in
-                form.errors.get('password2'))
-
     def test_password_contains_username(self):
         user = UserFactory.create(
             password='beatles4Lyfe!', username='imagine71')
 
         data = {
-            'password1': 'Letsimagine71?1234567890',
-            'password2': 'Letsimagine71?1234567890',
+            'password': 'Letsimagine71?1234567890',
         }
         form = forms.ResetPasswordKeyForm(data, user=user)
 
         assert form.is_valid() is False
         assert (_("The password is too similar to the username.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
 
     def test_password_contains_username_case_insensitive(self):
         user = UserFactory.create(
             password='beatles4Lyfe!', username='imagine71')
 
         data = {
-            'password1': 'LetsIMAGINE71?1234567890',
-            'password2': 'LetsIMAGINE71?1234567890',
+            'password': 'LetsIMAGINE71?1234567890',
         }
         form = forms.ResetPasswordKeyForm(data, user=user)
 
         assert form.is_valid() is False
         assert (_("The password is too similar to the username.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
 
     def test_password_contains_email(self):
         user = UserFactory.create(
             password='beatles4Lyfe!', email='john@thebeatles.uk')
 
         data = {
-            'password1': 'IsJOHNreallythebest34?',
-            'password2': 'IsJOHNreallythebest34?',
+            'password': 'IsJOHNreallythebest34?',
         }
         form = forms.ResetPasswordKeyForm(data, user=user)
 
         assert form.is_valid() is False
         assert (_("Passwords cannot contain your email.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
 
     def test_password_contains_less_than_min_characters(self):
         user = UserFactory.create(password='beatles4Lyfe!')
 
         data = {
-            'password1': '<3yoko',
-            'password2': '<3yoko',
+            'password': '<3yoko',
         }
         form = forms.ResetPasswordKeyForm(data, user=user)
 
         assert form.is_valid() is False
         assert (_("This password is too short."
                   " It must contain at least 10 characters.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
 
     def test_password_does_not_meet_unique_character_requirements(self):
         user = UserFactory.create(password='beatles4Lyfe!')
 
         data = {
-            'password1': 'YOKOISJUSTTHEBEST',
-            'password2': 'YOKOISJUSTTHEBEST',
+            'password': 'YOKOISJUSTTHEBEST',
         }
         form = forms.ResetPasswordKeyForm(data, user=user)
 
@@ -607,14 +554,13 @@ class ResetPasswordKeyFormTest(UserTestCase, TestCase):
     def test_user_not_allowed_change_password(self):
         user = UserFactory.create(password='beatles4Lyfe!', change_pw=False)
         data = {
-            'password1': 'iloveyoko79!',
-            'password2': 'iloveyoko79!',
+            'password': 'iloveyoko79!',
         }
         form = forms.ResetPasswordKeyForm(data, user=user)
 
         assert form.is_valid() is False
         assert (_("The password for this user can not be changed.") in
-                form.errors.get('password1'))
+                form.errors.get('password'))
 
 
 class ResetPasswordFormTest(UserTestCase, TestCase):

--- a/cadasta/accounts/tests/test_views_default.py
+++ b/cadasta/accounts/tests/test_views_default.py
@@ -79,8 +79,7 @@ class PasswordChangeTest(ViewTestCase, UserTestCase, TestCase):
     def test_password_change(self):
         self.user = UserFactory.create(password='Noonewillguess!')
         data = {'oldpassword': 'Noonewillguess!',
-                'password1': 'Someonemightguess?',
-                'password2': 'Someonemightguess?'}
+                'password': 'Someonemightguess?'}
         response = self.request(method='POST', post_data=data, user=self.user)
 
         assert response.status_code == 302

--- a/cadasta/templates/allauth/account/password_change.html
+++ b/cadasta/templates/allauth/account/password_change.html
@@ -32,10 +32,10 @@
         </a>
      </div>
     </div>
-  <div class="form-group{% if form.password1.errors %} has-error{% endif %}">
-    <label class="control-label" for="id_password1">{% trans "Enter a new password" %}</label>
+  <div class="form-group{% if form.password.errors %} has-error{% endif %}">
+    <label class="control-label" for="id_password">{% trans "Enter a new password" %}</label>
     <div class="input-group input-group-lg">
-      {% render_field form.password1 class+="form-control" placeholder="" data-parsley-required="true" data-parsley-minlength="10" data-parsley-character="3" data-parsley-userfield="1" data-parsley-emailfield="1" %}
+      {% render_field form.password class+="form-control" placeholder="" data-parsley-required="true" data-parsley-minlength="10" data-parsley-character="3" data-parsley-userfield="1" data-parsley-emailfield="1" %}
       <span class="input-group-btn">
         <button class="btn" type="button">
           <span class="glyphicon glyphicon-eye-close" aria-hidden="true"></span>
@@ -43,20 +43,7 @@
       </span>
     </div>
     <p class="help-block small">{% trans "Passwords must have a minimum of 10 characters and contain at least 3 of the following: lowercase characters, uppercase characters, special characters, and/or numerical characters.  Passwords cannot contain the username or email address." %}</p>
-    <div class="error-block">{{ form.password1.errors }}</div>
-  </div>
-
-  <div class="form-group{% if form.password2.errors %} has-error{% endif %}">
-    <label class="control-label" for="id_password2">{% trans "Confirm the new password" %}</label>
-    <div class="input-group input-group-lg">
-      {% render_field form.password2 class+="form-control" placeholder="" data-parsley-required="true" data-parsley-equalto="#id_password1" %}
-      <span class="input-group-btn">
-        <button class="btn" type="button">
-          <span class="glyphicon glyphicon-eye-close" aria-hidden="true"></span>
-        </button>
-      </span>
-    </div>
-    <div class="error-block">{{ form.password2.errors }}</div>
+    <div class="error-block">{{ form.password.errors }}</div>
   </div>
 
   <button type="submit" name="action"

--- a/cadasta/templates/allauth/account/password_reset_from_key.html
+++ b/cadasta/templates/allauth/account/password_reset_from_key.html
@@ -22,10 +22,10 @@
             <form method="POST" action="." data-parsley-validate>
                 {% csrf_token %}
 
-                <div class="form-group{% if form.password1.errors %} has-error{% endif %}">
-                    <label class="control-label" for="id_password1">{% trans "Enter a new password" %}</label>
+                <div class="form-group{% if form.password.errors %} has-error{% endif %}">
+                    <label class="control-label" for="id_password">{% trans "Enter a new password" %}</label>
                     <div class="input-group input-group-lg">
-                        {% render_field form.password1 class+="form-control" placeholder="" data-parsley-required="true" data-parsley-minlength="10" data-parsley-character="3" data-parsley-userfield="1" data-parsley-emailfield="1" %}
+                        {% render_field form.password class+="form-control" placeholder="" data-parsley-required="true" data-parsley-minlength="10" data-parsley-character="3" data-parsley-userfield="1" data-parsley-emailfield="1" %}
                         <span class="input-group-btn">
                             <button class="btn" type="button">
                                 <span class="glyphicon glyphicon-eye-close" aria-hidden="true"></span>
@@ -33,20 +33,7 @@
                         </span>
                     </div>
                     <p class="help-block small">{% trans "Passwords must have a minimum of 10 characters and contain at least 3 of the following: lowercase characters, uppercase characters, special characters, and/or numerical characters.  Passwords cannot contain the username or email address." %}</p>
-                    <div class="error-block">{{ form.password1.errors }}</div>
-                </div>
-
-                <div class="form-group{% if form.password2.errors %} has-error{% endif %}">
-                    <label class="control-label" for="id_password2">{% trans "Confirm the new password" %}</label>
-                    <div class="input-group input-group-lg">
-                        {% render_field form.password2 class+="form-control" placeholder="" data-parsley-required="true" data-parsley-equalto="#id_password1" %}
-                        <span class="input-group-btn">
-                            <button class="btn" type="button">
-                                <span class="glyphicon glyphicon-eye-close" aria-hidden="true"></span>
-                            </button>
-                        </span>
-                    </div>
-                    <div class="error-block">{{ form.password2.errors }}</div>
+                    <div class="error-block">{{ form.password.errors }}</div>
                 </div>
 
                 <input class="btn btn-primary btn-lg btn-block text-uppercase" type="submit" name="action" value="{% trans 'Change password' %}"/>

--- a/cadasta/templates/allauth/account/signup.html
+++ b/cadasta/templates/allauth/account/signup.html
@@ -12,7 +12,7 @@
 {% block extra_script %}
 <script type="text/javascript">
   $(document).ready(function() {
-    $("input[name='password1']").on('focus', function() {
+    $("input[name='password']").on('focus', function() {
       $(this).parent().next(".help-block").removeClass("hidden");
     });
   });
@@ -56,10 +56,10 @@
     <div class="error-block">{{ form.email.errors }}</div>
   </div>
 
-  <div class="form-group{% if form.password1.errors %} has-error{% endif %}">
-    <label class="control-label" for="id_password1">{% trans "Password" %}</label>
+  <div class="form-group{% if form.password.errors %} has-error{% endif %}">
+    <label class="control-label" for="id_password">{% trans "Password" %}</label>
     <div class="input-group input-group-lg">
-      {% render_field form.password1 class+="form-control" data-parsley-minlength="10" data-parsley-character="3" data-parsley-userfield="1" data-parsley-emailfield="1" %}
+      {% render_field form.password class+="form-control" data-parsley-minlength="10" data-parsley-character="3" data-parsley-userfield="1" data-parsley-emailfield="1" %}
       <span class="input-group-btn">
         <button class="btn" type="button">
           <span class="glyphicon glyphicon-eye-close" aria-hidden="true"></span>
@@ -67,20 +67,7 @@
       </span>
     </div>
     <p class="help-block small hidden">{% trans "Passwords must have a minimum of 10 characters and contain at least 3 of the following: lowercase characters, uppercase characters, special characters, and/or numerical characters.  Passwords cannot contain the username or email address." %}</p>
-    <div class="error-block">{{ form.password1.errors }}</div>
-  </div>
-
-  <div class="form-group{% if form.password2.errors %} has-error{% endif %}">
-    <label class="control-label" for="id_password2">{% trans "Confirm password" %}</label>
-    <div class="input-group input-group-lg">
-      {% render_field form.password2 class+="form-control" data-parsley-equalto="#id_password1" %}
-      <span class="input-group-btn">
-        <button class="btn" type="button">
-          <span class="glyphicon glyphicon-eye-close" aria-hidden="true"></span>
-        </button>
-      </span>
-    </div>
-    <div class="error-block">{{ form.password2.errors }}</div>
+    <div class="error-block">{{ form.password.errors }}</div>
   </div>
 
   <div class="form-group{% if form.full_name.errors %} has-error{% endif %}">

--- a/functional_tests/accounts/test_registration.py
+++ b/functional_tests/accounts/test_registration.py
@@ -26,35 +26,24 @@ class RegistrationTest(FunctionalTest):
         fields = page.get_fields()
 
         # Try to submit an empty form and check for validation errors.
-        page.try_submit(err=['username', 'email', 'password1', 'password2'])
+        page.try_submit(err=['username', 'email', 'password'])
 
         # Fill in required fields one by one, try to submit and check
         # for errors.
         fields = page.get_fields()
         fields['username'].send_keys('user3')
-        page.try_submit(err=['email', 'password1', 'password2'],
+        page.try_submit(err=['email', 'password'],
                         ok=['username'],)
         fields = page.get_fields()
         fields['email'].send_keys('user3@example.net')
-        page.try_submit(err=['password1', 'password2'],
+        page.try_submit(err=['password'],
                         ok=['username', 'email'],)
-        fields = page.get_fields()
-        fields['password1'].send_keys('very_secret')
-        page.try_submit(err=['password2'],
-                        ok=['username', 'email', 'password1'],)
-        fields = page.get_fields()
-        fields['password2'].send_keys('not_very_secret')
-        page.try_submit(err=['password2'],
-                        ok=['username', 'email', 'password1'],
-                        message='This value should be the same.')
 
         # Fill in extra fields, fill in final required form and submit
         fields = page.get_fields()
         fields['full_name'].send_keys('User Three')
-        fields['password1'].clear()
-        fields['password1'].send_keys('very_secret')
-        fields['password2'].clear()
-        fields['password2'].send_keys('very_secret')
+        fields['password'].clear()
+        fields['password'].send_keys('very_secret')
         self.click_through(fields['register'], self.BY_DASHBOARD)
         self.assert_has_message('alert', "signed in")
 
@@ -80,11 +69,10 @@ class RegistrationTest(FunctionalTest):
 
         fields['username'].send_keys(self.test_data['users'][0]['username'])
         fields['email'].send_keys('b@lah.net')
-        fields['password1'].send_keys('password123')
-        fields['password2'].send_keys('password123')
+        fields['password'].send_keys('password123')
         fields['full_name'].send_keys('Jane Doe')
         page.try_submit(err=['username'],
-                        ok=['email', 'password1', 'password2',
+                        ok=['email', 'password',
                             'full_name'],
                         message='A user with that username already exists.')
         assert page.is_on_page()

--- a/functional_tests/pages/Registration.py
+++ b/functional_tests/pages/Registration.py
@@ -31,10 +31,7 @@ class RegistrationPage(Page):
         return self.get_form_field("input[@name='email']")
 
     def get_password_input(self):
-        return self.get_form_field("input[@name='password1']")
-
-    def get_password_repeat_input(self):
-        return self.get_form_field("input[@name='password2']")
+        return self.get_form_field("input[@name='password']")
 
     def get_full_name_input(self):
         return self.get_form_field("input[@name='full_name']")
@@ -46,9 +43,8 @@ class RegistrationPage(Page):
         return {
             'username':   self.get_username_input(),
             'email':      self.get_email_input(),
-            'password1':  self.get_password_input(),
-            'password2':  self.get_password_repeat_input(),
-            'full_name': self.get_full_name_input(),
+            'password':   self.get_password_input(),
+            'full_name':  self.get_full_name_input(),
             'register':   self.get_register_button()
         }
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR resolves #1242.  The logic to be enforced:

- If you're creating a password, you shouldn't be required to enter it twice. Instead, you should be able to unmask the single `password` field.
- If you're entering an existing password, you should not be able to unmask the password field.

Actions to make this so:

- Remove second password field on the following forms:
  - Registration View: `/account/signup/`
  - Reset Password From Key View: `/account/password/reset/key/<key>/`
  - Change Password View: `/account/password/change`

Both the `allauth` [`ChangePasswordForm`](https://github.com/pennersr/django-allauth/blob/9e36f1dcf1938277334621b82052c1c505614b8f/allauth/account/forms.py#L365-L387) and the [`ResetPasswordKeyForm`](https://github.com/pennersr/django-allauth/blob/9e36f1dcf1938277334621b82052c1c505614b8f/allauth/account/forms.py#L471-L492) that were subclassed from in `accounts.forms` assumed that there would be a second password verification field, meaning that we could not use those forms as base classes.

My understanding was that the Login View (`/account/login/`) required no changes.

### When should this PR be merged

No blocking dependencies from my vantage-point.


### Risks

- I am not familiar with all of the `*.po`, I'm guessing they're automatically generated?  Do they need to be updated when making changes to view code?
- **I have not actually run the functional tests**. I did my best to get them to a place where I felt that they would pass but **please let me know how to run the functional tests** so that I may verify this.

### Follow up actions

I recommend reviewers try out the various password reset flows.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] ** Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] ** Are all UI and API inputs run through forms or serializers?** 
- [ ] ** Are all external inputs validated and sanitized appropriately?**
- [ ] ** Does all branching logic have a default case?**
- [ ] ** Does this solution handle outliers and edge cases gracefully?**
- [ ] ** Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 