### PR TITLE
Fixes #724 -- Send confirmation email after password change and reset

### DIFF
--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -100,7 +100,7 @@ def password_changed_reset(sender, request, user, **kwargs):
     msg_body = render_to_string(
         'accounts/email/password_changed_notification.txt')
     send_mail(
-        _("Password Changed"),
+        _("Change of password at Cadasta Platform"),
         msg_body,
         settings.DEFAULT_FROM_EMAIL,
         [user.email],

--- a/cadasta/accounts/tests/test_urls_api.py
+++ b/cadasta/accounts/tests/test_urls_api.py
@@ -25,3 +25,10 @@ class UserUrlsTest(TestCase):
 
         resolved = resolve(version_url('/account/login/'))
         assert resolved.func.__name__ == api.AccountLogin.__name__
+
+    def test_account_password(self):
+        assert (reverse(version_ns('accounts:password')) ==
+                version_url('/account/password/'))
+
+        resolved = resolve(version_url('/account/password/'))
+        assert resolved.func.__name__ == api.SetPasswordView.__name__

--- a/cadasta/accounts/tests/test_views_api.py
+++ b/cadasta/accounts/tests/test_views_api.py
@@ -128,3 +128,26 @@ class AccountLoginTest(APITestCase, UserTestCase, TestCase):
         assert response.status_code == 400
         assert 'auth_token' not in response.content
         assert len(mail.outbox) == 1
+
+
+class AccountSetPasswordViewTest(APITestCase, UserTestCase, TestCase):
+    view_class = api_views.SetPasswordView
+
+    def setup_models(self):
+        self.user = UserFactory.create(username='imagine71',
+                                       email='john@beatles.uk',
+                                       password='iloveyoko79!')
+
+    def test_change_password(self):
+        data = {
+            'new_password': 'iloveyoko80!',
+            're_new_password': 'iloveyoko80!',
+            'current_password': 'iloveyoko79!',
+        }
+        response = self.request(method='POST', post_data=data, user=self.user)
+        assert response.status_code == 204
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].subject == 'Password Changed'
+        assert 'john@beatles.uk' in mail.outbox[0].to
+        self.user.refresh_from_db()
+        assert self.user.check_password('iloveyoko80!') is True

--- a/cadasta/accounts/tests/test_views_api.py
+++ b/cadasta/accounts/tests/test_views_api.py
@@ -147,7 +147,8 @@ class AccountSetPasswordViewTest(APITestCase, UserTestCase, TestCase):
         response = self.request(method='POST', post_data=data, user=self.user)
         assert response.status_code == 204
         assert len(mail.outbox) == 1
-        assert mail.outbox[0].subject == 'Password Changed'
+        assert (mail.outbox[0].subject ==
+                'Change of password at Cadasta Platform')
         assert 'john@beatles.uk' in mail.outbox[0].to
         self.user.refresh_from_db()
         assert self.user.check_password('iloveyoko80!') is True

--- a/cadasta/accounts/urls/api.py
+++ b/cadasta/accounts/urls/api.py
@@ -6,4 +6,5 @@ urlpatterns = [
     url(r'^$', api.AccountUser.as_view(), name='user'),
     url(r'^register/$', api.AccountRegister.as_view(), name='register'),
     url(r'^login/$', api.AccountLogin.as_view(), name='login'),
+    url(r'^password/$', api.SetPasswordView.as_view(), name='password'),
 ]

--- a/cadasta/accounts/views/api.py
+++ b/cadasta/accounts/views/api.py
@@ -8,6 +8,7 @@ from rest_framework import status
 
 from djoser import views as djoser_views
 from djoser import signals
+from allauth.account.signals import password_changed
 
 from .. import serializers
 from ..models import now_plus_48_hours
@@ -75,3 +76,12 @@ class AccountLogin(djoser_views.LoginView):
                 data={'detail': _("The email has not been verified.")},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+
+class SetPasswordView(djoser_views.SetPasswordView):
+    def _action(self, serializer):
+        response = super()._action(serializer)
+        password_changed.send(sender=self.request.user.__class__,
+                              request=self.request._request,
+                              user=self.request.user)
+        return response

--- a/cadasta/templates/accounts/email/password_changed_notification.txt
+++ b/cadasta/templates/accounts/email/password_changed_notification.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% autoescape off %}
+{% trans "You are receiving this email because someone has changed or reset the password for your account at Cadasta Platform. If it wasn't you, please contact us immediately under security@cadasta.org" %} 
+{% endautoescape %}

--- a/cadasta/templates/accounts/email/password_changed_notification.txt
+++ b/cadasta/templates/accounts/email/password_changed_notification.txt
@@ -1,3 +1,3 @@
 {% load i18n %}{% autoescape off %}
-{% trans "You are receiving this email because someone has changed or reset the password for your account at Cadasta Platform. If it wasn't you, please contact us immediately under security@cadasta.org" %} 
+{% trans "You are receiving this email because a user at Cadasta Platform has changed or reset the password for your account. If it wasn't you, please contact us immediately under security@cadasta.org" %} 
 {% endautoescape %}


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #724: Sends an email to the user when the password has been changed or reset
- Adds a signal reviever for `allauth`'s `password_changed` and `password_reset` emails that takes care of sending the email. 
- Adds a new API view `SetPasswordView` that overwrites `djoser`'s default behaviour when setting a new password. The custom view sends a `password_changed` signal after the password has been updated via the API. 

### When should this PR be merged

Anytime

### Risks

None

### Follow-up actions

None

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
