### PR TITLE
Fixes #592 -- Bump jsonattrs; small style fixes

### DIFF
--- a/cadasta/xforms/views/api.py
+++ b/cadasta/xforms/views/api.py
@@ -91,9 +91,9 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
         return self._formatMessageResponse(request, e, status)
 
     def _formatMessageResponse(self, request, message, status):
-        tempate_data = {'message': message}
+        template_data = {'message': message}
         content = render_to_string('xforms/submission_response.xml',
-                                   tempate_data)
+                                   template_data)
         headers = self.get_openrosa_headers(request,
                                             location=False,
                                             content_length=False)

--- a/cadasta/xforms/views/api.py
+++ b/cadasta/xforms/views/api.py
@@ -91,17 +91,16 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
         return self._formatMessageResponse(request, e, status)
 
     def _formatMessageResponse(self, request, message, status):
-            tempate_data = {'message': message}
-            # print(DEFAULT_CONTENT_TYPE)
-            content = render_to_string('xforms/submission_response.xml',
-                                       tempate_data)
-            headers = self.get_openrosa_headers(request,
-                                                location=False,
-                                                content_length=False)
-            return Response(data=content,
-                            headers=headers,
-                            status=status,
-                            content_type=self.DEFAULT_CONTENT_TYPE)
+        tempate_data = {'message': message}
+        content = render_to_string('xforms/submission_response.xml',
+                                   tempate_data)
+        headers = self.get_openrosa_headers(request,
+                                            location=False,
+                                            content_length=False)
+        return Response(data=content,
+                        headers=headers,
+                        status=status,
+                        content_type=self.DEFAULT_CONTENT_TYPE)
 
 
 class XFormListView(OpenRosaHeadersMixin,

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -24,7 +24,7 @@ django-buckets==0.1.20
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.4.2
-django-jsonattrs==0.1.22a11
+django-jsonattrs==0.1.22
 openpyxl==2.4.1
 pytz==2016.4
 shapely==1.5.16

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -24,7 +24,7 @@ django-buckets==0.1.20
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.4.2
-django-jsonattrs==0.1.22a8
+django-jsonattrs==0.1.22a11
 openpyxl==2.4.1
 pytz==2016.4
 shapely==1.5.16


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes #592. 

GeoODK sends empty XML (`<location_problems />`) elements when no value is provided for a form field. We convert the XML into a Python dictionary using pyxform.xform2json.XFormToDict; all empty XML elements are converted to empty strings (`"location_problems": ""`) or a list with one empty string (`"location_problems": [""]`).

This is a problem for integer, decimal, select_one and select_multiple fields because an empty string is an actual value but it's not valid for fields mentioned above because it's not a number and usually not an option for select fields.

This PR only bumps django-jsonattrs to a new version. The actual bug fix is added to [django-json attrs PR #17](https://github.com/Cadasta/django-jsonattrs/pull/17). Please review the django-jsonattrs PR before accepting this one. 

### When should this PR be merged

When ready.

### Risks

None/

### Follow-up actions

- @oliverroick to make a full release of django-jsonattrs when the PR is accepted.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
