### PR TITLE
Support repr() if Question has no QuestionGroup

### DIFF
--- a/cadasta/questionnaires/models.py
+++ b/cadasta/questionnaires/models.py
@@ -170,9 +170,13 @@ class Question(MultilingualLabelsMixin, RandomIDModel):
     history = HistoricalRecords()
 
     def __repr__(self):
-        repr_string = ('<Question id={obj.id} name={obj.name}'
-                       ' questionnaire={obj.questionnaire.id}'
-                       ' question_group={obj.question_group.id}>')
+        repr_string = (
+            '<Question id={obj.id} name={obj.name}'
+            ' questionnaire={obj.questionnaire.id}'
+            ' question_group=' +
+            ('{obj.question_group.id}' if self.question_group else 'None') +
+            '>'
+        )
         return repr_string.format(obj=self)
 
     @property

--- a/cadasta/questionnaires/tests/test_models.py
+++ b/cadasta/questionnaires/tests/test_models.py
@@ -55,6 +55,14 @@ class QuestionTest(TestCase):
                                   'questionnaire=abc123 '
                                   'question_group=abc123>')
 
+        question = factories.QuestionFactory.build(id='abc234',
+                                                   name='Question',
+                                                   question_group=None,
+                                                   questionnaire=questionnaire)
+        assert repr(question) == ('<Question id=abc234 name=Question '
+                                  'questionnaire=abc123 '
+                                  'question_group=None>')
+
     def test_has_options(self):
         question = factories.QuestionFactory.create(type='S1')
         assert question.has_options is True


### PR DESCRIPTION
### Proposed changes in this pull request

- Currently, if a `Question` has no associated `QuestionGroup`, `repr()` of the `Question` instance fails. This allows it to handle `Question` instances that have no `QuestionGroup`.

### When should this PR be merged

Anytime

### Risks

None

### Follow-up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 