### PR TITLE
Bugfix #1322: Resources uploaded via API do not display image preview.

### DIFF
--- a/cadasta/resources/serializers.py
+++ b/cadasta/resources/serializers.py
@@ -2,10 +2,7 @@ import json
 from buckets.serializers import S3Field
 from django.utils.translation import ugettext as _
 from rest_framework import serializers
-import os
-from django.conf import settings
-import magic
-from urllib.request import urlretrieve
+import mimetypes
 
 from .models import ContentObject, Resource, SpatialResource
 
@@ -44,21 +41,7 @@ class ResourceSerializer(serializers.ModelSerializer):
             return self.resource
         else:
             file_url = validated_data['file']
-            file_name = file_url.split("/")[-1]
-            file_path = os.path.join(settings.MEDIA_ROOT,
-                                     's3/uploads/resources/',
-                                     file_name)
-
-            file_path, headers = urlretrieve(file_url, file_path)
-            mime_type_headers = headers.get_content_type()
-
-            mime = magic.Magic(mime=True)
-            mime_type_magic = str(mime.from_file(file_path), 'utf-8')
-
-            if mime_type_magic == mime_type_headers:
-                mime_type = mime_type_magic
-            else:
-                raise serializers.ValidationError(_("Invalid file type"))
+            mime_type = mimetypes.MimeTypes().guess_type(file_url)
 
             return Resource.objects.create(
                 content_object=self.context['content_object'],


### PR DESCRIPTION
### Proposed changes in this pull request

Addressed Issue #1322 in this PR.

- Every _Resource_ object created by uploading via API was missing thumbnail preview because of  missing _mime_type_  attribute while creation. 
- I have modified `create` method of `ResourceSerializer` class of `resource/serializers.py` by testing the mime_type of uploaded file using type identification library `magic`.  

### When should this PR be merged

After reviews and after this PR passes tests.
can merge this pull request.

### Risks

- None

### Follow up actions

- None

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] ** Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] ** Are all UI and API inputs run through forms or serializers?** 
- [ ] ** Are all external inputs validated and sanitized appropriately?**
- [ ] ** Does all branching logic have a default case?**
- [ ] ** Does this solution handle outliers and edge cases gracefully?**
- [ ] ** Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
