### PR TITLE
Adds mime_type field to resource serializer

### DIFF
--- a/cadasta/resources/serializers.py
+++ b/cadasta/resources/serializers.py
@@ -12,8 +12,9 @@ class ResourceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Resource
         fields = ('id', 'name', 'description', 'file', 'original_file',
-                  'archived',)
+                  'archived', 'mime_type', )
         read_only_fields = ('id', )
+        extra_kwargs = {'mime_type': {'required': False}}
 
     def is_valid(self, raise_exception=False):
         data = self.initial_data

--- a/cadasta/resources/tests/test_models.py
+++ b/cadasta/resources/tests/test_models.py
@@ -201,6 +201,18 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
             settings.MEDIA_ROOT, 's3/uploads/resources/thumb_test-128x128.jpg')
         )
 
+    def test_create_no_thumbnail_non_images(self):
+        file = self.get_file('/resources/tests/files/text.txt', 'rb')
+        file_name = self.storage.save('resources/text.txt', file)
+        contributor = UserFactory.create()
+        resource = ResourceFactory.create(file=file_name,
+                                          mime_type='text/plain',
+                                          contributor=contributor)
+        resource.save()
+        assert os.path.isfile(os.path.join(
+            settings.MEDIA_ROOT, 's3/uploads/resources/text-128x128.txt')
+        ) is False
+
     def test_create_spatial_resource(self):
         file = self.get_file('/resources/tests/files/deramola.xml', 'rb')
         file_name = self.storage.save('resources/deramola.xml', file)


### PR DESCRIPTION
### Proposed changes in this pull request

- This PR adds a temporary workaround to #1322 to ensure thumbnails are created for @SteadyCadence's imports. Proper handling of mime types should be implemented with #490.

### When should this PR be merged

Soon; this is important to move forward with data imports.

### Risks

None

### Follow-up actions

None


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
