### PR TITLE
Sanitise text-like fields only

### DIFF
--- a/cadasta/resources/tests/factories.py
+++ b/cadasta/resources/tests/factories.py
@@ -30,8 +30,9 @@ class ResourceFactory(ExtendedFactory):
 
         if not resource.file.url:
             storage = FakeS3Storage()
-            file = open(path + '/resources/tests/files/image.jpg', 'rb').read()
-            file_name = storage.save('resources/image.jpg', file)
+            file = open(path + '/resources/tests/files/image.jpg', 'rb')
+            file_name = storage.save('resources/image.jpg', file.read())
+            file.close()
 
             resource.file = file_name
             if create:

--- a/cadasta/xforms/mixins/model_helper.py
+++ b/cadasta/xforms/mixins/model_helper.py
@@ -269,7 +269,7 @@ class ModelHelper():
         submission = full_submission[list(full_submission.keys())[0]]
 
         sanitizable_questions = Question.objects.filter(
-            questionnaire__id=submission['id'],
+            questionnaire__id_string=submission['id'],
             questionnaire__version=submission['version'],
             type__in=['TX', 'NO']).values_list('name', flat=True)
         self.sanitize_submission(submission, sanitizable_questions)

--- a/cadasta/xforms/mixins/model_helper.py
+++ b/cadasta/xforms/mixins/model_helper.py
@@ -258,6 +258,12 @@ class ModelHelper():
             elif key in sanitizable_questions and not sanitize_string(value):
                 raise InvalidXMLSubmission(SANITIZE_ERROR)
 
+    def get_sanitizable_questions(self, id_string, version):
+        return Question.objects.filter(
+            questionnaire__id_string=id_string,
+            questionnaire__version=version,
+            type__in=['TX', 'NO']).values_list('name', flat=True)
+
     def upload_submission_data(self, request):
         if 'xml_submission_file' not in request.data.keys():
             raise InvalidXMLSubmission(_('XML submission not found'))
@@ -268,10 +274,8 @@ class ModelHelper():
 
         submission = full_submission[list(full_submission.keys())[0]]
 
-        sanitizable_questions = Question.objects.filter(
-            questionnaire__id_string=submission['id'],
-            questionnaire__version=submission['version'],
-            type__in=['TX', 'NO']).values_list('name', flat=True)
+        sanitizable_questions = self.get_sanitizable_questions(
+            submission['id'], submission['version'])
         self.sanitize_submission(submission, sanitizable_questions)
 
         with transaction.atomic():

--- a/cadasta/xforms/tests/files/test_resources.py
+++ b/cadasta/xforms/tests/files/test_resources.py
@@ -40,6 +40,48 @@ STANDARD = '''<?xml version=\'1.0\' ?>
         </meta>
     </t_questionnaire>'''.strip()
 
+NOT_SANE = '''<?xml version=\'1.0\' ?>
+    <t_questionnaire
+        id="t_questionnaire" version="20160727122110">
+        <start>2016-07-07T16:38:20.310-04</start>
+        <end>2016-07-07T16:39:23.673-04</end>
+        <today>2016-07-07</today>
+        <deviceid>00:bb:3a:44:d0:fb</deviceid>
+        <title />
+        <party_type>IN</party_type>
+        <party_name>=Bilbo Baggins</party_name>
+        <location_geometry>40.6890612 -73.9925067 0.0 0.0;</location_geometry>
+        <location_type>MI</location_type>
+        <location_resource_photo>test_image_one.png</location_resource_photo>
+        <party_resource_photo>test_image_two.png</party_resource_photo>
+        <party_resource_audio>test_audio_one.mp3</party_resource_audio>
+        <location_photo>test_image_one.png</location_photo>
+        <party_photo>test_image_two.png</party_photo>
+        <tenure_resource_photo>test_image_three.png</tenure_resource_photo>
+        <tenure_type>LH</tenure_type>
+        <location_attributes>
+            <name>Middle Earth</name>
+            <infrastructure>water food electricity</infrastructure>
+        </location_attributes>
+        <party_attributes_default>
+            <notes>Party attribute default notes.</notes>
+        </party_attributes_default>
+        <party_attributes_individual>
+            <gender>f</gender>
+            <homeowner>no</homeowner>
+            <dob>2016-07-07</dob>
+        </party_attributes_individual>
+        <party_relationship_attributes>
+            <notes>Party relationship notes.</notes>
+        </party_relationship_attributes>
+        <tenure_relationship_attributes>
+            <notes>Tenure relationship notes.</notes>
+        </tenure_relationship_attributes>
+        <meta>
+            <instanceID>uuid:b3f225d3-0fac-4a0b-80c7-60e6db4cc0ad</instanceID>
+        </meta>
+    </t_questionnaire>'''.strip()
+
 POLY = '''<?xml version=\'1.0\' ?>
     <t_questionnaire
         id="t_questionnaire" version="20160727122110">
@@ -621,6 +663,7 @@ REPEAT_PARTY_MINUS_TENURE = '''<?xml version=\'1.0\' ?>
 
 responses = {
     'submission': STANDARD,
+    'submission_not_sane': NOT_SANE,
     'submission_line': LINE,
     'submission_poly': POLY,
     'submission_geotrace_as_poly': GEOTRACE_AS_POLY,

--- a/cadasta/xforms/tests/test_model_helper.py
+++ b/cadasta/xforms/tests/test_model_helper.py
@@ -1119,6 +1119,90 @@ class XFormModelHelperTest(TestCase):
             name='integer',
             type='IN',
             questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='select_one',
+            type='S1',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='select_multiple',
+            type='SM',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='geopoint',
+            type='GP',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='geotrace',
+            type='GT',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='geoshape',
+            type='GS',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='date',
+            type='DA',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='time',
+            type='TI',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='datetime',
+            type='DT',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='calculate',
+            type='CA',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='acknowledge',
+            type='AC',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='photo',
+            type='PH',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='audio',
+            type='AU',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='video',
+            type='VI',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='barcode',
+            type='BC',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='start',
+            type='ST',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='end',
+            type='EN',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='today',
+            type='TD',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='deviceid',
+            type='DI',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='subscriber_id',
+            type='SI',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='simserial',
+            type='SS',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='phonenumber',
+            type='PN',
+            questionnaire=self.questionnaire)
 
         sanitizeable_questions = mh.get_sanitizable_questions(
             mh(),
@@ -1128,3 +1212,24 @@ class XFormModelHelperTest(TestCase):
         assert 'text' in sanitizeable_questions
         assert 'note' in sanitizeable_questions
         assert 'integer' not in sanitizeable_questions
+        assert 'select_one' not in sanitizeable_questions
+        assert 'select_multiple' not in sanitizeable_questions
+        assert 'geopoint' not in sanitizeable_questions
+        assert 'geotrace' not in sanitizeable_questions
+        assert 'geoshape' not in sanitizeable_questions
+        assert 'date' not in sanitizeable_questions
+        assert 'time' not in sanitizeable_questions
+        assert 'datetime' not in sanitizeable_questions
+        assert 'calculate' not in sanitizeable_questions
+        assert 'acknowledge' not in sanitizeable_questions
+        assert 'photo' not in sanitizeable_questions
+        assert 'audio' not in sanitizeable_questions
+        assert 'video' not in sanitizeable_questions
+        assert 'barcode' not in sanitizeable_questions
+        assert 'start' not in sanitizeable_questions
+        assert 'end' not in sanitizeable_questions
+        assert 'today' not in sanitizeable_questions
+        assert 'deviceid' not in sanitizeable_questions
+        assert 'subscriber_id' not in sanitizeable_questions
+        assert 'simserial' not in sanitizeable_questions
+        assert 'phonenumber' not in sanitizeable_questions

--- a/cadasta/xforms/tests/test_model_helper.py
+++ b/cadasta/xforms/tests/test_model_helper.py
@@ -1105,3 +1105,26 @@ class XFormModelHelperTest(TestCase):
             mh._check_perm(mh, self.user, self.project)
         except PermissionDenied:
             self.fail("PermissionDenied raised unexpectedly")
+
+    def test_get_sanitizable_questions(self):
+        QuestionFactory.create(
+            name='text',
+            type='TX',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='note',
+            type='NO',
+            questionnaire=self.questionnaire)
+        QuestionFactory.create(
+            name='integer',
+            type='IN',
+            questionnaire=self.questionnaire)
+
+        sanitizeable_questions = mh.get_sanitizable_questions(
+            mh(),
+            self.questionnaire.id_string,
+            self.questionnaire.version)
+        assert len(sanitizeable_questions) == 2
+        assert 'text' in sanitizeable_questions
+        assert 'note' in sanitizeable_questions
+        assert 'integer' not in sanitizeable_questions


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #1613 
- For GeoODK submissions, string sanitation is only applied to text-like fields (text and notes). For each submission, a list of text-like fields is retrieved from the database and provided to the method `sanitize_submission`. When iterating through all fields of the submission, we compare the field's key with the list of text-like fields and only sanitize when there is a match. 

### When should this PR be merged

ASAP; the should be scheduled for the next release. 

### Risks

Low

### Follow-up actions

None

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
