### PR TITLE
Return 401 responses on failed login

### DIFF
--- a/cadasta/accounts/tests/test_views_api.py
+++ b/cadasta/accounts/tests/test_views_api.py
@@ -117,7 +117,7 @@ class AccountLoginTest(APITestCase, UserTestCase, TestCase):
         """The view should return a token to authenticate API calls"""
         data = {'username': 'imagine71', 'password': 'iloveyoko78!'}
         response = self.request(method='POST', post_data=data)
-        assert response.status_code == 400
+        assert response.status_code == 401
 
     def test_login_with_unverified_email(self):
         """The view should return an error message if the User.verify_email_by
@@ -127,7 +127,7 @@ class AccountLoginTest(APITestCase, UserTestCase, TestCase):
         self.user.save()
         data = {'username': 'imagine71', 'password': 'iloveyoko79!'}
         response = self.request(method='POST', post_data=data, user=self.user)
-        assert response.status_code == 400
+        assert response.status_code == 401
         assert 'auth_token' not in response.content
         assert len(mail.outbox) == 1
 

--- a/cadasta/accounts/views/api.py
+++ b/cadasta/accounts/views/api.py
@@ -55,7 +55,7 @@ class AccountLogin(djoser_views.LoginView):
         except ValidationError:
             return Response(
                 data=serializer.errors,
-                status=status.HTTP_400_BAD_REQUEST,
+                status=status.HTTP_401_UNAUTHORIZED,
             )
         except EmailNotVerifiedError:
             user = serializer.user
@@ -66,7 +66,7 @@ class AccountLogin(djoser_views.LoginView):
 
             return Response(
                 data={'detail': _("The email has not been verified.")},
-                status=status.HTTP_400_BAD_REQUEST,
+                status=status.HTTP_401_UNAUTHORIZED,
             )
 
 


### PR DESCRIPTION
### Proposed changes in this pull request

- When a login fails, we currently return a `400` response. A [`401` response](https://httpstatuses.com/401) is slightly more descriptive and accurate.

### When should this PR be merged

Any time.



### Risks

Low. Only complication I could think of would be API consumers, however a review of the QGIS plugin failed to show any issues.

### Follow-up actions

None



### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 