### PR TITLE
Fixes #1397 -- Catch and ignore QuestionOption.DoesNotExist

### DIFF
--- a/cadasta/party/views/default.py
+++ b/cadasta/party/views/default.py
@@ -93,13 +93,17 @@ class PartiesDetail(LoginPermissionRequiredMixin,
                     questionnaire_id=project.current_questionnaire)
                 context['type_labels'] = template_xlang_labels(
                     party_type.label_xlat)
-
-                option = QuestionOption.objects.get(question=party_type,
-                                                    name=context['party'].type)
-                context['type_choice_labels'] = template_xlang_labels(
-                    option.label_xlat)
             except Question.DoesNotExist:
                 pass
+            else:
+                try:
+                    option = QuestionOption.objects.get(
+                        question=party_type,
+                        name=context['party'].type)
+                    context['type_choice_labels'] = template_xlang_labels(
+                        option.label_xlat)
+                except QuestionOption.DoesNotExist:
+                    pass
 
             try:
                 tenure_type = Question.objects.get(
@@ -234,14 +238,17 @@ class PartyRelationshipDetail(LoginPermissionRequiredMixin,
                     questionnaire_id=project.current_questionnaire)
                 context['type_labels'] = template_xlang_labels(
                     tenure_type.label_xlat)
-
-                option = QuestionOption.objects.get(
-                    question=tenure_type,
-                    name=context['relationship'].tenure_type_id)
-                context['type_choice_labels'] = template_xlang_labels(
-                    option.label_xlat)
             except Question.DoesNotExist:
                 pass
+            else:
+                try:
+                    option = QuestionOption.objects.get(
+                        question=tenure_type,
+                        name=context['relationship'].tenure_type_id)
+                    context['type_choice_labels'] = template_xlang_labels(
+                        option.label_xlat)
+                except QuestionOption.DoesNotExist:
+                    pass
 
         return context
 

--- a/cadasta/spatial/views/default.py
+++ b/cadasta/spatial/views/default.py
@@ -88,14 +88,17 @@ class LocationDetail(LoginPermissionRequiredMixin,
                     questionnaire_id=project.current_questionnaire)
                 context['type_labels'] = template_xlang_labels(
                     question.label_xlat)
-
-                option = QuestionOption.objects.get(
-                    question=question,
-                    name=context['location'].type)
-                context['type_choice_labels'] = template_xlang_labels(
-                    option.label_xlat)
             except Question.DoesNotExist:
                 pass
+            else:
+                try:
+                    option = QuestionOption.objects.get(
+                        question=question,
+                        name=context['location'].type)
+                    context['type_choice_labels'] = template_xlang_labels(
+                        option.label_xlat)
+                except QuestionOption.DoesNotExist:
+                    pass
 
             try:
                 tenure_type = Question.objects.get(


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #1397: When an option for one of the standard select fields (location type, party type, tenure relationship type) was missing from the questionnaire and that same option was used in an entity instance `QuestionOption.DoesNotExist' is thrown when accessing the detail page of that entity. (Other that stated in the bug report this only affects detail pages). 
- The exception is caught and ignore. The `QuestionOption` instance is queried from the database to create multi-language labels. If an option is not present, multi-language labels will not be populated, a case that is handled gracefully on the client-side. That's why it's ok to just ignore the exceptions. 

### When should this PR be merged

- Anytime

### Risks

None

### Follow-up actions

None

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
