### PR TITLE
Fix #1373 -- Ignore empty geometries for SHP export

### DIFF
--- a/cadasta/organization/download/shape.py
+++ b/cadasta/organization/download/shape.py
@@ -74,6 +74,10 @@ class ShapeExporter(Exporter):
         layers = {}
 
         for su in spatial_units:
+            # Excluding empty geometries from export
+            if not su.geometry:
+                continue
+
             geom = ogr.CreateGeometryFromWkt(su.geometry.wkt)
             layer_type = geom.GetGeometryName().lower()
             layer = layers.get(layer_type, None)

--- a/cadasta/organization/tests/test_downloads.py
+++ b/cadasta/organization/tests/test_downloads.py
@@ -419,9 +419,12 @@ class ShapeTest(UserTestCase, TestCase):
             attributes={'geom_type': 'multipolygon'})
         su7 = SpatialUnitFactory.create(
             project=project,
-            geometry='SRID=4326;'
-                     'POLYGON EMPTY',
+            geometry='SRID=4326;POLYGON EMPTY',
             attributes={'geom_type': 'empty'})
+        su8 = SpatialUnitFactory.create(
+            project=project,
+            geometry=None,
+            attributes={'geom_type': 'none'})
 
         dst_dir = os.path.join(settings.MEDIA_ROOT, 'temp/file4')
         ds = exporter.create_datasource(dst_dir)
@@ -437,7 +440,7 @@ class ShapeTest(UserTestCase, TestCase):
             assert feature.GetFieldAsString('id') == su.id
 
             # Ensuring empty polygons are not added to shape
-            assert su.id != su7.id
+            assert su.id not in [su7.id, su8.id]
         ds.Destroy()
 
         with open(filename) as csvfile:
@@ -459,6 +462,8 @@ class ShapeTest(UserTestCase, TestCase):
                     assert row == [su6.id, su6.type, 'multipolygon']
                 if i == 7:
                     assert row == [su7.id, su7.type, 'empty']
+                if i == 8:
+                    assert row == [su8.id, su8.type, 'none']
 
         # remove this so other tests pass
         os.remove(filename)

--- a/cadasta/organization/tests/test_downloads.py
+++ b/cadasta/organization/tests/test_downloads.py
@@ -417,6 +417,11 @@ class ShapeTest(UserTestCase, TestCase):
                      'MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),'
                      '((15 5, 40 10, 10 20, 5 10, 15 5)))',
             attributes={'geom_type': 'multipolygon'})
+        su7 = SpatialUnitFactory.create(
+            project=project,
+            geometry='SRID=4326;'
+                     'POLYGON EMPTY',
+            attributes={'geom_type': 'empty'})
 
         dst_dir = os.path.join(settings.MEDIA_ROOT, 'temp/file4')
         ds = exporter.create_datasource(dst_dir)
@@ -430,6 +435,9 @@ class ShapeTest(UserTestCase, TestCase):
             feature = layer.GetNextFeature()
             assert geom.equals(GEOSGeometry(feature.geometry().ExportToWkt()))
             assert feature.GetFieldAsString('id') == su.id
+
+            # Ensuring empty polygons are not added to shape
+            assert su.id != su7.id
         ds.Destroy()
 
         with open(filename) as csvfile:
@@ -449,6 +457,8 @@ class ShapeTest(UserTestCase, TestCase):
                     assert row == [su5.id, su5.type, 'multilinestring']
                 if i == 6:
                     assert row == [su6.id, su6.type, 'multipolygon']
+                if i == 7:
+                    assert row == [su7.id, su7.type, 'empty']
 
         # remove this so other tests pass
         os.remove(filename)


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #1373: Ignores empty geometries when writing spatial units to a shape file. 
- The spatial unit properties are still available throught the CSV.

### When should this PR be merged

Whenever.

### Risks

None.

### Follow-up actions

None.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
