### PR TITLE
Bugfix/#1113

### DIFF
--- a/cadasta/organization/download/base.py
+++ b/cadasta/organization/download/base.py
@@ -17,9 +17,14 @@ class Exporter(SchemaSelectorMixin):
     def get_values(self, item, model_attrs, schema_attrs):
         values = OrderedDict()
         for attr in model_attrs:
+
+            if attr.split('.')[0] == 'geometry' and not item.geometry:
+                values[attr] = None
+                continue
+
             value = item
             for a in attr.split('.'):
-                value = getattr(value, a, None)
+                value = getattr(value, a)
             values[attr] = value
 
         content_type = ContentType.objects.get_for_model(item)

--- a/cadasta/organization/download/base.py
+++ b/cadasta/organization/download/base.py
@@ -17,15 +17,10 @@ class Exporter(SchemaSelectorMixin):
     def get_values(self, item, model_attrs, schema_attrs):
         values = OrderedDict()
         for attr in model_attrs:
-            if '.' in attr:
-                attr_items = attr.split('.')
-                value = None
-                for a in attr_items:
-                    value = (getattr(item, a)
-                             if not value else getattr(value, a))
-                values[attr] = value
-            else:
-                values[attr] = getattr(item, attr)
+            value = item
+            for a in attr.split('.'):
+                value = getattr(value, a, None)
+            values[attr] = value
 
         content_type = ContentType.objects.get_for_model(item)
         conditional_selector = self.get_conditional_selector(content_type)

--- a/cadasta/organization/importers/base.py
+++ b/cadasta/organization/importers/base.py
@@ -221,6 +221,9 @@ class Importer(SchemaSelectorMixin):
         if spatial_ct:
             try:
                 spatial_unit_id = row[headers.index(s_id)]
+            except ValueError:
+                su = SpatialUnit.objects.create(**spatial_ct)
+            else:
                 if spatial_unit_id:
                     created_su_id = self._locations_created.get(
                         spatial_unit_id, None
@@ -233,12 +236,13 @@ class Importer(SchemaSelectorMixin):
                 else:
                     su = SpatialUnit.objects.create(**spatial_ct)
                     self._locations_created[spatial_unit_id] = su.pk
-            except ValueError:
-                su = SpatialUnit.objects.create(**spatial_ct)
 
         if party_ct:
             try:
                 party_id = row[headers.index(p_id)]
+            except ValueError:
+                party = Party.objects.create(**party_ct)
+            else:
                 if party_id:
                     created_party_id = self._parties_created.get(
                         party_id, None)
@@ -250,8 +254,6 @@ class Importer(SchemaSelectorMixin):
                 else:
                     party = Party.objects.create(**party_ct)
                     self._parties_created[party_id] = party.pk
-            except ValueError:
-                party = Party.objects.create(**party_ct)
 
         if party_ct and spatial_ct:
             tt = TenureRelationshipType.objects.get(id=tenure_type)

--- a/cadasta/organization/importers/validators.py
+++ b/cadasta/organization/importers/validators.py
@@ -43,7 +43,7 @@ def validate_row(headers, row, config):
         else:
             try:
                 geometry = GEOSGeometry(coords)
-            except:
+            except ValueError:
                 try:
                     geometry = GEOSGeometry(odk_geom_to_wkt(coords))
                 except InvalidODKGeometryError:

--- a/cadasta/organization/importers/validators.py
+++ b/cadasta/organization/importers/validators.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.geos import GEOSGeometry, GEOSException
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
@@ -43,7 +43,7 @@ def validate_row(headers, row, config):
         else:
             try:
                 geometry = GEOSGeometry(coords)
-            except ValueError:
+            except (ValueError, GEOSException):
                 try:
                     geometry = GEOSGeometry(odk_geom_to_wkt(coords))
                 except InvalidODKGeometryError:

--- a/cadasta/organization/tests/test_downloads.py
+++ b/cadasta/organization/tests/test_downloads.py
@@ -110,14 +110,17 @@ class BaseExporterTest(UserTestCase, TestCase):
                                                     'key_2': ['choice_1',
                                                               'choice_2']})
         model_attrs = ('id', 'party_id', 'spatial_unit_id',
-                       'tenure_type.label')
+                       'tenure_type.label', 'missing_attr',
+                       'spatial_unit_id.missing_nested')
         schema_attrs = exporter.get_schema_attrs(content_type)
         values = exporter.get_values(item, model_attrs, schema_attrs)
         assert values == {
             'id': item.id, 'party_id': item.party_id,
             'spatial_unit_id': item.spatial_unit_id,
             'tenure_type.label': 'Leasehold',
-            'key': 'text', 'key_2': 'choice_1, choice_2'}
+            'key': 'text', 'key_2': 'choice_1, choice_2',
+            'missing_attr': None, 'spatial_unit_id.missing_nested': None
+        }
 
     def test_get_values_with_conditional_selector(self):
         project = ProjectFactory.create(current_questionnaire='123abc')

--- a/cadasta/organization/tests/test_downloads.py
+++ b/cadasta/organization/tests/test_downloads.py
@@ -110,8 +110,7 @@ class BaseExporterTest(UserTestCase, TestCase):
                                                     'key_2': ['choice_1',
                                                               'choice_2']})
         model_attrs = ('id', 'party_id', 'spatial_unit_id',
-                       'tenure_type.label', 'missing_attr',
-                       'spatial_unit_id.missing_nested')
+                       'tenure_type.label')
         schema_attrs = exporter.get_schema_attrs(content_type)
         values = exporter.get_values(item, model_attrs, schema_attrs)
         assert values == {
@@ -119,8 +118,21 @@ class BaseExporterTest(UserTestCase, TestCase):
             'spatial_unit_id': item.spatial_unit_id,
             'tenure_type.label': 'Leasehold',
             'key': 'text', 'key_2': 'choice_1, choice_2',
-            'missing_attr': None, 'spatial_unit_id.missing_nested': None
         }
+
+
+    def test_get_values_null_geom(self):
+        project = ProjectFactory.create(current_questionnaire='123abc')
+        exporter = Exporter(project)
+        item = SpatialUnitFactory.create(
+            project=project,
+            geometry=None)
+        content_type = ContentType.objects.get(app_label='spatial',
+                                               model='spatialunit')
+        model_attrs = ('id', 'geometry.wkt')
+        schema_attrs = exporter.get_schema_attrs(content_type)
+        values = exporter.get_values(item, model_attrs, schema_attrs)
+        assert values == {'id': item.id, 'geometry.wkt': None}
 
     def test_get_values_with_conditional_selector(self):
         project = ProjectFactory.create(current_questionnaire='123abc')

--- a/cadasta/organization/tests/test_downloads.py
+++ b/cadasta/organization/tests/test_downloads.py
@@ -120,7 +120,6 @@ class BaseExporterTest(UserTestCase, TestCase):
             'key': 'text', 'key_2': 'choice_1, choice_2',
         }
 
-
     def test_get_values_null_geom(self):
         project = ProjectFactory.create(current_questionnaire='123abc')
         exporter = Exporter(project)

--- a/cadasta/organization/tests/test_importers.py
+++ b/cadasta/organization/tests/test_importers.py
@@ -170,6 +170,18 @@ class ImportValidatorTest(TestCase):
                 headers, row, config)
         assert e.value.message == "Invalid geometry."
 
+    def test_validate_empty_geometry(self):
+        config = {
+            'party_type_field': 'party_type',
+            'geometry_field': 'location_geometry',
+            'type': 'csv'
+        }
+        geometry = 'POLYGON EMPTY'
+        headers = ['party_type', 'location_geometry']
+        row = ['IN', geometry]
+        _, _, geo, _, _ = validators.validate_row(headers, row, config)
+        assert geo.empty is True
+
     def test_validate_location_type_choice(self):
         config = {
             'party_name_field': 'party_name',

--- a/cadasta/spatial/tests/test_models.py
+++ b/cadasta/spatial/tests/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 
+from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from jsonattrs.models import Attribute, AttributeType, Schema
@@ -43,6 +44,28 @@ class SpatialUnitTest(UserTestCase, TestCase):
             '11.36667 47.28333, '
             '11.36667 47.25000))')
         assert spatial_unit.geometry is not None
+
+    def test_empty_geometries(self):
+        geoms = (
+            "POINT EMPTY",
+            # "POLYGON EMPTY",  # Uncomment after Django 1.11 or libgeos 3.6.1
+            "LINESTRING EMPTY",
+            "MULTIPOINT EMPTY",
+            "MULTILINESTRING EMPTY",
+            "MULTIPOLYGON EMPTY",
+            "GEOMETRYCOLLECTION EMPTY",
+        )
+        for geom in geoms:
+            spatial_unit = SpatialUnitFactory.create(
+                geometry=GEOSGeometry(geom))
+            assert spatial_unit.geometry.wkt == geom
+
+    def test_empty_geometry(self):
+        # Temp workaround where 'POLYGON EMPTY' is cast to None. Should
+        # be removed when Django is 1.11+ or libgeos is 3.6.1+
+        spatial_unit = SpatialUnitFactory.create(
+            geometry=GEOSGeometry('POLYGON EMPTY'))
+        assert spatial_unit.geometry is None
 
     def test_reassign_extent(self):
         spatial_unit = SpatialUnitFactory.create(


### PR DESCRIPTION
### Proposed changes in this pull request

The core idea of this PR was to resolve #1113, supporting the upload of empty spatial data.  We already support the idea of `SpatialUnit` instances with `geometry` values of `None`, however our system throws an error when WKT representing empty AKA none data is uploaded (e.g. `POLYGON EMPTY`).

The initial fix is simple: don't run `reassign_spatial_geometry()` on the `SpatialUnit` instance in the `pre_save` signal handler if the instance has an empty `geometry` (checked via `geometry.empty == True`).

However, when making this so I ran into [a bug where `libgeos` fails to serialize WKT of `POLYGON EMPTY` into the correct EWKB format](https://trac.osgeo.org/geos/ticket/680) (used by PostGIS). This bug has been fixed in `libgeos` version `3.6.1`, however we're using `3.4.2` (installed automatically via `apt-get` as a dependency of `libgdal-dev`). Django `1.11` will have [a fix to work around this issue](https://github.com/django/django/commit/b90d72facf1e4294df1c2e6b51b26f6879bf2992#diff-181a3ea304dfaf57f1e1d680b32d2b76R248), however that version is still in release-candidate state and we're using `1.10.4`. To work around this, I've put in a hacky solution of overwriting an empty `Polygon` instance with `None` in the `SpatialUnit` `pre_save` handler (mimicking the logic used in the `1.11` work-around).

We could store any empty geometries as `None`, however I prefer to keep data as close to its initially uploaded data as possible.  If others disagree with this rationale, feel free to let me know.  Running the following code, I was able to determine which `WKT` had supported empty values:

```
from django.contrib.gis.geos import GEOSGeometry


types = (
    "Geometry",
    "Point",
    "LineString",
    "Polygon",
    "MultiPoint",
    "MultiLineString",
    "MultiPolygon",
    "GeometryCollection",
    "CircularString",
    "CompoundCurve",
    "CurvePolygon",
    "MultiCurve",
    "MultiSurface",
    "Curve",
    "Surface",
    "PolyhedralSurface",
    "TIN",
    "Triangle",
)

SUCCESS = []
FAIL = []
p_id = Project.objects.first().id
for t in types:
    empty_str = '{} EMPTY'.format(t.upper())
    try:
        geo = GEOSGeometry(empty_str)
    except Exception as e:
        FAIL.append("{}: Failed to instantiate".format(empty_str))
        continue

    try:
        su = SpatialUnit.objects.create(geometry=geo, project_id=p_id)
        SUCCESS.append("{}: {}".format(empty_str, su.geometry))
    except Exception as e:
        FAIL.append("{}: {}".format(empty_str, e))

print("Supported:")
for t in SUCCESS:
    print("  {}".format(t))

print("Not Supported:")
for t in FAIL:
    print("  {}".format(t))
:--
Supported:
  POINT EMPTY: SRID=4326;POINT EMPTY
  LINESTRING EMPTY: SRID=4326;LINESTRING EMPTY
  POLYGON EMPTY: None  # <- Well, this is supported in WKT but not by PostGIS, as explained above
  MULTIPOINT EMPTY: SRID=4326;MULTIPOINT EMPTY
  MULTILINESTRING EMPTY: SRID=4326;MULTILINESTRING EMPTY
  MULTIPOLYGON EMPTY: SRID=4326;MULTIPOLYGON EMPTY
  GEOMETRYCOLLECTION EMPTY: SRID=4326;GEOMETRYCOLLECTION EMPTY
Not Supported:
  GEOMETRY EMPTY: Failed to instantiate
  CIRCULARSTRING EMPTY: Failed to instantiate
  COMPOUNDCURVE EMPTY: Failed to instantiate
  CURVEPOLYGON EMPTY: Failed to instantiate
  MULTICURVE EMPTY: Failed to instantiate
  MULTISURFACE EMPTY: Failed to instantiate
  CURVE EMPTY: Failed to instantiate
  SURFACE EMPTY: Failed to instantiate
  POLYHEDRALSURFACE EMPTY: Failed to instantiate
  TIN EMPTY: Failed to instantiate
  TRIANGLE EMPTY: Failed to instantiate
```

I've written a test to validate the supported datatypes and another to validate the expected behaviour of the `POLYGON EMPTY` work-around.  I don't know if this list of supported empty WKT types should be recorded anywhere beyond the test suite.

Finally, while I was in `organization.importers.validators.validate_row()` I noticed that the geometry data could either be returned as a `GEOSGeometry` instance or a WKT string.  While Python allows this, it feels a bit wrong as it detracts from the predictability of the function.  For this reason, I changed the code to return the `geometry` data as either `None` or a `GEOSGeometry` instance.  Also, while in the function I attempted to remove repeated code by adding the `get_field_value()` function.

### When should this PR be merged

Any time is good.

### Risks

The only risk I can see is if storing empty geometries is not desired behaviour (i.e. we should actually be throwing a `ValidationError`), however #1113 seems to suggest that it is desired behaviour.

### Follow-up actions

N/A

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 