### PR TITLE
Ensure that a view can list projects in an organization even if no projects exist

### DIFF
--- a/cadasta/organization/tests/test_views_api_projects.py
+++ b/cadasta/organization/tests/test_views_api_projects.py
@@ -306,6 +306,14 @@ class OrganizationProjectListAPITest(APITestCase, UserTestCase, TestCase):
         assert all([proj.get('organization').get('id') == self.organization.id
                     for proj in response.content['results']])
 
+    def test_empty_list(self):
+        """
+        It should return an empty array.
+        """
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        assert response.content['results'] == []
+
     def test_full_list_with_unauthorized_user(self):
         """
         It should return all projects.

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -162,6 +162,9 @@ class OrganizationProjectList(PermissionsFilterMixin,
                                          slug=self.kwargs['organization'])
         return self.org
 
+    def get_perms_objects(self):
+        return list(self.get_queryset()) + [self.get_organization()]
+
     def get_serializer_context(self, *args, **kwargs):
         org = self.get_organization()
         context = super(OrganizationProjectList,


### PR DESCRIPTION
### Proposed changes in this pull request

Currently, the `OrganizationProjectList` API view has no `get_perms_objects()` method. When a user loads the Project List api view: `/api/v1/organizations/{slug}/projects/`, our system will search for all projects that the user is permitted to view and return those projects.  If no projects exist, it will return a `403`.  In reality, we should return a response with the body of an empty array (`[]`) and a `200` status code.  Add `get_perms_objects()` allows the view to question if the user is permitted to view the `Organization`, and if so will return the empty array.

### When should this PR be merged

Anytime

### Risks

Low

### Follow-up actions

None


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 