### PR TITLE
Fix #1118 and other issues

### DIFF
--- a/cadasta/search/mock_es/tests/test_urls.py
+++ b/cadasta/search/mock_es/tests/test_urls.py
@@ -6,40 +6,30 @@ from .. import views
 
 class MockEsUrlsTest(TestCase):
 
-    def test_all(self):
-        actual = reverse('mock_es:all',
+    def test_search(self):
+        actual = reverse('mock_es:search',
                          kwargs={
                             'projectid': '123abc',
+                            'type': '456def',
                          })
-        expected = '/project-123abc/_search/'
+        expected = '/project-123abc/456def/_search/'
         assert actual == expected
 
-        resolved = resolve('/project-123abc/_search/')
-        assert resolved.func.__name__ == views.AllEsTypes.__name__
+        resolved = resolve('/project-123abc/456def/_search/')
+        assert resolved.func.__name__ == views.Search.__name__
         assert resolved.kwargs['projectid'] == '123abc'
+        assert resolved.kwargs['type'] == '456def'
 
-    def test_type(self):
-        actual = reverse('mock_es:type',
-                         kwargs={
-                            'projectid': 'foo',
-                            'type': 'bar',
-                         })
-        expected = '/project-foo/bar/_search/'
-        assert actual == expected
-
-        resolved = resolve('/project-foo/bar/_search/')
-        assert resolved.func.__name__ == views.SingleEsType.__name__
-        assert resolved.kwargs['projectid'] == 'foo'
-        assert resolved.kwargs['type'] == 'bar'
-
-    def test_dump_all(self):
-        actual = reverse('mock_es:dump_all',
+    def test_dump(self):
+        actual = reverse('mock_es:dump',
                          kwargs={
                             'projectid': '123abc',
+                            'type': '456def',
                          })
-        expected = '/project-123abc/_data/'
+        expected = '/project-123abc/456def/_data/'
         assert actual == expected
 
-        resolved = resolve('/project-123abc/_data/')
-        assert resolved.func.__name__ == views.DumpAllEsTypes.__name__
+        resolved = resolve('/project-123abc/456def/_data/')
+        assert resolved.func.__name__ == views.Dump.__name__
         assert resolved.kwargs['projectid'] == '123abc'
+        assert resolved.kwargs['type'] == '456def'

--- a/cadasta/search/mock_es/urls.py
+++ b/cadasta/search/mock_es/urls.py
@@ -5,20 +5,16 @@ from . import views
 urls = [
     url(
         r'^_search/$',
-        views.AllEsTypes.as_view(),
-        name='all'),
-    url(
-        r'^(?P<type>[-\w]+)/_search/$',
-        views.SingleEsType.as_view(),
-        name='type'),
+        views.Search.as_view(),
+        name='search'),
     url(
         r'^_data/$',
-        views.DumpAllEsTypes.as_view(),
-        name='dump_all'),
+        views.Dump.as_view(),
+        name='dump'),
 ]
 
 urlpatterns = [
     url(
-        r'^project-(?P<projectid>[-\w]+)/',
+        r'^project-(?P<projectid>[-\w]+)/(?P<type>[-\w,]+)/',
         include(urls, namespace='mock_es')),
 ]

--- a/cadasta/search/parser.py
+++ b/cadasta/search/parser.py
@@ -1,0 +1,94 @@
+import pyparsing
+
+
+# Specify the ES fields for all ES types for full-text search
+fields = ['type', 'name', 'attributes.value', 'tenure_attributes.value',
+          'tenure_type_id', 'description', 'original_file', 'mime_type']
+
+# pyparsing objects
+fuzzy = pyparsing.Regex(r'\S+')
+exact = pyparsing.QuotedString('"', unquoteResults=False)
+term = exact | fuzzy
+must_term = pyparsing.Group('+' + term)
+must_not_term = pyparsing.Group('-' + term)
+token = must_term | must_not_term | term
+query = pyparsing.OneOrMore(token)
+
+
+def parse_query(raw_query_str):
+    """This function takes the raw UI search query string, parses it, then
+    generates and returns the 'bool' JSON object for the 'query' DSL field."""
+
+    # Parse query string into tokens and sort them into buckets
+    tokens = query.parseString(raw_query_str).asList()
+    must_terms = []
+    must_not_terms = []
+    should_terms = []
+    for token in tokens:
+        if isinstance(token, list):
+            if token[0] == '-':
+                must_not_terms.append(token[1])
+            else:
+                assert token[0] == '+'
+                must_terms.append(token[1])
+        else:
+            should_terms.append(token)
+
+    # Go through each bucket and generate the 'bool' clause lists
+    must_dsl = transform_to_dsl(must_terms)
+    must_not_dsl = transform_to_dsl(must_not_terms, has_fuzziness=False)
+    should_dsl = transform_to_dsl(should_terms)
+
+    # Add clause to remove archived resources
+    must_not_dsl.append({'match': {'archived': True}})
+
+    # Construct then return the complete 'bool' DSL
+    dsl = {'bool': {'must_not': must_not_dsl}}
+    if must_dsl:
+        dsl['bool']['must'] = must_dsl
+    if should_dsl:
+        dsl['bool']['should'] = should_dsl
+    return dsl
+
+
+def transform_to_dsl(terms, has_fuzziness=True):
+    dsl = []
+    for term in terms:
+        # Exact phrase clause
+        if term[0] == '"' and term[-1] == '"':
+            dsl.append({
+                'query': term[1:-1],
+                'fields': fields,
+                'type': 'phrase',
+                'boost': 10 if has_fuzziness else 1,
+            })
+
+        # Fuzzy term
+        else:
+            # Exact match clause
+            dsl.append({
+                'query': term,
+                'fields': fields,
+                'boost': 10 if has_fuzziness else 1,
+            })
+
+            # Fuzzy match clause
+            if has_fuzziness and len(term) > 1:
+                dsl.append({
+                    'query': term,
+                    'fields': fields,
+                    'fuzziness': get_fuzziness(term),
+                    'prefix_length': 1,
+                })
+
+    return [{'multi_match': x} for x in dsl]
+
+
+def get_fuzziness(term):
+    assert len(term) > 0
+    if len(term) == 1:
+        return 0
+    elif len(term) < 4:
+        return 1
+    else:
+        return 2

--- a/cadasta/search/parser.py
+++ b/cadasta/search/parser.py
@@ -56,32 +56,31 @@ def transform_to_dsl(terms, has_fuzziness=True):
     for term in terms:
         # Exact phrase clause
         if term[0] == '"' and term[-1] == '"':
-            dsl.append({
+            dsl.append({'multi_match': {
                 'query': term[1:-1],
                 'fields': fields,
                 'type': 'phrase',
                 'boost': 10 if has_fuzziness else 1,
-            })
+            }})
 
         # Fuzzy term
         else:
             # Exact match clause
-            dsl.append({
+            dsl.append({'multi_match': {
                 'query': term,
                 'fields': fields,
                 'boost': 10 if has_fuzziness else 1,
-            })
+            }})
 
             # Fuzzy match clause
             if has_fuzziness and len(term) > 1:
-                dsl.append({
+                dsl.append({'multi_match': {
                     'query': term,
                     'fields': fields,
                     'fuzziness': get_fuzziness(term),
                     'prefix_length': 1,
-                })
-
-    return [{'multi_match': x} for x in dsl]
+                }})
+    return dsl
 
 
 def get_fuzziness(term):

--- a/cadasta/search/tests/test_parser.py
+++ b/cadasta/search/tests/test_parser.py
@@ -1,0 +1,363 @@
+import pytest
+
+from django.test import TestCase
+
+from .. import parser
+
+
+class ParserTest(TestCase):
+
+    def test_parse_string(self):
+        p = parser.query.parseString
+
+        # Simple cases
+        assert p('a').asList() == ['a']
+        assert p('a        ').asList() == ['a']
+        assert p('    a    ').asList() == ['a']
+        assert p('        a').asList() == ['a']
+        assert p('a b').asList() == ['a', 'b']
+        assert p('a             b').asList() == ['a', 'b']
+        assert p('   a          b').asList() == ['a', 'b']
+        assert p('a          b   ').asList() == ['a', 'b']
+        assert p('   a       b   ').asList() == ['a', 'b']
+        assert p('a_b').asList() == ['a_b']
+        assert p('a b c').asList() == ['a', 'b', 'c']
+        assert p('a___ b--- c+++').asList() == ['a___', 'b---', 'c+++']
+
+        # Quoted cases
+        assert p('"a b"').asList() == ['"a b"']
+        assert p('"a    b"').asList() == ['"a    b"']
+        assert p('"a b" c').asList() == ['"a b"', 'c']
+        assert p('a "b c"').asList() == ['a', '"b c"']
+        assert p('a "b c" d').asList() == ['a', '"b c"', 'd']
+
+        # +- cases
+        assert p('+a').asList() == [['+', 'a']]
+        assert p('-a').asList() == [['-', 'a']]
+        assert p('+"a  b"').asList() == [['+', '"a  b"']]
+        assert p('-"a  b"').asList() == [['-', '"a  b"']]
+        assert p('b +a').asList() == ['b', ['+', 'a']]
+        assert p('b -a').asList() == ['b', ['-', 'a']]
+        assert p('"b +a"').asList() == ['"b +a"']
+        assert p('"b -a"').asList() == ['"b -a"']
+        assert p('b+a').asList() == ['b+a']
+        assert p('b-a').asList() == ['b-a']
+        assert p('"b+a"').asList() == ['"b+a"']
+        assert p('"b-a"').asList() == ['"b-a"']
+        assert p('+a b c').asList() == [['+', 'a'], 'b', 'c']
+        assert p('-a b c').asList() == [['-', 'a'], 'b', 'c']
+        assert p('+a "b c"').asList() == [['+', 'a'], '"b c"']
+        assert p('-a "b c"').asList() == [['-', 'a'], '"b c"']
+        assert p('a   b +c').asList() == ['a', 'b', ['+', 'c']]
+        assert p('a   b -c').asList() == ['a', 'b', ['-', 'c']]
+        assert p('a   "b +c"').asList() == ['a', '"b +c"']
+        assert p('a   "b -c"').asList() == ['a', '"b -c"']
+        assert p('+a -b +c').asList() == [['+', 'a'], ['-', 'b'], ['+', 'c']]
+        assert p('-a +b -c').asList() == [['-', 'a'], ['+', 'b'], ['-', 'c']]
+        assert p('+a -"b +c"').asList() == [['+', 'a'], ['-', '"b +c"']]
+        assert p('-a +"b -c"').asList() == [['-', 'a'], ['+', '"b -c"']]
+        assert p('+a-b +c').asList() == [['+', 'a-b'], ['+', 'c']]
+        assert p('-a+b -c').asList() == [['-', 'a+b'], ['-', 'c']]
+        assert p('+"a-b" +c').asList() == [['+', '"a-b"'], ['+', 'c']]
+        assert p('-"a+b" -c').asList() == [['-', '"a+b"'], ['-', 'c']]
+        assert p('+a-"b +c"').asList() == [['+', 'a-"b'], ['+', 'c"']]
+        assert p('-a+"b -c"').asList() == [['-', 'a+"b'], ['-', 'c"']]
+        assert p('+a   -b+c').asList() == [['+', 'a'], ['-', 'b+c']]
+        assert p('-a   +b-c').asList() == [['-', 'a'], ['+', 'b-c']]
+        assert p('+a   -"b+c"').asList() == [['+', 'a'], ['-', '"b+c"']]
+        assert p('-a   +"b-c"').asList() == [['-', 'a'], ['+', '"b-c"']]
+        assert p('+a   "-b+c"').asList() == [['+', 'a'], '"-b+c"']
+        assert p('-a   "+b-c"').asList() == [['-', 'a'], '"+b-c"']
+
+    def test_parse_query(self):
+        f = parser.fields
+
+        assert parser.parse_query('ab') == {
+            'bool': {
+                'should': [
+                    {
+                        'multi_match': {
+                            'query': 'ab',
+                            'fields': f,
+                            'boost': 10,
+                        }
+                    },
+                    {
+                        'multi_match': {
+                            'query': 'ab',
+                            'fields': f,
+                            'fuzziness': 1,
+                            'prefix_length': 1,
+                        }
+                    },
+                ],
+                'must_not': [{'match': {'archived': True}}],
+            }
+        }
+        assert parser.parse_query('"a b"') == {
+            'bool': {
+                'should': [
+                    {
+                        'multi_match': {
+                            'query': 'a b',
+                            'fields': f,
+                            'type': 'phrase',
+                            'boost': 10,
+                        }
+                    },
+                ],
+                'must_not': [{'match': {'archived': True}}],
+            }
+        }
+        assert parser.parse_query('+ab') == {
+            'bool': {
+                'must': [
+                    {
+                        'multi_match': {
+                            'query': 'ab',
+                            'fields': f,
+                            'boost': 10,
+                        }
+                    },
+                    {
+                        'multi_match': {
+                            'query': 'ab',
+                            'fields': f,
+                            'fuzziness': 1,
+                            'prefix_length': 1,
+                        }
+                    },
+                ],
+                'must_not': [{'match': {'archived': True}}],
+            }
+        }
+        assert parser.parse_query('+"a b"') == {
+            'bool': {
+                'must': [
+                    {
+                        'multi_match': {
+                            'query': 'a b',
+                            'fields': f,
+                            'type': 'phrase',
+                            'boost': 10,
+                        }
+                    },
+                ],
+                'must_not': [{'match': {'archived': True}}],
+            }
+        }
+        assert parser.parse_query('-a') == {
+            'bool': {
+                'must_not': [
+                    {
+                        'multi_match': {
+                            'query': 'a',
+                            'fields': f,
+                            'boost': 1,
+                        }
+                    },
+                    {'match': {'archived': True}},
+                ],
+            }
+        }
+        assert parser.parse_query('-"a b"') == {
+            'bool': {
+                'must_not': [
+                    {
+                        'multi_match': {
+                            'query': 'a b',
+                            'fields': f,
+                            'type': 'phrase',
+                            'boost': 1,
+                        }
+                    },
+                    {'match': {'archived': True}},
+                ],
+            }
+        }
+        assert parser.parse_query('"a" +"b"') == {
+            'bool': {
+                'must': [
+                    {
+                        'multi_match': {
+                            'query': 'b',
+                            'fields': f,
+                            'type': 'phrase',
+                            'boost': 10,
+                        }
+                    },
+                ],
+                'should': [
+                    {
+                        'multi_match': {
+                            'query': 'a',
+                            'fields': f,
+                            'type': 'phrase',
+                            'boost': 10,
+                        }
+                    },
+                ],
+                'must_not': [{'match': {'archived': True}}],
+            }
+        }
+        assert parser.parse_query('"a" -"b"') == {
+            'bool': {
+                'must_not': [
+                    {
+                        'multi_match': {
+                            'query': 'b',
+                            'fields': f,
+                            'type': 'phrase',
+                            'boost': 1,
+                        }
+                    },
+                    {'match': {'archived': True}},
+                ],
+                'should': [
+                    {
+                        'multi_match': {
+                            'query': 'a',
+                            'fields': f,
+                            'type': 'phrase',
+                            'boost': 10,
+                        }
+                    },
+                ],
+            }
+        }
+        assert parser.parse_query('+"a" -"b"') == {
+            'bool': {
+                'must': [
+                    {
+                        'multi_match': {
+                            'query': 'a',
+                            'fields': f,
+                            'type': 'phrase',
+                            'boost': 10,
+                        }
+                    },
+                ],
+                'must_not': [
+                    {
+                        'multi_match': {
+                            'query': 'b',
+                            'fields': f,
+                            'type': 'phrase',
+                            'boost': 1,
+                        }
+                    },
+                    {'match': {'archived': True}},
+                ],
+            }
+        }
+
+    def test_transform_to_dsl(self):
+        f = parser.fields
+
+        assert parser.transform_to_dsl(['a']) == [
+            {'multi_match': {'query': 'a', 'fields': f, 'boost': 10}},
+        ]
+        assert parser.transform_to_dsl(['ab']) == [
+            {'multi_match': {'query': 'ab', 'fields': f, 'boost': 10}},
+            {'multi_match': {
+                'query': 'ab',
+                'fields': f,
+                'fuzziness': 1,
+                'prefix_length': 1,
+            }},
+        ]
+        assert parser.transform_to_dsl(['"a"']) == [
+            {'multi_match': {
+                'query': 'a',
+                'fields': f,
+                'type': 'phrase',
+                'boost': 10,
+            }},
+        ]
+        assert parser.transform_to_dsl(['a'], has_fuzziness=False) == [
+            {'multi_match': {'query': 'a', 'fields': f, 'boost': 1}},
+        ]
+        assert parser.transform_to_dsl(['"a"'], has_fuzziness=False) == [
+            {'multi_match': {
+                'query': 'a',
+                'fields': f,
+                'type': 'phrase',
+                'boost': 1,
+            }},
+        ]
+        assert parser.transform_to_dsl(['ab', '"b"']) == [
+            {'multi_match': {'query': 'ab', 'fields': f, 'boost': 10}},
+            {'multi_match': {
+                'query': 'ab',
+                'fields': f,
+                'fuzziness': 1,
+                'prefix_length': 1,
+            }},
+            {'multi_match': {
+                'query': 'b',
+                'fields': f,
+                'type': 'phrase',
+                'boost': 10,
+            }},
+        ]
+        assert parser.transform_to_dsl(['"a"', 'bc']) == [
+            {'multi_match': {
+                'query': 'a',
+                'fields': f,
+                'type': 'phrase',
+                'boost': 10,
+            }},
+            {'multi_match': {'query': 'bc', 'fields': f, 'boost': 10}},
+            {'multi_match': {
+                'query': 'bc',
+                'fields': f,
+                'fuzziness': 1,
+                'prefix_length': 1,
+            }},
+        ]
+        assert parser.transform_to_dsl(['ab', '"b"'], has_fuzziness=False) == [
+            {'multi_match': {'query': 'ab', 'fields': f, 'boost': 1}},
+            {'multi_match': {
+                'query': 'b',
+                'fields': f,
+                'type': 'phrase',
+                'boost': 1,
+            }},
+        ]
+        assert parser.transform_to_dsl(['"a"', 'bc'], has_fuzziness=False) == [
+            {'multi_match': {
+                'query': 'a',
+                'fields': f,
+                'type': 'phrase',
+                'boost': 1,
+            }},
+            {'multi_match': {'query': 'bc', 'fields': f, 'boost': 1}},
+        ]
+        assert parser.transform_to_dsl(['"a']) == [
+            {'multi_match': {'query': '"a', 'fields': f, 'boost': 10}},
+            {'multi_match': {
+                'query': '"a',
+                'fields': f,
+                'fuzziness': 1,
+                'prefix_length': 1,
+            }},
+        ]
+        assert parser.transform_to_dsl(['a"']) == [
+            {'multi_match': {'query': 'a"', 'fields': f, 'boost': 10}},
+            {'multi_match': {
+                'query': 'a"',
+                'fields': f,
+                'fuzziness': 1,
+                'prefix_length': 1,
+            }},
+        ]
+
+    def test_get_fuzziness(self):
+        with pytest.raises(AssertionError):
+            parser.get_fuzziness('')
+        assert parser.get_fuzziness('a') == 0
+        assert parser.get_fuzziness('ab') == 1
+        assert parser.get_fuzziness('abc') == 1
+        assert parser.get_fuzziness('abcd') == 2
+        assert parser.get_fuzziness('abcde') == 2
+        assert parser.get_fuzziness('abcdef') == 2

--- a/cadasta/templates/search/search.html
+++ b/cadasta/templates/search/search.html
@@ -33,9 +33,12 @@
                 <div id="search-guidelines" class="hidden small">
                   {% blocktrans %}
                   <ul>
-                    <li>Review your wording, make sure that there aren’t any typos in your search query</li>
-                    <li>If no results match your query, try removing some search terms (<kbd>John</kbd>, instead of <kbd>John White</kbd>)</li>
-                    <li>Search results are limited to a maximum of {{ max_num_results }} entries</li>
+                    <li>By default, search results are required to only match at least one of the provided terms.
+                      To force a term to be required, prefix it with a plus sign (ex. <kbd>+wanted</kbd>).
+                      To force a term to be excluded, prefix it with a hyphen (ex. <kbd>-unwanted</kbd>).</li>
+                    <li>To search for exact phrases, use quotation marks (ex. <kbd>"John White"</kbd>).</li>
+                    <li>Review your wording, make sure that there aren’t any typos in your search terms.</li>
+                    <li>Search results are limited to a maximum of {{ max_num_results }} entries.</li>
                   </ul>
                   {% endblocktrans%}
                 </div>
@@ -56,7 +59,7 @@
               <p><strong>{% trans "Search tips:" %}</strong></p>
               <ul>
                 <li>{% trans "Double check your spelling for typos." %}</li>
-                <li>{% trans "Use fewer keywords." %}</li>
+                <li>{% trans "Add more keywords." %}</li>
                 <li>{% trans "Refer to our search guidelines for more tips." %}</li>
               </ul>
             </div>
@@ -130,7 +133,7 @@ function performSearch(query, updateDocumentUrl) {
         last: 'Last',
       },
     }
- }).draw();
+ });
 }
 
 function drawHandler(settings) {

--- a/cadasta/templates/search/search.html
+++ b/cadasta/templates/search/search.html
@@ -33,7 +33,7 @@
                 <div id="search-guidelines" class="hidden small">
                   {% blocktrans %}
                   <ul>
-                    <li>By default, search results are required to only match at least one of the provided terms.
+                    <li>By default, search results are required to match at least one of the provided terms.
                       To force a term to be required, prefix it with a plus sign (ex. <kbd>+wanted</kbd>).
                       To force a term to be excluded, prefix it with a hyphen (ex. <kbd>-unwanted</kbd>).</li>
                     <li>To search for exact phrases, use quotation marks (ex. <kbd>"John White"</kbd>).</li>

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -34,3 +34,4 @@ awscli==1.11.23
 pandas==0.19.0
 argon2-cffi==16.3.0
 requests==2.11.1
+pyparsing==2.2.0


### PR DESCRIPTION
### Proposed changes in this pull request
- Use default "or":
    - Make search use "or" by default and allow users to specify that terms are required or excluded by prefixing them with `+` and `-` respectively.
    - Implement this by using the pyparsing Python library. See the new **search/parser.py** source file and the `parse_query()` function for details. Before, the platform just passes the UI query string directly to ES which does the parsing. Now, we can control our search query syntax by having the platform do the parsing and then constructing the ES search DSL based on the parsed results.
    - Terms without the prefixed `+` or `-` are mapped to the ES `should` boolean clause, terms with the prefixed `+` are mapped to the ES `must` boolean clause, and terms with the prefixed `-` are mapped to the ES `must_not` boolean clause. [[ES reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html)]
    - In addition, full-text search is now limited to ES fields that we can reasonably expect users to want to search on.
    - Update the search guidelines on the search HTML page.
- Fix #1118 (search only matches on exact strings):
    - Make search fuzzy by default and allow users to specify exact matching on whole phrases by using quotation marks. However, make the "not" operator (`-`) use exact matching (we don't want to accidentally exclude things that fuzzily match the "not" term).
    - Implement the fuzziness by adding a second fuzzy matching clause to `should` and `must` clauses. The fuzziness (aka [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)) is set to 1 for terms that are 2 to 3 characters long and to 2 for longer terms. If the term is only 1 character long, no fuzzy matching clause is added.
    - Implement exact matching by using pyparsing's `QuotedString` object. These are then mapped to the ES `phrase` match type and no fuzzy matching clauses are added as mentioned in the previous bullet. 
    - Update the search guidelines on the search HTML page.
- Fix #1354 (archived resources are included in results):
    - Add the following additional `must_not` clause to the ES query DSL: `{"match": {"archived": true}}`
- Fix remaining DataTables Ajax warnings:
    - Before I assumed that connecting to the ES API will always succeed and then flagging an error to the user only if the HTTP response code is not 200. Now HTTP connection errors to ES are also caught (by catching `requests.exceptions.RequestException` exceptions). This should now avoid the JavaScript "DataTables warning" popup that appears when there is a connection error.
    - Also add an explicit `timeout=10` parameter to HTTP requests. Without this, requests will wait indefinitely. [[Requests reference](http://docs.python-requests.org/en/master/user/advanced/#timeouts)]
- Fix the issue that the search Ajax endpoint is hit twice for every search:
    - Remove a redundant call to the `draw()` DataTables API function.
- Other improvements:
    - Limit the ES types to be searched to just `spatial`, `party`, and `resource` by specifying them in the ES API URL. Before, no ES type was specified so this defaults to searching all ES types, which also includes the `project` ES type.
        - Adjust the Mock ES implementation to handle this change of ES API URL.

### When should this PR be merged
- Within Sprint 16 and after the search export PR has been merged (this PR is branched off the **feature/search-export** branch).

### Risks
- None foreseen.

### Follow-up actions
- This PR adds the pyparsing Python library, so this should be installed when deployed.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
