### PR TITLE
Create Attributes with correct schema selector

### DIFF
--- a/cadasta/questionnaires/serializers.py
+++ b/cadasta/questionnaires/serializers.py
@@ -266,6 +266,8 @@ class QuestionnaireSerializer(serializers.ModelSerializer):
                     project=project,
                     **validated_data)
 
+                project.current_questionnaire = instance.id
+
                 context = {
                     'questionnaire_id': instance.id,
                     'project': project,
@@ -274,7 +276,6 @@ class QuestionnaireSerializer(serializers.ModelSerializer):
                 create_questions(questions, context)
                 create_groups(question_groups, context)
 
-                project.current_questionnaire = instance.id
                 project.save()
 
                 return instance


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes a bug that was introduced in PR #1372. When creating `Attribute` instances via the questionnaires API, all `Attributes` were created with an incorrect schema selector because the project's `current_questionnaire` was set _after_ question groups were created. This meant that the `Attribute` instances were not found when creating locations, parties, and relationships leaving forms incomplete or failing validation via the API.

The PR fixes this by assigning the `current_questionnaire` before creating question groups. I also added a test to verify the behavior.

### When should this PR be merged

Soon. This is a critical issue, relevant for the QGIS plugin to work properly. 

### Risks

[List any risks that could arise from merging your pull request.]

Low.

### Follow-up actions

None.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
