### PR TITLE
Add pagination to API list endpoints

### DIFF
--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -98,9 +98,12 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ),
     'DEFAULT_VERSIONING_CLASS':
-    'rest_framework.versioning.NamespaceVersioning',
+        'rest_framework.versioning.NamespaceVersioning',
     'DEFAULT_VERSION': 'v1',
-    'EXCEPTION_HANDLER': 'core.views.api.exception_handler'
+    'EXCEPTION_HANDLER': 'core.views.api.exception_handler',
+    'DEFAULT_PAGINATION_CLASS':
+        'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 100
 }
 
 SITE_NAME = 'Cadasta'

--- a/cadasta/core/tests/test_pagination.py
+++ b/cadasta/core/tests/test_pagination.py
@@ -1,0 +1,87 @@
+
+from django.test import TestCase
+from rest_framework import serializers
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+from rest_framework.settings import api_settings
+from unittest.mock import patch, MagicMock
+
+from ..util import paginate_results, get_next_link, get_previous_link
+
+
+class PaginationTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _get_request(self, *args, **kwargs):
+        req = self.factory.get(*args, **kwargs)
+        return APIView().initialize_request(req)
+
+    @patch('core.util.get_next_link', MagicMock(return_value='http://nxt'))
+    @patch('core.util.get_previous_link', MagicMock(return_value='http://prv'))
+    def test_pagination(self):
+        req = self._get_request('/foo', {'limit': 10, 'offset': 20})
+        qs = [{'id': i} for i in range(50)]
+
+        class FakeSerializer(serializers.Serializer):
+            id = serializers.IntegerField()
+
+        assert paginate_results(req, (qs, FakeSerializer)) == {
+            'count': 50,
+            'next': 'http://nxt',
+            'previous': 'http://prv',
+            'results': [{'id': 20+i} for i in range(10)]
+        }
+
+    @patch('core.util.get_next_link', MagicMock(return_value='http://nxt'))
+    @patch('core.util.get_previous_link', MagicMock(return_value='http://prv'))
+    def test_pagination_multiple_datatypes(self):
+        req = self._get_request('/foo', {'limit': 10, 'offset': 20})
+        qs1 = [{'id': i} for i in range(25)]
+        qs2 = [{'name': i} for i in range(25)]
+
+        class FakeSerializer1(serializers.Serializer):
+            id = serializers.IntegerField()
+
+        class FakeSerializer2(serializers.Serializer):
+            name = serializers.IntegerField()
+
+        resp = paginate_results(
+            req, (qs1, FakeSerializer1), (qs2, FakeSerializer2))
+        assert resp == {
+            'count': 50,
+            'next': 'http://nxt',
+            'previous': 'http://prv',
+            'results': (
+                [{'id': 20+i} for i in range(5)] +
+                [{'name': i} for i in range(5)]
+            )
+        }
+
+    def test_next_link(self):
+        req = self._get_request('/foo')
+        assert (
+            get_next_link(req, 200) ==
+            'http://testserver/foo?limit={}&offset=100'.format(
+                api_settings.PAGE_SIZE))
+
+    def test_no_next_link(self):
+        req = self._get_request('/foo', {'offset': 100})
+        assert get_next_link(req, 200) is None
+
+    def test_previous_link(self):
+        req = self._get_request('/foo', {'offset': 200})
+        resp = get_previous_link(req)
+        assert (
+            resp == 'http://testserver/foo?limit={}&offset=100'.format(
+                api_settings.PAGE_SIZE))
+
+        req = self._get_request('/foo', {'offset': api_settings.PAGE_SIZE})
+        resp = get_previous_link(req)
+        assert (
+            resp == 'http://testserver/foo?limit={}'.format(
+                api_settings.PAGE_SIZE))
+
+    def test_no_previous_link(self):
+        req = self._get_request('/foo')
+        assert get_previous_link(req) is None

--- a/cadasta/core/util.py
+++ b/cadasta/core/util.py
@@ -1,6 +1,10 @@
+from collections import OrderedDict
 import random
 import string
+
 import django.utils.text as base_utils
+from rest_framework.settings import api_settings
+from rest_framework.utils.urls import replace_query_param, remove_query_param
 
 
 ID_FIELD_LENGTH = 24
@@ -25,3 +29,70 @@ def slugify(text, max_length=None, allow_unicode=False):
     if max_length is not None:
         slug = slug[:max_length]
     return slug
+
+
+def paginate_results(request, *qs_serializers):
+    """
+    Custom pagination to handle multiple querysets and renderers.
+    Supports serializing 1 to many different querysets. Based of DRF's
+    LimitOffsetPagination. Useful when adding pagination to a regular
+    APIView.
+
+    qs_serializers - tuple of a queryset/array and respective serializer
+    """
+    limit = int(request.query_params.get('limit', api_settings.PAGE_SIZE))
+    offset = int(request.query_params.get('offset', 0))
+
+    count = 0
+    cur_offset = offset
+    out = []
+    for qs, serializer in qs_serializers:
+        len_func = ('__len__' if isinstance(qs, list) else 'count')
+        qs_len = getattr(qs, len_func)()
+        count += qs_len
+        if (len(out) < limit):
+            end_index = min([limit - len(out) + cur_offset, qs_len])
+            qs = qs[cur_offset:end_index]
+            if qs:
+                out += serializer(qs, many=True).data
+            cur_offset = max([cur_offset - end_index, 0])
+
+    return OrderedDict([
+        ('count', count),
+        ('next', get_next_link(request, count)),
+        ('previous', get_previous_link(request)),
+        ('results', out),
+    ])
+
+
+def get_next_link(request, count):
+    """ Generate URL of next page in pagination. """
+    limit = int(request.query_params.get('limit', api_settings.PAGE_SIZE))
+    offset = int(request.query_params.get('offset', 0))
+
+    if offset + limit >= count:
+        return None
+
+    url = request.build_absolute_uri()
+    url = replace_query_param(url, 'limit', limit)
+
+    offset = offset + limit
+    return replace_query_param(url, 'offset', offset)
+
+
+def get_previous_link(request):
+    """ Generate URL of previous page in pagination. """
+    limit = int(request.query_params.get('limit', api_settings.PAGE_SIZE))
+    offset = int(request.query_params.get('offset', 0))
+
+    if offset <= 0:
+        return None
+
+    url = request.build_absolute_uri()
+    url = replace_query_param(url, 'limit', limit)
+
+    if offset - limit <= 0:
+        return remove_query_param(url, 'offset')
+
+    offset = offset - limit
+    return replace_query_param(url, 'offset', offset)

--- a/cadasta/organization/tests/test_views_api_organizations.py
+++ b/cadasta/organization/tests/test_views_api_organizations.py
@@ -36,8 +36,8 @@ class OrganizationListAPITest(APITestCase, UserTestCase, TestCase):
         OrganizationFactory.create_batch(2)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
-        assert 'users' not in response.content[0]
+        assert len(response.content['results']) == 2
+        assert 'users' not in response.content['results'][0]
 
     def test_list_only_one_organization_is_authorized(self):
         """
@@ -57,8 +57,8 @@ class OrganizationListAPITest(APITestCase, UserTestCase, TestCase):
 
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 1
-        assert response.content[0]['slug'] != 'unauthorized'
+        assert len(response.content['results']) == 1
+        assert response.content['results'][0]['slug'] != 'unauthorized'
 
     def test_full_list_with_unauthorized_user(self):
         """
@@ -67,8 +67,8 @@ class OrganizationListAPITest(APITestCase, UserTestCase, TestCase):
         OrganizationFactory.create_batch(2)
         response = self.request()
         assert response.status_code == 200
-        assert len(response.content) == 2
-        assert 'users' not in response.content[0]
+        assert len(response.content['results']) == 2
+        assert 'users' not in response.content['results'][0]
 
     def test_filter_active(self):
         """
@@ -81,8 +81,8 @@ class OrganizationListAPITest(APITestCase, UserTestCase, TestCase):
                                         admin=True)
         response = self.request(user=self.user, get_data={'archived': True})
         assert response.status_code == 200
-        assert len(response.content) == 1
-        assert response.content[0]['archived'] is True
+        assert len(response.content['results']) == 1
+        assert response.content['results'][0]['archived'] is True
 
     def test_search_filter(self):
         """
@@ -95,8 +95,9 @@ class OrganizationListAPITest(APITestCase, UserTestCase, TestCase):
         ])
         response = self.request(user=self.user, get_data={'search': 'match'})
         assert response.status_code == 200
-        assert len(response.content) == 2
-        assert not any([org['name'] == 'Excluded' for org in response.content])
+        assert len(response.content['results']) == 2
+        assert not any([org['name'] == 'Excluded' for org in
+                        response.content['results']])
 
     def test_ordering(self):
         OrganizationFactory.create_from_kwargs([
@@ -105,8 +106,8 @@ class OrganizationListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=self.user,
                                 get_data={'ordering': 'name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [org['name'] for org in response.content]
+        assert len(response.content['results']) == 3
+        names = [org['name'] for org in response.content['results']]
         assert(names == sorted(names))
 
     def test_reverse_ordering(self):
@@ -116,8 +117,8 @@ class OrganizationListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=self.user,
                                 get_data={'ordering': '-name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [org['name'] for org in response.content]
+        assert len(response.content['results']) == 3
+        names = [org['name'] for org in response.content['results']]
         assert(names == sorted(names, reverse=True))
 
     def test_permission_filter(self):
@@ -138,8 +139,8 @@ class OrganizationListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=self.user,
                                 get_data={'permissions': 'project.create'})
         assert response.status_code == 200
-        assert len(response.content) == 1
-        assert response.content[0]['slug'] != 'unauthorized'
+        assert len(response.content['results']) == 1
+        assert response.content['results'][0]['slug'] != 'unauthorized'
 
 
 class OrganizationCreateAPITest(APITestCase, UserTestCase, TestCase):
@@ -403,9 +404,9 @@ class OrganizationUsersAPITest(APITestCase, UserTestCase, TestCase):
         other_user = UserFactory.create()
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
         assert (other_user.username not in
-                [u['username'] for u in response.content])
+                [u['username'] for u in response.content['results']])
 
     def test_get_users_with_unauthorized_user(self):
         response = self.request()

--- a/cadasta/organization/tests/test_views_api_projects.py
+++ b/cadasta/organization/tests/test_views_api_projects.py
@@ -65,9 +65,9 @@ class ProjectUsersAPITest(APITestCase, UserTestCase, TestCase):
         self.project = ProjectFactory.create(add_users=prj_users)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
         assert (other_user.username not in
-                [u['username'] for u in response.content])
+                [u['username'] for u in response.content['results']])
 
     def test_full_list_with_unauthorized_user(self):
         self.project = ProjectFactory.create()
@@ -302,9 +302,9 @@ class OrganizationProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ProjectFactory.create_batch(2)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
         assert all([proj.get('organization').get('id') == self.organization.id
-                    for proj in response.content])
+                    for proj in response.content['results']])
 
     def test_full_list_with_unauthorized_user(self):
         """
@@ -314,9 +314,9 @@ class OrganizationProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ProjectFactory.create_batch(2)
         response = self.request()
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
         assert all([proj.get('organization').get('id') == self.organization.id
-                    for proj in response.content])
+                    for proj in response.content['results']])
 
     def test_filter_archived_without_authorization(self):
         """
@@ -326,7 +326,7 @@ class OrganizationProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ProjectFactory.create(organization=self.organization, archived=False)
         response = self.request(user=self.user, get_data={'archived': True})
         assert response.status_code == 200
-        assert len(response.content) == 0
+        assert len(response.content['results']) == 0
 
     def test_fitler_archived_with_org_admin(self):
         """
@@ -339,7 +339,7 @@ class OrganizationProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ProjectFactory.create(organization=self.organization, archived=False)
         response = self.request(user=user, get_data={'archived': True})
         assert response.status_code == 200
-        assert len(response.content) == 1
+        assert len(response.content['results']) == 1
 
     def test_search_filter(self):
         """
@@ -349,8 +349,9 @@ class OrganizationProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ProjectFactory.create(organization=self.organization, name='aaaa',)
         response = self.request(user=self.user, get_data={'search': 'opdp'})
         assert response.status_code == 200
-        assert len(response.content) == 1
-        assert all([proj['name'] == 'opdp' for proj in response.content])
+        assert len(response.content['results']) == 1
+        assert all([proj['name'] == 'opdp' for proj in
+                    response.content['results']])
 
     def test_ordering(self):
         ProjectFactory.create_from_kwargs([
@@ -360,8 +361,8 @@ class OrganizationProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ])
         response = self.request(user=self.user, get_data={'ordering': 'name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [proj['name'] for proj in response.content]
+        assert len(response.content['results']) == 3
+        names = [proj['name'] for proj in response.content['results']]
         assert names == sorted(names)
 
     def test_reverse_ordering(self):
@@ -372,8 +373,8 @@ class OrganizationProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ])
         response = self.request(user=self.user, get_data={'ordering': '-name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [proj['name'] for proj in response.content]
+        assert len(response.content['results']) == 3
+        names = [proj['name'] for proj in response.content['results']]
         assert names == sorted(names, reverse=True)
 
     def test_permission_filter(self):
@@ -397,8 +398,8 @@ class OrganizationProjectListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=self.user,
                                 get_data={'permissions': 'party.create'})
         assert response.status_code == 200
-        assert len(response.content) == 1
-        assert response.content[0]['slug'] != 'unauthorized'
+        assert len(response.content['results']) == 1
+        assert response.content['results'][0]['slug'] != 'unauthorized'
 
 
 class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
@@ -417,7 +418,7 @@ class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ProjectFactory.create_batch(2)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 4
+        assert len(response.content['results']) == 4
 
     def test_full_list_with_superuser(self):
         """
@@ -431,7 +432,7 @@ class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ProjectFactory.create_batch(2)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 4
+        assert len(response.content['results']) == 4
 
     def test_full_list_with_unauthorized_user(self):
         """
@@ -441,9 +442,9 @@ class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ProjectFactory.create_batch(2)
         response = self.request()
         assert response.status_code == 200
-        assert len(response.content) == 4
+        assert len(response.content['results']) == 4
         assert all(['users' not in proj['organization']
-                    for proj in response.content])
+                    for proj in response.content['results']])
 
     def test_empty_list_with_unauthorized_user(self):
         """
@@ -451,7 +452,7 @@ class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
         """
         response = self.request()
         assert response.status_code == 200
-        assert len(response.content) == 0
+        assert len(response.content['results']) == 0
 
     def test_filter_active(self):
         """
@@ -461,7 +462,7 @@ class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ProjectFactory.create(archived=False)
         response = self.request(user=self.user, get_data={'archived': False})
         assert response.status_code == 200
-        assert len(response.content) == 1
+        assert len(response.content['results']) == 1
 
     def test_search_filter(self):
         """
@@ -471,8 +472,9 @@ class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ProjectFactory.create_batch(2)
         response = self.request(user=self.user, get_data={'search': 'opdp'})
         assert response.status_code == 200
-        assert len(response.content) == 1
-        assert all([proj['name'] == 'opdp' for proj in response.content])
+        assert len(response.content['results']) == 1
+        assert all([proj['name'] == 'opdp' for proj in
+                    response.content['results']])
 
     def test_ordering(self):
         ProjectFactory.create_from_kwargs([
@@ -480,8 +482,8 @@ class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ])
         response = self.request(user=self.user, get_data={'ordering': 'name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [proj['name'] for proj in response.content]
+        assert len(response.content['results']) == 3
+        names = [proj['name'] for proj in response.content['results']]
         assert names == sorted(names)
 
     def test_reverse_ordering(self):
@@ -490,8 +492,8 @@ class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
         ])
         response = self.request(user=self.user, get_data={'ordering': '-name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [proj['name'] for proj in response.content]
+        assert len(response.content['results']) == 3
+        names = [proj['name'] for proj in response.content['results']]
         assert names == sorted(names, reverse=True)
 
     def test_permission_filter(self):
@@ -515,8 +517,8 @@ class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=self.user,
                                 get_data={'permissions': 'party.create'})
         assert response.status_code == 200
-        assert len(response.content) == 1
-        assert response.content[0]['slug'] != 'unauthorized'
+        assert len(response.content['results']) == 1
+        assert response.content['results'][0]['slug'] != 'unauthorized'
 
     # CONDITIONS:
     #
@@ -556,7 +558,7 @@ class ProjectListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=user)
         assert response.status_code == 200
         expected_names = [prjs[i].name for i in idxs]
-        pnames = [p['name'] for p in response.content]
+        pnames = [p['name'] for p in response.content['results']]
         assert(sorted(expected_names) == sorted(pnames))
 
     def test_visibility_filtering(self):

--- a/cadasta/organization/tests/test_views_api_users.py
+++ b/cadasta/organization/tests/test_views_api_users.py
@@ -34,7 +34,7 @@ class UserListAPITest(APITestCase, UserTestCase, TestCase):
         UserFactory.create_batch(2)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 3
+        assert len(response.content['results']) == 3
 
     def test_full_list_organizations(self):
         """
@@ -46,20 +46,20 @@ class UserListAPITest(APITestCase, UserTestCase, TestCase):
         o2 = OrganizationFactory.create(add_users=[user2])
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 3
+        assert len(response.content['results']) == 3
 
-        assert 'organizations' in response.content[0]
-        assert response.content[0]['organizations'] == []
-        assert 'organizations' in response.content[1]
+        assert 'organizations' in response.content['results'][0]
+        assert response.content['results'][0]['organizations'] == []
+        assert 'organizations' in response.content['results'][1]
         assert ({'id': o0.id, 'name': o0.name}
-                in response.content[1]['organizations'])
+                in response.content['results'][1]['organizations'])
         assert ({'id': o1.id, 'name': o1.name}
-                in response.content[1]['organizations'])
-        assert 'organizations' in response.content[2]
+                in response.content['results'][1]['organizations'])
+        assert 'organizations' in response.content['results'][2]
         assert ({'id': o0.id, 'name': o0.name}
-                in response.content[2]['organizations'])
+                in response.content['results'][2]['organizations'])
         assert ({'id': o2.id, 'name': o2.name}
-                in response.content[2]['organizations'])
+                in response.content['results'][2]['organizations'])
 
     def test_full_list_with_unautorized_user(self):
         """
@@ -79,7 +79,7 @@ class UserListAPITest(APITestCase, UserTestCase, TestCase):
         ])
         response = self.request(user=self.user, get_data={'is_active': True})
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
     def test_search_filter(self):
         """
@@ -92,9 +92,9 @@ class UserListAPITest(APITestCase, UserTestCase, TestCase):
         ])
         response = self.request(user=self.user, get_data={'search': 'match'})
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
         assert not any([user['username'] == 'excluded'
-                        for user in response.content])
+                        for user in response.content['results']])
 
     def test_ordering(self):
         UserFactory.create_from_kwargs([
@@ -103,8 +103,8 @@ class UserListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=self.user,
                                 get_data={'ordering': 'username'})
         assert response.status_code == 200
-        assert len(response.content) == 4
-        usernames = [user['username'] for user in response.content]
+        assert len(response.content['results']) == 4
+        usernames = [user['username'] for user in response.content['results']]
         assert(usernames == sorted(usernames))
 
     def test_reverse_ordering(self):
@@ -114,8 +114,8 @@ class UserListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=self.user,
                                 get_data={'ordering': '-username'})
         assert response.status_code == 200
-        assert len(response.content) == 4
-        usernames = [user['username'] for user in response.content]
+        assert len(response.content['results']) == 4
+        usernames = [user['username'] for user in response.content['results']]
         assert(usernames == sorted(usernames, reverse=True))
 
 

--- a/cadasta/party/tests/test_views_api_parties.py
+++ b/cadasta/party/tests/test_views_api_parties.py
@@ -65,8 +65,8 @@ class PartyListAPITest(APITestCase, UserTestCase, TestCase):
         PartyFactory.create_batch(2, project=self.prj)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
-        assert 'users' not in response.content[0]
+        assert len(response.content['results']) == 2
+        assert 'users' not in response.content['results'][0]
 
     def test_full_list_with_unauthorized_user(self):
         PartyFactory.create(project=self.prj)
@@ -83,7 +83,7 @@ class PartyListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=self.user,
                                 get_data={'name': 'Test Party One'})
         assert response.status_code == 200
-        assert len(response.content) == 1
+        assert len(response.content['results']) == 1
 
     def test_type_filter(self):
         PartyFactory.create_from_kwargs([
@@ -93,7 +93,7 @@ class PartyListAPITest(APITestCase, UserTestCase, TestCase):
         ])
         response = self.request(user=self.user, get_data={'type': 'GR'})
         assert response.status_code == 200
-        assert len(response.content) == 1
+        assert len(response.content['results']) == 1
 
     def test_ordering(self):
         PartyFactory.create_from_kwargs([
@@ -103,8 +103,8 @@ class PartyListAPITest(APITestCase, UserTestCase, TestCase):
         ])
         response = self.request(user=self.user, get_data={'ordering': 'name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [party['name'] for party in response.content]
+        assert len(response.content['results']) == 3
+        names = [party['name'] for party in response.content['results']]
         assert names == sorted(names)
 
     def test_reverse_ordering(self):
@@ -115,8 +115,8 @@ class PartyListAPITest(APITestCase, UserTestCase, TestCase):
         ])
         response = self.request(user=self.user, get_data={'ordering': '-name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [party['name'] for party in response.content]
+        assert len(response.content['results']) == 3
+        names = [party['name'] for party in response.content['results']]
         assert names == sorted(names, reverse=True)
 
     def test_get_full_list_organization_does_not_exist(self):
@@ -290,9 +290,9 @@ class PartyResourceListAPITest(APITestCase, UserTestCase, FileStorageTestCase,
     def test_full_list(self):
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
-        returned_ids = [r['id'] for r in response.content]
+        returned_ids = [r['id'] for r in response.content['results']]
         assert all(res.id in returned_ids for res in self.resources)
 
     def test_full_list_with_unauthorized_user(self):
@@ -313,8 +313,8 @@ class PartyResourceListAPITest(APITestCase, UserTestCase, FileStorageTestCase,
             url_kwargs={'party': party.id},
             get_data={'ordering': 'name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [resource['name'] for resource in response.content]
+        assert len(response.content['results']) == 3
+        names = [resource['name'] for resource in response.content['results']]
         assert(names == sorted(names))
 
     def test_reverse_ordering(self):
@@ -330,8 +330,8 @@ class PartyResourceListAPITest(APITestCase, UserTestCase, FileStorageTestCase,
             url_kwargs={'party': party.id},
             get_data={'ordering': '-name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [resource['name'] for resource in response.content]
+        assert len(response.content['results']) == 3
+        names = [resource['name'] for resource in response.content['results']]
         assert(names == sorted(names, reverse=True))
 
     def test_search_filter(self):
@@ -353,7 +353,7 @@ class PartyResourceListAPITest(APITestCase, UserTestCase, FileStorageTestCase,
                         'party': party.id},
             get_data={'search': 'image'})
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
     def test_get_full_list_organization_does_not_exist(self):
         response = self.request(user=self.user,
@@ -378,9 +378,9 @@ class PartyResourceListAPITest(APITestCase, UserTestCase, FileStorageTestCase,
             project=self.prj, content_object=self.party, archived=True)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
-        returned_ids = [r['id'] for r in response.content]
+        returned_ids = [r['id'] for r in response.content['results']]
         assert all(res.id in returned_ids for res in self.resources)
 
     def test_add_resource(self):

--- a/cadasta/party/tests/test_views_api_relationship_list.py
+++ b/cadasta/party/tests/test_views_api_relationship_list.py
@@ -65,9 +65,9 @@ class SpatialUnitsRelationshipListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=self.user,
                                 url_kwargs={'location': su1.id})
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
         valid_ids = (sr1.id, sr2.id)
-        for rel in response.content:
+        for rel in response.content['results']:
             assert rel['id'] in valid_ids
 
     def test_get_all_relationships_of_party(self):
@@ -85,9 +85,9 @@ class SpatialUnitsRelationshipListAPITest(APITestCase, UserTestCase, TestCase):
         response = self.request(user=self.user,
                                 url_kwargs={'party': party1.id})
         assert response.status_code == 200
-        assert len(response.content) == 3
+        assert len(response.content['results']) == 3
         valid_ids = (pr1.id, pr2.id, tr1.id)
-        for rel in response.content:
+        for rel in response.content['results']:
             assert rel['id'] in valid_ids
 
     def test_get_invalid_relationship_class(self):

--- a/cadasta/party/tests/test_views_api_tenure_relationships.py
+++ b/cadasta/party/tests/test_views_api_tenure_relationships.py
@@ -638,9 +638,9 @@ class TenureRelationshipResourceListAPITest(APITestCase, FileStorageTestCase,
     def test_full_list(self):
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
-        returned_ids = [r['id'] for r in response.content]
+        returned_ids = [r['id'] for r in response.content['results']]
         assert all(res.id in returned_ids for res in self.resources)
 
     def test_full_list_with_unauthorized_user(self):
@@ -662,8 +662,8 @@ class TenureRelationshipResourceListAPITest(APITestCase, FileStorageTestCase,
             url_kwargs={'tenure_rel_id': tenure.id},
             get_data={'ordering': 'name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [resource['name'] for resource in response.content]
+        assert len(response.content['results']) == 3
+        names = [resource['name'] for resource in response.content['results']]
         assert(names == sorted(names))
 
     def test_reverse_ordering(self):
@@ -680,8 +680,8 @@ class TenureRelationshipResourceListAPITest(APITestCase, FileStorageTestCase,
             url_kwargs={'tenure_rel_id': tenure.id},
             get_data={'ordering': '-name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [resource['name'] for resource in response.content]
+        assert len(response.content['results']) == 3
+        names = [resource['name'] for resource in response.content['results']]
         assert(names == sorted(names, reverse=True))
 
     def test_search_filter(self):
@@ -704,7 +704,7 @@ class TenureRelationshipResourceListAPITest(APITestCase, FileStorageTestCase,
                         'tenure_rel_id': tenure.id},
             get_data={'search': 'image'})
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
     def test_get_full_list_organization_does_not_exist(self):
         response = self.request(user=self.user,
@@ -729,9 +729,9 @@ class TenureRelationshipResourceListAPITest(APITestCase, FileStorageTestCase,
             project=self.prj, content_object=self.tenure, archived=True)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
-        returned_ids = [r['id'] for r in response.content]
+        returned_ids = [r['id'] for r in response.content['results']]
         assert all(res.id in returned_ids for res in self.resources)
 
     def test_add_resource(self):

--- a/cadasta/resources/tests/test_views_api.py
+++ b/cadasta/resources/tests/test_views_api.py
@@ -91,9 +91,9 @@ class ProjectResourcesTest(APITestCase, UserTestCase,
     def test_list_resources(self):
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
-        returned_ids = [r['id'] for r in response.content]
+        returned_ids = [r['id'] for r in response.content['results']]
         assert all(res.id in returned_ids for res in self.resources)
 
     def test_get_full_list_organization_does_not_exist(self):
@@ -110,7 +110,7 @@ class ProjectResourcesTest(APITestCase, UserTestCase,
     def test_get_full_list_with_unauthorized_user(self):
         response = self.request(user=UserFactory.create())
         assert response.status_code == 200
-        assert len(response.content) == 0
+        assert len(response.content['results']) == 0
 
     def test_add_resource(self):
         response = self.request(method='POST', user=self.user)
@@ -171,7 +171,7 @@ class ProjectResourcesTest(APITestCase, UserTestCase,
                         'project': prj.slug},
             get_data={'search': 'image'})
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
     def test_filter_unarchived(self):
         prj = ProjectFactory.create()
@@ -186,7 +186,7 @@ class ProjectResourcesTest(APITestCase, UserTestCase,
                         'project': prj.slug},
             get_data={'archived': False})
         assert response.status_code == 200
-        assert len(response.content) == 1
+        assert len(response.content['results']) == 1
 
     def test_filter_archived_with_nonunarchiver(self):
         prj = ProjectFactory.create()
@@ -202,7 +202,7 @@ class ProjectResourcesTest(APITestCase, UserTestCase,
                         'project': prj.slug},
             get_data={'archived': True})
         assert response.status_code == 200
-        assert len(response.content) == 0
+        assert len(response.content['results']) == 0
 
     def test_filter_archived_with_unarchiver(self):
         prj = ProjectFactory.create()
@@ -223,7 +223,7 @@ class ProjectResourcesTest(APITestCase, UserTestCase,
                         'project': prj.slug},
             get_data={'archived': True})
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
     def test_ordering(self):
         prj = ProjectFactory.create()
@@ -239,8 +239,8 @@ class ProjectResourcesTest(APITestCase, UserTestCase,
                         'project': prj.slug},
             get_data={'ordering': 'name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [resource['name'] for resource in response.content]
+        assert len(response.content['results']) == 3
+        names = [resource['name'] for resource in response.content['results']]
         assert(names == sorted(names))
 
     def test_reverse_ordering(self):
@@ -256,8 +256,8 @@ class ProjectResourcesTest(APITestCase, UserTestCase,
                         'project': prj.slug},
             get_data={'ordering': '-name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [resource['name'] for resource in response.content]
+        assert len(response.content['results']) == 3
+        names = [resource['name'] for resource in response.content['results']]
         assert(names == sorted(names, reverse=True))
 
 
@@ -470,20 +470,21 @@ class ProjectSpatialResourcesTest(APITestCase, UserTestCase,
     def test_list_spatial_resources(self):
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 1
-        assert response.content[0]['id'] == self.resource.id
-        assert response.content[0]['spatial_resources'] is not None
-        assert response.content[0]['spatial_resources'][0]['name'] == 'tracks'
-        assert response.content[0]['spatial_resources'][0][
+        results = response.content['results']
+        assert len(results) == 1
+        assert results[0]['id'] == self.resource.id
+        assert results[0]['spatial_resources'] is not None
+        assert results[0]['spatial_resources'][0]['name'] == 'tracks'
+        assert results[0]['spatial_resources'][0][
             'geom']['type'] == 'GeometryCollection'
-        assert response.content[0]['spatial_resources'][0]['geom'][
+        assert results[0]['spatial_resources'][0]['geom'][
             'geometries'][0]['type'] == 'MultiLineString'
 
     def test_list_spatial_resources_with_unauthorized_user(self):
         response = self.request(user=UserFactory.create())
         assert response.status_code == 200
-        assert len(response.content) == 0
-        assert response.content == []
+        assert len(response.content['results']) == 0
+        assert response.content['results'] == []
 
 
 @pytest.mark.usefixtures('make_dirs')

--- a/cadasta/spatial/tests/test_views_api_spatial_units.py
+++ b/cadasta/spatial/tests/test_views_api_spatial_units.py
@@ -63,9 +63,10 @@ class SpatialUnitListAPITest(APITestCase, UserTestCase, TestCase):
         extra_record = SpatialUnitFactory.create()
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
-        assert extra_record.id not in (
-            [u['properties']['id'] for u in response.content['features']])
+        assert len(response.content['results']) == 2
+        assert extra_record.id not in [
+            u['properties']['id'] for u in
+            response.content['results']['features']]
 
     def test_full_list_with_unauthorized_user(self):
         SpatialUnitFactory.create_batch(2, project=self.prj)
@@ -73,9 +74,10 @@ class SpatialUnitListAPITest(APITestCase, UserTestCase, TestCase):
 
         response = self.request()
         assert response.status_code == 200
-        assert len(response.content) == 2
-        assert extra_record.id not in (
-            [u['properties']['id'] for u in response.content['features']])
+        assert len(response.content['results']) == 2
+        assert extra_record.id not in [
+            u['properties']['id'] for u in
+            response.content['results']['features']]
 
     def test_ordering(self):
         SpatialUnitFactory.create(project=self.prj, type='AP')
@@ -84,9 +86,9 @@ class SpatialUnitListAPITest(APITestCase, UserTestCase, TestCase):
 
         response = self.request(user=self.user, get_data={'ordering': 'type'})
         assert response.status_code == 200
-        assert len(response.content['features']) == 3
+        assert len(response.content['results']['features']) == 3
         names = [su['properties']['type'] for su in
-                 response.content['features']]
+                 response.content['results']['features']]
         assert names == sorted(names)
 
     def test_reverse_ordering(self):
@@ -96,9 +98,9 @@ class SpatialUnitListAPITest(APITestCase, UserTestCase, TestCase):
 
         response = self.request(user=self.user, get_data={'ordering': '-type'})
         assert response.status_code == 200
-        assert len(response.content['features']) == 3
+        assert len(response.content['results']['features']) == 3
         names = [su['properties']['type'] for su in
-                 response.content['features']]
+                 response.content['results']['features']]
         assert names == sorted(names, reverse=True)
 
     def test_type_filter(self):
@@ -107,7 +109,7 @@ class SpatialUnitListAPITest(APITestCase, UserTestCase, TestCase):
         SpatialUnitFactory.create(project=self.prj, type='RW')
         response = self.request(user=self.user, get_data={'type': 'RW'})
         assert response.status_code == 200
-        assert len(response.content['features']) == 1
+        assert len(response.content['results']['features']) == 1
 
     def test_get_full_list_organization_does_not_exist(self):
         response = self.request(user=self.user,
@@ -129,9 +131,10 @@ class SpatialUnitListAPITest(APITestCase, UserTestCase, TestCase):
         extra_record = SpatialUnitFactory.create()
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
-        assert extra_record.id not in (
-            [u['properties']['id'] for u in response.content['features']])
+        assert len(response.content['results']) == 2
+        assert extra_record.id not in [
+            u['properties']['id'] for u in
+            response.content['results']['features']]
 
     def test_list_private_record_with_unauthorized_user(self):
         self.prj.access = 'private'
@@ -789,9 +792,9 @@ class SpatialUnitResourceListAPITest(APITestCase, UserTestCase,
     def test_full_list(self):
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
-        returned_ids = [r['id'] for r in response.content]
+        returned_ids = [r['id'] for r in response.content['results']]
         assert all(res.id in returned_ids for res in self.resources)
 
     def test_full_list_with_unauthorized_user(self):
@@ -812,8 +815,8 @@ class SpatialUnitResourceListAPITest(APITestCase, UserTestCase,
             url_kwargs={'location': su.id},
             get_data={'ordering': 'name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [resource['name'] for resource in response.content]
+        assert len(response.content['results']) == 3
+        names = [resource['name'] for resource in response.content['results']]
         assert(names == sorted(names))
 
     def test_reverse_ordering(self):
@@ -829,8 +832,8 @@ class SpatialUnitResourceListAPITest(APITestCase, UserTestCase,
             url_kwargs={'location': su.id},
             get_data={'ordering': '-name'})
         assert response.status_code == 200
-        assert len(response.content) == 3
-        names = [resource['name'] for resource in response.content]
+        assert len(response.content['results']) == 3
+        names = [resource['name'] for resource in response.content['results']]
         assert(names == sorted(names, reverse=True))
 
     def test_search_filter(self):
@@ -852,7 +855,7 @@ class SpatialUnitResourceListAPITest(APITestCase, UserTestCase,
                         'location': su.id},
             get_data={'search': 'image'})
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
     def test_get_full_list_organization_does_not_exist(self):
         response = self.request(user=self.user,
@@ -877,9 +880,9 @@ class SpatialUnitResourceListAPITest(APITestCase, UserTestCase,
             project=self.prj, content_object=self.su, archived=True)
         response = self.request(user=self.user)
         assert response.status_code == 200
-        assert len(response.content) == 2
+        assert len(response.content['results']) == 2
 
-        returned_ids = [r['id'] for r in response.content]
+        returned_ids = [r['id'] for r in response.content['results']]
         assert all(res.id in returned_ids for res in self.resources)
 
     def test_add_resource(self):


### PR DESCRIPTION
### Proposed changes in this pull request

All API list views now paginate the data returned.  This is important if we are to avoid tying up web servers with large responses (and is a requirement for #1400).  The default page size is set to `100` elements, although this can be changed via the URL or per view.  To add pagination, I used the [`LimitOffsetPagination`](http://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination) class which I felt adds a bit more transparency about the request than the [`PageNumberPagination`](http://www.django-rest-framework.org/api-guide/pagination/#pagenumberpagination) used by the `/async/organizations/<organization>/projects/<project>/spatial/` view (being that it makes the `limit` value obvious) *(this will likely be the most contentious aspect of the PR)*.


### When should this PR be merged

Any time seems fine.

### Risks

**Medium - High**

Any current consumers of the API will need to be updated to support paginated responses. At current moment, I am only familiar with scripts used by @SteadyCadence and the QGIS Plugin.  A PR for the QGIS plugin is linked below.

To the best of my knowledge, our JS scripts on the front-end do not require any changes as they all request data from `/async` endpoints.

**Please let me know if there are other consumers of the API that could be disrupted from these changes!**

### Follow-up actions

- Updates should be made to the API Documentation (See cadasta/api-docs#30)
- Updates should be made to the QGIS Plugin (See cadasta/cadasta-qgis-plugin#154)


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 