### PR TITLE
create new rtl style files, add styling for projects page

### DIFF
--- a/cadasta/core/static/css/rtl.css
+++ b/cadasta/core/static/css/rtl.css
@@ -1,0 +1,11 @@
+@import "//cdn.rawgit.com/morteza/bootstrap-rtl/v3.3.4/dist/css/bootstrap-rtl.min.css";
+.page-title h1 {
+  height: 50px; }
+
+.table-num {
+  width: 150px; }
+
+td .org-logo {
+  float: right; }
+
+/*# sourceMappingURL=../../../../../static/css/rtl.css.map */

--- a/cadasta/core/static/css/rtl.css.map
+++ b/cadasta/core/static/css/rtl.css.map
@@ -1,0 +1,9 @@
+{
+	"version": 3,
+	"file": "../../vagrant/cadasta/core/static/css/rtl.css",
+	"sources": [
+		"../../vagrant/cadasta/core/static/css/rtl.scss"
+	],
+	"names": [],
+	"mappings": "AAAA,OAAO,CAAP,8EAAO;AAEP,AAAY,WAAD,CAAC,EAAE,CAAC;EACb,MAAM,EAAE,IAAI,GACb;;AAED,AAAA,UAAU,CAAC;EACT,KAAK,EAAE,KAAK,GACb;;AAED,AAAG,EAAD,CAAC,SAAS,CAAC;EACX,KAAK,EAAE,KAAK,GACb"
+}

--- a/cadasta/core/static/css/rtl.scss
+++ b/cadasta/core/static/css/rtl.scss
@@ -1,0 +1,13 @@
+@import "//cdn.rawgit.com/morteza/bootstrap-rtl/v3.3.4/dist/css/bootstrap-rtl.min.css";
+
+.page-title h1 {
+  height: 50px;
+}
+
+.table-num {
+  width: 150px;
+}
+
+td .org-logo {
+  float: right;
+}

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -17,8 +17,7 @@
           href="https://cdn.datatables.net/r/bs-3.3.5/jq-2.1.4,dt-1.10.8/datatables.min.css"/>
     <link href="{% sass_src 'css/main.scss' %}" rel="stylesheet" type="text/css">
     {% if LANGUAGE_BIDI %}
-    <link rel="stylesheet" type="text/css"
-          href="//cdn.rawgit.com/morteza/bootstrap-rtl/v3.3.4/dist/css/bootstrap-rtl.min.css">
+    <link href="{% sass_src 'css/rtl.scss' %}" rel="stylesheet" type="text/css">
     {% endif %}
     {% include "core/tracker.html" %}
     {% block extra_head %}{% endblock %}


### PR DESCRIPTION
### Proposed changes in this pull request

Partially fixes issue 564

- Created a new rtl.scss file, move external bootstrap rtl link to the new file (changed base.html to add  link to this)

- Added styling to fix the following issues on the projects page: (changes made to rtl.scss)
-- Increase h1 height to prevent letters being cut at the bottom
-- Increase the width of the “table-num” div to prevent it overlapping with the div which shows which page of the table is being displayed
-- Logo images should be floated right (they are currently floated left


### When should this PR be merged

Anytime



### Risks

I don't know if extra tests are needed for this addition.

I don't think there are any risks - these changes only effect rtl languages, which are disabled in default.py.


### Follow-up actions

There are other changes that still need to be made for the rtl styling


### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [x] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [x] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [x] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [x] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [x] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [x] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [x] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
