### PR TITLE
Pytest warning filters

### DIFF
--- a/cadasta/pytest.ini
+++ b/cadasta/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 addopts = --ds=config.settings.test
+filterwarnings= default
+                ignore:.*is deprecated.*:Warning
+                error::DeprecationWarning:importlib.*

--- a/cadasta/pytest.ini
+++ b/cadasta/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
 addopts = --ds=config.settings.test
 filterwarnings= default
-                ignore:.*is deprecated.*:Warning
-                error::DeprecationWarning:importlib.*
+                ignore:DeprecationWarning

--- a/cadasta/pytest.ini
+++ b/cadasta/pytest.ini
@@ -2,4 +2,4 @@
 addopts = --ds=config.settings.test
 filterwarnings= default
                 ignore:DeprecationWarning
-                ignore:.*is deprecated.*:Warning
+                ignore:.*deprecated.*:Warning

--- a/cadasta/pytest.ini
+++ b/cadasta/pytest.ini
@@ -2,3 +2,4 @@
 addopts = --ds=config.settings.test
 filterwarnings= default
                 ignore:DeprecationWarning
+                ignore:.*is deprecated.*:Warning

--- a/runtests.py
+++ b/runtests.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
         pytest_args = PYTEST_ARGS[style]
 
         if os.environ['DJANGO_SETTINGS_MODULE'] == 'config.settings.travis':
-            pytest_args = pytest_args + ['--ds=config.settings.travis']
+            pytest_args = pytest_args + ['--disable-pytest-warnings'] + ['--ds=config.settings.travis']
 
         pytest_args_functional = PYTEST_ARGS_FUNCTIONAL[style]
 

--- a/runtests.py
+++ b/runtests.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
         pytest_args = PYTEST_ARGS[style]
 
         if os.environ['DJANGO_SETTINGS_MODULE'] == 'config.settings.travis':
-            pytest_args = pytest_args + ['--disable-pytest-warnings'] + ['--ds=config.settings.travis']
+            pytest_args = pytest_args + ['--disable-pytest-warnings', '--ds=config.settings.travis']
 
         pytest_args_functional = PYTEST_ARGS_FUNCTIONAL[style]
 


### PR DESCRIPTION
### Proposed changes in this pull request

The `pytest` [v3.1.0](https://docs.pytest.org/en/latest/changelog.html#id1) update on 22 May integrated `pytest-warnings` -- this is what caused our Travis builds to break, as our warnings output exceeded the 4MB max log file size set by Travis.

This PR disables warnings for the Travis env, and adds filters to ignore warnings across all envs. To view the list of warnings in dev, remove the ignore filters in pytest.ini

### When should this PR be merged

ASAP, to restore normalcy to the realm

### Risks

No risks to platform; only affects display of test suite warnings. End of build message will still indicate the number of warnings, but won't display the warnings themselves. Example:

`================= 1873 passed, 829 warnings in 499.97 seconds ==================`

(Yeah, that's how many warnings we've got.)

### Follow-up actions

Fix the warnings/deprecations and update our packages in a timely manner.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
