### PR TITLE
Display thumbnails for .TIFF resources

### DIFF
--- a/cadasta/resources/models.py
+++ b/cadasta/resources/models.py
@@ -102,7 +102,7 @@ class Resource(RandomIDModel):
     def thumbnail(self):
         if not hasattr(self, '_thumbnail'):
             icon = settings.ICON_LOOKUPS.get(self.mime_type, None)
-            if 'image' in self.mime_type and 'tif' not in self.mime_type:
+            if 'image' in self.mime_type:
                 ext = self.file_name.split('.')[-1]
                 base_url = self.file.url[:self.file.url.rfind('.')]
                 self._thumbnail = base_url + '-128x128.' + ext


### PR DESCRIPTION
### Proposed changes in this pull request

Strangely, we opt to display a generic thumbnail for resources where `instance.mime_type == image/tiff`. 

![tiff thumbnail](https://s3-us-west-2.amazonaws.com/cadasta-resources/icons/tiff.png)

There may be a story behind this, I'm unsure. However, looking at my dev machine, it appears that thumbnails for TIFF images do get generated correctly.  I believe we should display those thumbnails rather than the generic thumbnail.

<img width="221" alt="screen shot 2017-05-12 at 10 02 40 pm" src="https://cloud.githubusercontent.com/assets/897290/26022303/df6ba00e-375e-11e7-8229-6b997193ea5a.png">



### When should this PR be merged

Anytime



### Risks

There's likely a good reason why we don't currently display .TIFF thumbnails. This was added in #688 as a solution to #668. I'm not sure why this was, perhaps @clash99 can comment on this.

### Follow-up actions

None


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 