### PR TITLE
Reduce the number of warnings logged for tests

### DIFF
--- a/cadasta/accounts/load.py
+++ b/cadasta/accounts/load.py
@@ -14,15 +14,17 @@ def run(verbose=True, force=False):
     pols = {}
     for pol in ['default', 'superuser', 'org-admin', 'org-member',
                 'project-manager', 'data-collector', 'project-user']:
+        policy_file = open(PERMISSIONS_DIR + pol + '.json')
         try:
             pols[pol] = models.Policy.objects.get(name=pol)
-            pols[pol].body = open(PERMISSIONS_DIR + pol + '.json').read()
+            pols[pol].body = policy_file.read()
             pols[pol].save()
         except:
             pols[pol] = models.Policy.objects.create(
                 name=pol,
-                body=open(PERMISSIONS_DIR + pol + '.json').read()
+                body=policy_file.read()
             )
+        policy_file.close()
 
     if not models.Role.objects.filter(name='superuser').exists():
         models.Role.objects.create(

--- a/cadasta/core/mixins.py
+++ b/cadasta/core/mixins.py
@@ -23,7 +23,7 @@ class PermissionRequiredMixin(mixins.PermissionRequiredMixin):
         redirect_url = self.request.META.get('HTTP_REFERER', '/')
 
         if (referer and '/account/login/' in referer and
-                not self.request.user.is_anonymous()):
+                not self.request.user.is_anonymous):
 
             if 'organization' in self.kwargs and 'project' in self.kwargs:
                 redirect_url = reverse(

--- a/cadasta/core/tests/test_mixins.py
+++ b/cadasta/core/tests/test_mixins.py
@@ -163,7 +163,8 @@ class SchemaSelectorMixinTest(UserTestCase, FileStorageTestCase, TestCase):
         super().setUp()
         file = self.get_file(
             '/questionnaires/tests/files/xls-form-attrs.xlsx', 'rb')
-        form = self.storage.save('xls-forms/xls-form-attrs.xlsx', file)
+        form = self.storage.save('xls-forms/xls-form-attrs.xlsx', file.read())
+        file.close()
         self.project = ProjectFactory.create()
         Questionnaire.objects.create_from_form(
             xls_form=form,

--- a/cadasta/core/tests/utils/cases.py
+++ b/cadasta/core/tests/utils/cases.py
@@ -24,11 +24,13 @@ class FileStorageTestCase:
         return self.storage
 
     def get_file(self, path, mode):
-        return open(self.path + path, mode).read()
+        return open(self.path + path, mode)
 
     def get_form(self, form_name):
         file = self.get_file(
             path='/questionnaires/tests/files/{}.xlsx'.format(form_name),
             mode='rb')
-        form = self.storage.save('xls-forms/{}.xlsx'.format(form_name), file)
+        form = self.storage.save('xls-forms/{}.xlsx'.format(form_name),
+                                 file.read())
+        file.close()
         return form

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -593,18 +593,11 @@ class ProjectEditDetailsTest(UserTestCase, FileStorageTestCase, TestCase):
             'contacts-0-tel': ''
         }
 
-    def _get_form(self, form_name):
-        file = self.get_file(
-            '/questionnaires/tests/files/{}.xlsx'.format(form_name),
-            'rb')
-        form = self.storage.save('xls-forms/{}.xlsx'.format(form_name), file)
-        return form
-
     def test_add_new_questionnaire(self):
         project = ProjectFactory.create()
         data = {
             'name': 'New name',
-            'questionnaire': self._get_form('xls-form'),
+            'questionnaire': self.get_form('xls-form'),
             'original_file': 'original.xls',
             'access': project.access,
             'contacts-TOTAL_FORMS': 1,
@@ -628,7 +621,7 @@ class ProjectEditDetailsTest(UserTestCase, FileStorageTestCase, TestCase):
         project = ProjectFactory.create()
         data = {
             'name': 'New name',
-            'questionnaire': self._get_form('xls-form-invalid'),
+            'questionnaire': self.get_form('xls-form-invalid'),
             'access': project.access,
             'contacts-TOTAL_FORMS': 1,
             'contacts-INITIAL_FORMS': 0,
@@ -649,10 +642,10 @@ class ProjectEditDetailsTest(UserTestCase, FileStorageTestCase, TestCase):
         project = ProjectFactory.create()
         questionnaire = QuestionnaireFactory.create(
             project=project,
-            xls_form=self._get_form('xls-form'))
+            xls_form=self.get_form('xls-form'))
         data = {
             'name': 'New name',
-            'questionnaire': self._get_form('xls-form-copy'),
+            'questionnaire': self.get_form('xls-form-copy'),
             'access': project.access,
             'contacts-TOTAL_FORMS': 1,
             'contacts-INITIAL_FORMS': 0,
@@ -677,13 +670,13 @@ class ProjectEditDetailsTest(UserTestCase, FileStorageTestCase, TestCase):
         project = ProjectFactory.create()
         questionnaire = QuestionnaireFactory.create(
             project=project,
-            xls_form=self._get_form('xls-form'))
+            xls_form=self.get_form('xls-form'))
 
         SpatialUnitFactory.create(project=project)
 
         data = {
             'name': 'New name',
-            'questionnaire': self._get_form('xls-form-copy'),
+            'questionnaire': self.get_form('xls-form-copy'),
             'access': project.access,
             'contacts-TOTAL_FORMS': 1,
             'contacts-INITIAL_FORMS': 0,
@@ -707,7 +700,7 @@ class ProjectEditDetailsTest(UserTestCase, FileStorageTestCase, TestCase):
         project = ProjectFactory.create()
         questionnaire = QuestionnaireFactory.create(
             project=project,
-            xls_form=self._get_form('xls-form'))
+            xls_form=self.get_form('xls-form'))
 
         SpatialUnitFactory.create(project=project)
 
@@ -736,7 +729,7 @@ class ProjectEditDetailsTest(UserTestCase, FileStorageTestCase, TestCase):
         project = ProjectFactory.create()
         questionnaire = QuestionnaireFactory.create(
             project=project,
-            xls_form=self._get_form('xls-form'))
+            xls_form=self.get_form('xls-form'))
         data = {
             'name': 'New name',
             'questionnaire': '',
@@ -1271,7 +1264,8 @@ class SelectImportFormTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_invalid_file_type(self):
         invalid_file = self.get_file(self.invalid_file_type, 'rb')
         file = SimpleUploadedFile(
-            'test_invalid.kml', invalid_file, 'application/kml')
+            'test_invalid.kml', invalid_file.read(), 'application/kml')
+        invalid_file.close()
         file_dict = {'file': file}
         form = forms.SelectImportForm(
             files=file_dict, data=self.data,
@@ -1295,7 +1289,8 @@ class SelectImportFormTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_set_mime_type(self):
         valid_file = self.get_file(self.valid_file_type, 'rb')
         file = SimpleUploadedFile(
-            'test.csv', valid_file, 'text/csv')
+            'test.csv', valid_file.read(), 'text/csv')
+        valid_file.close()
         file_dict = {'file': file}
         form = forms.SelectImportForm(
             files=file_dict, data=self.data,
@@ -1307,7 +1302,8 @@ class SelectImportFormTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_mime_type_file_mismatch(self):
         valid_file = self.get_file(self.valid_file_type, 'rb')
         file = SimpleUploadedFile(
-            'test.csv', valid_file, 'text/csv')
+            'test.csv', valid_file.read(), 'text/csv')
+        valid_file.close()
         file_dict = {'file': file}
         data = self.data.copy()
         data['type'] = 'xls'
@@ -1321,7 +1317,8 @@ class SelectImportFormTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_set_original_file(self):
         valid_file = self.get_file(self.valid_file_type, 'rb')
         file = SimpleUploadedFile(
-            'test.csv', valid_file, 'text/csv')
+            'test.csv', valid_file.read(), 'text/csv')
+        valid_file.close()
         file_dict = {'file': file}
         form = forms.SelectImportForm(
             files=file_dict, data=self.data,
@@ -1333,7 +1330,8 @@ class SelectImportFormTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_clean_entity_types(self):
         valid_file = self.get_file(self.valid_file_type, 'rb')
         file = SimpleUploadedFile(
-            'test.csv', valid_file, 'text/csv')
+            'test.csv', valid_file.read(), 'text/csv')
+        valid_file.close()
         file_dict = {'file': file}
         data = self.data.copy()
         data['entity_types'] = []

--- a/cadasta/organization/tests/test_importers.py
+++ b/cadasta/organization/tests/test_importers.py
@@ -236,7 +236,8 @@ class CSVImportTest(UserTestCase, FileStorageTestCase, TestCase):
         self.project = ProjectFactory.create(name='Test CSV Import')
         xlscontent = self.get_file(
             '/organization/tests/files/uttaran_test.xlsx', 'rb')
-        form = self.storage.save('xls-forms/uttaran_test.xlsx', xlscontent)
+        form = self.storage.save('xls-forms/uttaran_test.xlsx',
+                                 xlscontent.read())
         Questionnaire.objects.create_from_form(
             xls_form=form,
             project=self.project
@@ -573,7 +574,9 @@ class XLSImportTest(UserTestCase, FileStorageTestCase, TestCase):
         self.project = ProjectFactory.create(name='Test CSV Import')
         xlscontent = self.get_file(
             '/organization/tests/files/uttaran_test.xlsx', 'rb')
-        form = self.storage.save('xls-forms/uttaran_test.xlsx', xlscontent)
+        form = self.storage.save('xls-forms/uttaran_test.xlsx',
+                                 xlscontent.read())
+        xlscontent.close()
         Questionnaire.objects.create_from_form(
             xls_form=form,
             project=self.project

--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -435,7 +435,8 @@ class ProjectDashboardTest(FileStorageTestCase, ViewTestCase, UserTestCase,
     def test_get_with_labels(self):
         file = self.get_file(
             '/questionnaires/tests/files/ok-multilingual.xlsx', 'rb')
-        form = self.storage.save('xls-forms/xls-form.xlsx', file)
+        form = self.storage.save('xls-forms/xls-form.xlsx', file.read())
+        file.close()
         Questionnaire.objects.create_from_form(
             xls_form=form,
             original_file='original.xls',
@@ -560,13 +561,6 @@ class ProjectAddTest(UserTestCase, FileStorageTestCase, TestCase):
 
         assert 'organization' not in form_initial
 
-    def _get_xls_form(self, form_name):
-        file = self.get_file(
-            '/questionnaires/tests/files/{}.xlsx'.format(form_name),
-            'rb')
-        form = self.storage.save('xls-forms/' + form_name + '.xlsx', file)
-        return form
-
     EXTENTS_POST_DATA = {
         'project_add_wizard-current_step': 'extents',
         'extents-extent':
@@ -623,7 +617,7 @@ class ProjectAddTest(UserTestCase, FileStorageTestCase, TestCase):
             reverse('project:add'), self.EXTENTS_POST_DATA
         )
         assert extents_response.status_code == 200
-        self.DETAILS_POST_DATA['details-questionnaire'] = self._get_xls_form(
+        self.DETAILS_POST_DATA['details-questionnaire'] = self.get_form(
             'xls-form')
         self.DETAILS_POST_DATA['details-original_file'] = 'original.xls'
         details_response = self.client.post(
@@ -697,7 +691,7 @@ class ProjectAddTest(UserTestCase, FileStorageTestCase, TestCase):
         assert extents_response.status_code == 200
         details_post_data = self.DETAILS_POST_DATA.copy()
         details_post_data[
-            'details-questionnaire'] = self._get_xls_form(
+            'details-questionnaire'] = self.get_form(
             'xls-form-invalid')
         details_response = self.client.post(
             reverse('project:add'), details_post_data
@@ -800,7 +794,7 @@ class ProjectAddTest(UserTestCase, FileStorageTestCase, TestCase):
             self.EXTENTS_POST_DATA
         )
         assert extents_response.status_code == 200
-        self.DETAILS_POST_DATA['details-questionaire'] = self._get_xls_form(
+        self.DETAILS_POST_DATA['details-questionaire'] = self.get_form(
             'xls-form')
         details_response = self.client.post(
             reverse('organization:project-add',
@@ -1495,7 +1489,9 @@ class ProjectDataImportTest(UserTestCase, FileStorageTestCase, TestCase):
         xlscontent = self.get_file(
             '/organization/tests/files/uttaran_test.xlsx', 'rb'
         )
-        form = self.storage.save('xls-forms/uttaran_test.xlsx', xlscontent)
+        form = self.storage.save('xls-forms/uttaran_test.xlsx',
+                                 xlscontent.read())
+        xlscontent.close()
 
         Questionnaire.objects.create_from_form(
             xls_form=form,
@@ -1600,7 +1596,8 @@ class ProjectDataImportTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_full_flow_valid(self):
         self.client.force_login(self.user)
         csvfile = self.get_file(self.valid_csv, 'rb')
-        file = SimpleUploadedFile('test.csv', csvfile, 'text/csv')
+        file = SimpleUploadedFile('test.csv', csvfile.read(), 'text/csv')
+        csvfile.close()
         post_data = self.SELECT_FILE_POST_DATA.copy()
         post_data['select_file-file'] = file
         post_data['select_file-is_resource'] = True
@@ -1659,7 +1656,8 @@ class ProjectDataImportTest(UserTestCase, FileStorageTestCase, TestCase):
         'officedocument.spreadsheetml.sheet'
         self.client.force_login(self.user)
         xlsfile = self.get_file(self.valid_xls, 'rb')
-        file = SimpleUploadedFile('test_download.xlsx', xlsfile, mime)
+        file = SimpleUploadedFile('test_download.xlsx', xlsfile.read(), mime)
+        xlsfile.close()
         post_data = self.SELECT_FILE_POST_DATA.copy()
         post_data['select_file-file'] = file
         post_data['select_file-is_resource'] = True
@@ -1721,7 +1719,9 @@ class ProjectDataImportTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_full_flow_invalid_value(self):
         self.client.force_login(self.user)
         csvfile = self.get_file(self.invalid_csv, 'rb')
-        file = SimpleUploadedFile('test_invalid.csv', csvfile, 'text/csv')
+        file = SimpleUploadedFile('test_invalid.csv', csvfile.read(),
+                                  'text/csv')
+        csvfile.close()
         post_data = self.SELECT_FILE_POST_DATA.copy()
         post_data['select_file-file'] = file
         select_file_response = self.client.post(
@@ -1762,7 +1762,8 @@ class ProjectDataImportTest(UserTestCase, FileStorageTestCase, TestCase):
         self.client.force_login(self.user)
         invalid_file = self.get_file(self.invalid_file_type, 'rb')
         file = SimpleUploadedFile(
-            'test_invalid.kml', invalid_file, 'application/kml')
+            'test_invalid.kml', invalid_file.read(), 'application/kml')
+        invalid_file.close()
         post_data = self.SELECT_FILE_POST_DATA.copy()
         post_data['select_file-file'] = file
         select_file_response = self.client.post(
@@ -1804,7 +1805,8 @@ class ProjectDataImportTest(UserTestCase, FileStorageTestCase, TestCase):
 
         # post first page data
         csvfile = self.get_file(self.valid_csv, 'rb')
-        file = SimpleUploadedFile('test.csv', csvfile, 'text/csv')
+        file = SimpleUploadedFile('test.csv', csvfile.read(), 'text/csv')
+        csvfile.close()
         post_data = self.SELECT_FILE_POST_DATA.copy()
         post_data['select_file-file'] = file
         select_file_response = self.client.post(
@@ -1871,7 +1873,8 @@ class ProjectDataImportTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_full_flow_valid_no_resource(self):
         self.client.force_login(self.user)
         csvfile = self.get_file(self.valid_csv, 'rb')
-        file = SimpleUploadedFile('test.csv', csvfile, 'text/csv')
+        file = SimpleUploadedFile('test.csv', csvfile.read(), 'text/csv')
+        csvfile.close()
         post_data = self.SELECT_FILE_POST_DATA.copy()
         post_data['select_file-file'] = file
         post_data['select_file-is_resource'] = False

--- a/cadasta/organization/views/api.py
+++ b/cadasta/organization/views/api.py
@@ -36,7 +36,7 @@ class OrganizationList(PermissionsFilterMixin,
                                   else ('org.view_archived',))
 
     def post(self, request, *args, **kwargs):
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             raise NotAuthenticated
         return super().post(request, *args, **kwargs)
 

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -70,7 +70,7 @@ class ProjectMixin:
         return self._org_role
 
     def get_prj_role(self):
-        if self.request.user.is_anonymous():
+        if self.request.user.is_anonymous:
             return None
 
         if not hasattr(self, '_prj_role'):

--- a/cadasta/party/tests/test_views_api_parties.py
+++ b/cadasta/party/tests/test_views_api_parties.py
@@ -270,7 +270,9 @@ class PartyResourceListAPITest(APITestCase, UserTestCase, FileStorageTestCase,
 
         self.file = self.get_file(
             '/resources/tests/files/image.jpg', 'rb')
-        self.file_name = self.storage.save('resources/image.jpg', self.file)
+        self.file_name = self.storage.save('resources/image.jpg',
+                                           self.file.read())
+        self.file.close()
 
     def setup_url_kwargs(self):
         return {
@@ -335,7 +337,9 @@ class PartyResourceListAPITest(APITestCase, UserTestCase, FileStorageTestCase,
         assert(names == sorted(names, reverse=True))
 
     def test_search_filter(self):
-        not_found = self.storage.save('resources/bild.jpg', self.file)
+        file = self.get_file('/resources/tests/files/image.jpg', 'rb')
+        not_found = self.storage.save('resources/bild.jpg', file.read())
+        file.close()
         party = PartyFactory.create(project=self.prj)
         ResourceFactory.create_from_kwargs([
             {'content_object': party, 'project': self.prj,

--- a/cadasta/party/tests/test_views_api_tenure_relationships.py
+++ b/cadasta/party/tests/test_views_api_tenure_relationships.py
@@ -618,7 +618,9 @@ class TenureRelationshipResourceListAPITest(APITestCase, FileStorageTestCase,
 
         self.file = self.get_file(
             '/resources/tests/files/image.jpg', 'rb')
-        self.file_name = self.storage.save('resources/image.jpg', self.file)
+        self.file_name = self.storage.save('resources/image.jpg',
+                                           self.file.read())
+        self.file.close()
 
     def setup_url_kwargs(self):
         return {
@@ -685,7 +687,9 @@ class TenureRelationshipResourceListAPITest(APITestCase, FileStorageTestCase,
         assert(names == sorted(names, reverse=True))
 
     def test_search_filter(self):
-        not_found = self.storage.save('resources/bild.jpg', self.file)
+        file = self.get_file('/resources/tests/files/image.jpg', 'rb')
+        not_found = self.storage.save('resources/bild.jpg', file.read())
+        file.close()
         tenure = TenureRelationshipFactory.create(
             project=self.prj)
         ResourceFactory.create_from_kwargs([

--- a/cadasta/party/tests/test_views_default.py
+++ b/cadasta/party/tests/test_views_default.py
@@ -980,7 +980,8 @@ class PartyResourcesNewTest(ViewTestCase, UserTestCase, FileStorageTestCase,
 
     def setup_post_data(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/image.jpg', file)
+        file_name = self.storage.save('resources/image.jpg', file.read())
+        file.close()
 
         return {
             'name': 'Some name',
@@ -1628,7 +1629,8 @@ class PartyRelationshipResourceNewTest(ViewTestCase, UserTestCase,
 
     def setup_post_data(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/image.jpg', file)
+        file_name = self.storage.save('resources/image.jpg', file.read())
+        file.close()
 
         return {
             'name': 'Some name',

--- a/cadasta/questionnaires/tests/test_attr_schemas.py
+++ b/cadasta/questionnaires/tests/test_attr_schemas.py
@@ -27,7 +27,8 @@ class CreateAttributeSchemaTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_create_attribute_schemas(self):
         file = self.get_file(
             '/questionnaires/tests/files/xls-form-attrs.xlsx', 'rb')
-        form = self.storage.save('xls-forms/xls-form-attrs.xlsx', file)
+        form = self.storage.save('xls-forms/xls-form-attrs.xlsx', file.read())
+        file.close()
         project = ProjectFactory.create()
         models.Questionnaire.objects.create_from_form(
             xls_form=form,
@@ -296,7 +297,8 @@ class CreateAttributeSchemaTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_update_questionnaire_attribute_schema(self):
         file = self.get_file(
             '/questionnaires/tests/files/xls-form-attrs.xlsx', 'rb')
-        form = self.storage.save('xls-forms/xls-form.xlsx', file)
+        form = self.storage.save('xls-forms/xls-form.xlsx', file.read())
+        file.close()
         project = ProjectFactory.create(name='TestProject')
         q1 = models.Questionnaire.objects.create_from_form(
             xls_form=form,
@@ -335,7 +337,8 @@ class ConditionalAttributeSchemaTest(UserTestCase, FileStorageTestCase,
         super().setUp()
         file = self.get_file(
             '/questionnaires/tests/files/xls-form-attrs.xlsx', 'rb')
-        form = self.storage.save('xls-forms/xls-form-attrs.xlsx', file)
+        form = self.storage.save('xls-forms/xls-form-attrs.xlsx', file.read())
+        file.close()
         self.content_type = ContentType.objects.get(
             app_label='party', model='party')
         self.project = ProjectFactory.create(name='TestProject')

--- a/cadasta/questionnaires/tests/test_managers.py
+++ b/cadasta/questionnaires/tests/test_managers.py
@@ -127,7 +127,8 @@ class QuestionnaireManagerTest(FileStorageTestCase, TestCase):
 
     def test_create_from_form(self):
         file = self.get_file('/questionnaires/tests/files/xls-form.xlsx', 'rb')
-        form = self.storage.save('xls-forms/xls-form.xlsx', file)
+        form = self.storage.save('xls-forms/xls-form.xlsx', file.read())
+        file.close()
         model = models.Questionnaire.objects.create_from_form(
             xls_form=form,
             original_file='original.xls',
@@ -141,7 +142,8 @@ class QuestionnaireManagerTest(FileStorageTestCase, TestCase):
     def test_update_from_form(self):
         file = self.get_file(
             '/questionnaires/tests/files/xls-form.xlsx', 'rb')
-        form = self.storage.save('xls-forms/xls-form.xlsx', file)
+        form = self.storage.save('xls-forms/xls-form.xlsx', file.read())
+        file.close()
 
         project = ProjectFactory.create()
         m1 = models.Questionnaire.objects.create_from_form(
@@ -164,7 +166,9 @@ class QuestionnaireManagerTest(FileStorageTestCase, TestCase):
     def test_create_from_invald_form(self):
         file = self.get_file(
             '/questionnaires/tests/files/xls-form-invalid.xlsx', 'rb')
-        form = self.storage.save('xls-forms/xls-form-invalid.xlsx', file)
+        form = self.storage.save('xls-forms/xls-form-invalid.xlsx',
+                                 file.read())
+        file.close()
         with pytest.raises(InvalidQuestionnaire) as e:
             models.Questionnaire.objects.create_from_form(
                 xls_form=form,
@@ -182,7 +186,8 @@ class QuestionnaireManagerTest(FileStorageTestCase, TestCase):
             '/questionnaires/tests/files/'
             't_questionnaire_missing_relevant.xlsx', 'rb')
         form = self.storage.save(
-            'xls-forms/t_questionnaire_missing_relevant.xlsx', file)
+            'xls-forms/t_questionnaire_missing_relevant.xlsx', file.read())
+        file.close()
         with pytest.raises(InvalidQuestionnaire) as e:
             models.Questionnaire.objects.create_from_form(
                 xls_form=form,
@@ -317,7 +322,8 @@ class MultilingualQuestionnaireTest(UserTestCase, FileStorageTestCase,
     def _run(self, xlsxfile):
         file = self.get_file(
             '/questionnaires/tests/files/' + xlsxfile, 'rb')
-        form = self.storage.save('xls-forms/' + xlsxfile, file)
+        form = self.storage.save('xls-forms/' + xlsxfile, file.read())
+        file.close()
         return models.Questionnaire.objects.create_from_form(
             xls_form=form,
             original_file='original.xls',

--- a/cadasta/resources/tests/test_forms.py
+++ b/cadasta/resources/tests/test_forms.py
@@ -16,7 +16,8 @@ class ResourceFormTest(UserTestCase, FileStorageTestCase, TestCase):
     def setUp(self):
         super().setUp()
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/image.jpg', file)
+        file_name = self.storage.save('resources/image.jpg', file.read())
+        file.close()
 
         self.data = {
             'name': 'Some name',

--- a/cadasta/resources/tests/test_managers.py
+++ b/cadasta/resources/tests/test_managers.py
@@ -14,7 +14,8 @@ from ..models import Resource
 class ResourceModelTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_project_resource(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/image.jpg', file)
+        file_name = self.storage.save('resources/image.jpg', file.read())
+        file.close()
 
         project = ProjectFactory.create()
         user = UserFactory.create()

--- a/cadasta/resources/tests/test_models.py
+++ b/cadasta/resources/tests/test_models.py
@@ -180,7 +180,8 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_register_file_version(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/thumb_new.jpg', file)
+        file_name = self.storage.save('resources/thumb_new.jpg', file.read())
+        file.close()
         resource = ResourceFactory.create()
 
         resource.file = file_name
@@ -191,7 +192,8 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_create_thumbnail(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/thumb_test.jpg', file)
+        file_name = self.storage.save('resources/thumb_test.jpg', file.read())
+        file.close()
         contributor = UserFactory.create()
         resource = ResourceFactory.create(file=file_name,
                                           mime_type='image/jpeg',
@@ -203,7 +205,8 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_create_no_thumbnail_non_images(self):
         file = self.get_file('/resources/tests/files/text.txt', 'rb')
-        file_name = self.storage.save('resources/text.txt', file)
+        file_name = self.storage.save('resources/text.txt', file.read())
+        file.close()
         contributor = UserFactory.create()
         resource = ResourceFactory.create(file=file_name,
                                           mime_type='text/plain',
@@ -215,7 +218,8 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_create_spatial_resource(self):
         file = self.get_file('/resources/tests/files/deramola.xml', 'rb')
-        file_name = self.storage.save('resources/deramola.xml', file)
+        file_name = self.storage.save('resources/deramola.xml', file.read())
+        file.close()
         resource = ResourceFactory.create(
             file=file_name, mime_type='text/xml')
         assert os.path.isfile(os.path.join(
@@ -230,7 +234,8 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_invalid_gpx_mime_type(self):
         file = self.get_file('/resources/tests/files/mp3.xml', 'rb')
-        file_name = self.storage.save('resources/mp3.xml', file)
+        file_name = self.storage.save('resources/mp3.xml', file.read())
+        file.close()
         resource = ResourceFactory.build(
             file=file_name, mime_type='text/xml')
         assert os.path.isfile(os.path.join(
@@ -243,7 +248,8 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_invalid_gpx_file(self):
         file = self.get_file('/resources/tests/files/invalidgpx.xml', 'rb')
-        file_name = self.storage.save('resources/invalidgpx.xml', file)
+        file_name = self.storage.save('resources/invalidgpx.xml', file.read())
+        file.close()
         resource = ResourceFactory.build(
             file=file_name, mime_type='application/xml')
         assert os.path.isfile(os.path.join(
@@ -263,7 +269,8 @@ class SpatialResourceTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_spatial_resource(self):
         file = self.get_file('/resources/tests/files/tracks.gpx', 'rb')
-        file_name = self.storage.save('resources/tracks_test.gpx', file)
+        file_name = self.storage.save('resources/tracks_test.gpx', file.read())
+        file.close()
         resource = ResourceFactory.create(
             file=file_name, mime_type='text/xml')
         spatial_resource = SpatialResourceFactory.create(resource=resource)

--- a/cadasta/resources/tests/test_serializers.py
+++ b/cadasta/resources/tests/test_serializers.py
@@ -28,7 +28,8 @@ class ResourceSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_create_project_resource(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/image.jpg', file)
+        file_name = self.storage.save('resources/image.jpg', file.read())
+        file.close()
 
         project = ProjectFactory.create()
         user = UserFactory.create()
@@ -56,7 +57,8 @@ class ResourceSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_create_project_resource_without_mime_type(self):
         file = self.get_file('/resources/tests/files/text.txt', 'rb')
-        file_name = self.storage.save('resources/text.txt', file)
+        file_name = self.storage.save('resources/text.txt', file.read())
+        file.close()
 
         project = ProjectFactory.create()
         user = UserFactory.create()

--- a/cadasta/resources/tests/test_views_api.py
+++ b/cadasta/resources/tests/test_views_api.py
@@ -72,7 +72,9 @@ class ProjectResourcesTest(APITestCase, UserTestCase,
         self.storage = self.get_storage()
         self.file = self.get_file(
             '/resources/tests/files/image.jpg', 'rb')
-        self.file_name = self.storage.save('resources/image.jpg', self.file)
+        self.file_name = self.storage.save('resources/image.jpg',
+                                           self.file.read())
+        self.file.close()
 
     def setup_url_kwargs(self):
         return {
@@ -151,7 +153,9 @@ class ProjectResourcesTest(APITestCase, UserTestCase,
         assert self.project.resources.count() == 3
 
     def test_search_for_file(self):
-        not_found = self.storage.save('resources/bild.jpg', self.file)
+        file = self.get_file('/resources/tests/files/image.jpg', 'rb')
+        not_found = self.storage.save('resources/bild.jpg', file.read())
+        file.close()
         prj = ProjectFactory.create()
         ResourceFactory.create_from_kwargs([
             {'content_object': prj, 'project': prj, 'file': self.file_name},
@@ -408,14 +412,19 @@ class ProjectSpatialResourcesTest(APITestCase, UserTestCase,
 
     def setup_models(self):
         tracks = self.get_file('/resources/tests/files/tracks.gpx', 'rb')
-        self.tracks_file = self.storage.save('resources/tracks.gpx', tracks)
+        self.tracks_file = self.storage.save('resources/tracks.gpx',
+                                             tracks.read())
+        tracks.close()
 
         routes = self.get_file('/resources/tests/files/routes.gpx', 'rb')
-        self.routes_file = self.storage.save('resources/routes.gpx', routes)
+        self.routes_file = self.storage.save('resources/routes.gpx',
+                                             routes.read())
+        routes.close()
 
         waypoints = self.get_file('/resources/tests/files/waypoints.gpx', 'rb')
         self.waypoints_file = self.storage.save(
-            'resources/waypoints.gpx', waypoints)
+            'resources/waypoints.gpx', waypoints.read())
+        waypoints.close()
 
         self.project = ProjectFactory.create()
 
@@ -495,14 +504,19 @@ class ProjectSpatialResourcesDetailTest(APITestCase, UserTestCase,
 
     def setup_models(self):
         tracks = self.get_file('/resources/tests/files/tracks.gpx', 'rb')
-        self.tracks_file = self.storage.save('resources/tracks.gpx', tracks)
+        self.tracks_file = self.storage.save('resources/tracks.gpx',
+                                             tracks.read())
+        tracks.close()
 
         routes = self.get_file('/resources/tests/files/routes.gpx', 'rb')
-        self.routes_file = self.storage.save('resources/routes.gpx', routes)
+        self.routes_file = self.storage.save('resources/routes.gpx',
+                                             routes.read())
+        routes.close()
 
         waypoints = self.get_file('/resources/tests/files/waypoints.gpx', 'rb')
         self.waypoints_file = self.storage.save(
-            'resources/waypoints.gpx', waypoints)
+            'resources/waypoints.gpx', waypoints.read())
+        waypoints.close()
 
         self.project = ProjectFactory.create()
 

--- a/cadasta/resources/tests/test_views_default.py
+++ b/cadasta/resources/tests/test_views_default.py
@@ -297,7 +297,8 @@ class ProjectResourcesNewTest(ViewTestCase, UserTestCase,
 
     def setup_post_data(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/image.jpg', file)
+        file_name = self.storage.save('resources/image.jpg', file.read())
+        file.close()
 
         return {
             'name': 'Some name',
@@ -347,7 +348,8 @@ class ProjectResourcesNewTest(ViewTestCase, UserTestCase,
 
     def test_create_invalid_gpx(self):
         file = self.get_file('/resources/tests/files/mp3.xml', 'rb')
-        file_name = self.storage.save('resources/mp3.xml', file)
+        file_name = self.storage.save('resources/mp3.xml', file.read())
+        file.close()
 
         data = {
             'name': 'Some name',
@@ -526,7 +528,8 @@ class ProjectResourcesEditTest(ViewTestCase, UserTestCase,
 
     def setup_post_data(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/image.jpg', file)
+        file_name = self.storage.save('resources/image.jpg', file.read())
+        file.close()
         return {
             'name': 'Some name',
             'description': '',
@@ -816,7 +819,8 @@ class ResourceDetachTest(ViewTestCase, UserTestCase,
 
     def setup_post_data(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/image.jpg', file)
+        file_name = self.storage.save('resources/image.jpg', file.read())
+        file.close()
 
         return {
             'name': 'Some name',

--- a/cadasta/spatial/tests/test_views_api_spatial_units.py
+++ b/cadasta/spatial/tests/test_views_api_spatial_units.py
@@ -772,7 +772,9 @@ class SpatialUnitResourceListAPITest(APITestCase, UserTestCase,
         ResourceFactory.create(project=self.prj)
 
         self.file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        self.file_name = self.storage.save('resources/image.jpg', self.file)
+        self.file_name = self.storage.save('resources/image.jpg',
+                                           self.file.read())
+        self.file.close()
 
     def setup_url_kwargs(self):
         return {
@@ -837,7 +839,9 @@ class SpatialUnitResourceListAPITest(APITestCase, UserTestCase,
         assert(names == sorted(names, reverse=True))
 
     def test_search_filter(self):
-        not_found = self.storage.save('resources/bild.jpg', self.file)
+        file = self.get_file('/resources/tests/files/image.jpg', 'rb')
+        not_found = self.storage.save('resources/bild.jpg', file.read())
+        file.close()
         su = SpatialUnitFactory.create(project=self.prj)
         ResourceFactory.create_from_kwargs([
             {'content_object': su, 'project': self.prj,

--- a/cadasta/spatial/tests/test_views_default.py
+++ b/cadasta/spatial/tests/test_views_default.py
@@ -916,7 +916,8 @@ class LocationResourceNewTest(ViewTestCase, UserTestCase,
 
     def setup_post_data(self):
         file = self.get_file('/resources/tests/files/image.jpg', 'rb')
-        file_name = self.storage.save('resources/image.jpg', file)
+        file_name = self.storage.save('resources/image.jpg', file.read())
+        file.close()
 
         return {
             'name': 'Some name',

--- a/cadasta/xforms/tests/test_serializers.py
+++ b/cadasta/xforms/tests/test_serializers.py
@@ -15,14 +15,8 @@ from .. import serializers
 
 @pytest.mark.usefixtures('make_dirs')
 class XFormListSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
-    def _get_form(self, form_name):
-        file = self.get_file(
-            '/questionnaires/tests/files/{}.xlsx'.format(form_name), 'rb')
-        form = self.storage.save('xls-forms/{}.xlsx'.format(form_name), file)
-        return form
-
     def _test_serialize(self, https=False):
-        form = self._get_form('xls-form')
+        form = self.get_form('xls-form')
         self.url = '/collect/'
         user = UserFactory.create()
         request = APIRequestFactory().get(self.url)

--- a/cadasta/xforms/tests/test_views_api.py
+++ b/cadasta/xforms/tests/test_views_api.py
@@ -181,32 +181,36 @@ class XFormSubmissionTest(APITestCase, UserTestCase, FileStorageTestCase,
 
         data = {}
         for image_name in image:
-            img = self._get_resource(
+            img_file = self._get_resource(
                 file_name=image_name,
                 file_type='png')
+            img_stream = img_file.read()
             img = InMemoryUploadedFile(
-                file=io.BytesIO(img),
+                file=io.BytesIO(img_stream),
                 field_name=image_name,
                 name='{}.png'.format(image_name),
                 content_type='image/png',
-                size=len(img),
+                size=len(img_stream),
                 charset='utf-8',
             )
+            img_file.close()
             data[img.name] = img
 
         for audio_name in audio:
             audio_file = self._get_resource(
                 file_name=audio_name,
                 file_type='mp3')
-            audio_file = InMemoryUploadedFile(
-                file=io.BytesIO(audio_file),
+            audio_stream = audio_file.read()
+            audio = InMemoryUploadedFile(
+                file=io.BytesIO(audio_stream),
                 field_name=audio_name,
                 name='{}.mp3'.format(audio_name),
                 content_type='audio/mp3',
-                size=len(audio_file),
+                size=len(audio_stream),
                 charset='utf-8',
             )
-            data[audio_file.name] = audio_file
+            data[audio.name] = audio
+            audio_file.close()
 
         if file:
             file = InMemoryUploadedFile(
@@ -381,9 +385,10 @@ class XFormSubmissionTest(APITestCase, UserTestCase, FileStorageTestCase,
         msg = self._getResponseMessage(response)
         assert msg == "Tenure relationship error: 'tenure_type'"
 
-        bad_file = self.get_file(
+        file = self.get_file(
             '/xforms/tests/files/test_bad_resource.html', 'rb')
-        bad_file = bad_file.decode('utf-8')
+        bad_file = file.read().decode('utf-8')
+        file.close()
 
         self._create_questionnaire('t_questionnaire_bad', 2, False)
         data = self._submission(form='submission_bad_resource',


### PR DESCRIPTION
### Proposed changes in this pull request

A few improvements to cut down the number of warnings issued when running tests:

- Close all open files
- Replace deprecated method calls with their corresponding properties (`User.is_anonymous`, `User.is_authenticated`

### When should this PR be merged

ASAP

### Risks

Low, it only affects tests really.

### Follow-up actions

There are still loads of warnings. Some can be resolved by upgraded libraries we use (pytest, django rest framework). We also need to update our own libraries: django-tutelary for example, which causes a lot of deprecation warnings.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
