### PR TITLE
Fix #1638: Check for xlsform relevant clause syntax errors

### DIFF
--- a/cadasta/questionnaires/managers.py
+++ b/cadasta/questionnaires/managers.py
@@ -19,6 +19,12 @@ from core.validators import sanitize_string
 ATTRIBUTE_GROUPS = settings.ATTRIBUTE_GROUPS
 
 
+def check_relevant_clause(relevant):
+    if not re.match(r"^\$\{\w+\}=('|\"|”)\w+('|\"|”)$", relevant):
+        raise InvalidQuestionnaire(
+            [_("Invalid relevant clause: {0}".format(relevant))])
+
+
 def create_children(children, errors=[], project=None,
                     default_language='', kwargs={}):
     if children:
@@ -83,6 +89,7 @@ def create_attrs_schema(project=None, dict=None, content_type=None,
     if bind:
         relevant = bind.get('relevant', None)
         if relevant:
+            check_relevant_clause(relevant)
             clauses = relevant.split('=')
             selector = re.sub("'", '', clauses[1])
             selectors += (selector,)
@@ -267,6 +274,8 @@ class QuestionGroupManager(models.Manager):
         bind = dict.get('bind')
         if bind:
             relevant = bind.get('relevant', None)
+            if relevant:
+                check_relevant_clause(relevant)
 
         instance.name = dict.get('name')
         instance.label_xlat = dict.get('label', {})
@@ -301,6 +310,8 @@ class QuestionManager(models.Manager):
         bind = dict.get('bind')
         if bind:
             relevant = bind.get('relevant', None)
+            if relevant:
+                check_relevant_clause(relevant)
             required = True if bind.get('required', 'no') == 'yes' else False
 
         instance.type = type_dict[dict.get('type')]

--- a/cadasta/questionnaires/managers.py
+++ b/cadasta/questionnaires/managers.py
@@ -91,7 +91,7 @@ def create_attrs_schema(project=None, dict=None, content_type=None,
         if relevant:
             check_relevant_clause(relevant)
             clauses = relevant.split('=')
-            selector = re.sub("'", '', clauses[1])
+            selector = re.sub("('|\"|”)", '', clauses[1])
             selectors += (selector,)
 
     try:

--- a/cadasta/questionnaires/serializers.py
+++ b/cadasta/questionnaires/serializers.py
@@ -10,7 +10,7 @@ from jsonattrs.models import Attribute, AttributeType, Schema
 from .messages import MISSING_RELEVANT
 from .exceptions import InvalidQuestionnaire
 from .validators import validate_questionnaire
-from .managers import fix_labels
+from .managers import fix_labels, check_relevant_clause
 from . import models
 
 
@@ -94,15 +94,18 @@ class QuestionSerializer(FindInitialMixin, serializers.ModelSerializer):
     def create(self, validated_data):
         initial_data = self.find_initial_data(validated_data['name'])
         validated_data['label_xlat'] = initial_data['label']
+        relevant = initial_data.get('relevant', None)
+        if relevant:
+            check_relevant_clause(relevant)
         question = models.Question.objects.create(
             questionnaire_id=self.context['questionnaire_id'],
             question_group_id=self.context.get('question_group_id'),
             **validated_data)
 
         option_serializer = QuestionOptionSerializer(
-                data=initial_data.get('options', []),
-                many=True,
-                context={'question_id': question.id})
+            data=initial_data.get('options', []),
+            many=True,
+            context={'question_id': question.id})
 
         option_serializer.is_valid(raise_exception=True)
         option_serializer.save()
@@ -117,7 +120,7 @@ class QuestionGroupSerializer(FindInitialMixin, serializers.ModelSerializer):
 
     class Meta:
         model = models.QuestionGroup
-        fields = ('id', 'name', 'label',  'type', 'questions',
+        fields = ('id', 'name', 'label', 'type', 'questions',
                   'question_groups', 'label_xlat', 'relevant', 'index', )
         read_only_fields = ('id', 'questions', 'question_groups', )
         write_only_fields = ('label_xlat', )
@@ -139,6 +142,7 @@ class QuestionGroupSerializer(FindInitialMixin, serializers.ModelSerializer):
     def create(self, validated_data):
         initial_data = self.find_initial_data(validated_data['name'])
         validated_data['label_xlat'] = initial_data['label']
+
         group = models.QuestionGroup.objects.create(
             questionnaire_id=self.context['questionnaire_id'],
             question_group_id=self.context.get('question_group_id'),
@@ -162,8 +166,9 @@ class QuestionGroupSerializer(FindInitialMixin, serializers.ModelSerializer):
 
                 relevant = initial_data.get('relevant', None)
                 if relevant:
+                    check_relevant_clause(relevant)
                     clauses = relevant.split('=')
-                    selector = re.sub("'", '', clauses[1])
+                    selector = re.sub("('|\"|”)", '', clauses[1])
                     selectors += (selector,)
 
                 app_label = ATTRIBUTE_GROUPS[attr_group]['app_label']

--- a/cadasta/questionnaires/tests/test_managers.py
+++ b/cadasta/questionnaires/tests/test_managers.py
@@ -12,8 +12,20 @@ from jsonattrs.models import create_attribute_types
 
 from . import factories
 from .. import models
-from ..managers import create_children, create_options, santize_form
+from ..managers import (create_children, create_options, santize_form,
+                        check_relevant_clause)
 from ..messages import MISSING_RELEVANT
+
+
+class RelevantSyntaxValidationTest(TestCase):
+    def test_relevant_syntax_valid(self):
+        assert check_relevant_clause("${party_type}='IN'") is None
+
+    def test_relevant_syntax_invalid(self):
+        relevant = "${party_type='IN'}"
+        with pytest.raises(InvalidQuestionnaire) as e:
+            check_relevant_clause(relevant)
+        assert str(e.value) == "Invalid relevant clause: ${party_type='IN'}"
 
 
 class SanitizeFormTest(TestCase):

--- a/cadasta/questionnaires/tests/test_serializers.py
+++ b/cadasta/questionnaires/tests/test_serializers.py
@@ -265,7 +265,7 @@ class QuestionnaireSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
                     "default": None,
                     "hint": None,
                     "index": 1,
-                    "relevant": "${start}>='IN'"
+                    "relevant": None
                 },
                 {
                     "id": "rw7mt32858cu2w5urbf9z3a4",
@@ -593,6 +593,9 @@ class QuestionnaireSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
                     "label": "Label",
                     "type": 'group',
                     "index": 13,
+                    "bind": {
+                        "relevant": "$party_type='IN'"
+                    },
                     "questions": [
                         {
                             "id": "8v5znbuyvtyinsdd96ytyrui",
@@ -959,6 +962,37 @@ class QuestionnaireSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         assert questionnaire.question_groups.count() == 7
         assert Attribute.objects.count() == 13
 
+    def test_invalid_relevant_clause(self):
+        data = {
+            'title': 'yx8sqx6488wbc4yysnkrbnfq',
+            'id_string': 'yx8sqx6488wbc4yysnkrbnfq',
+            'default_language': 'en',
+            'questions': [{
+                'name': "start",
+                'label': 'Label',
+                'type': "ST",
+                'required': False,
+                'constraint': None,
+                'index': 0,
+                'relevant': "$party_type='IN'"
+            }, {
+                'name': "end",
+                'label': 'Label',
+                'type': "EN",
+                'index': 1
+            }]
+        }
+        project = ProjectFactory.create()
+
+        serializer = serializers.QuestionnaireSerializer(
+            data=data,
+            context={'project': project}
+        )
+        serializer.is_valid(raise_exception=True)
+        with pytest.raises(InvalidQuestionnaire) as e:
+            serializer.save()
+        assert str(e.value) == "Invalid relevant clause: $party_type='IN'"
+
 
 class QuestionGroupSerializerTest(UserTestCase, TestCase):
     def test_serialize(self):
@@ -1187,6 +1221,30 @@ class QuestionGroupSerializerTest(UserTestCase, TestCase):
         assert questionnaire.question_groups.count() == 1
         assert Attribute.objects.get(name='number').default == '0'
 
+    def test_question_group_with_invalid_relevant(self):
+        questionnaire = factories.QuestionnaireFactory.create()
+        data = [{
+            'label': 'A group',
+            'name': 'party_attributes_individual',
+            "relevant": "$party_type='IN'",
+            'questions': [{
+                'name': "start",
+                'label': 'Start',
+                'type': "TX",
+                'index': 0
+            }]
+        }]
+        serializer = serializers.QuestionGroupSerializer(
+            data=data,
+            many=True,
+            context={'questionnaire_id': questionnaire.id,
+                     'project': questionnaire.project,
+                     'default_language': 'en'})
+        serializer.is_valid(raise_exception=True)
+        with pytest.raises(InvalidQuestionnaire) as e:
+            serializer.save()
+        assert str(e.value) == "Invalid relevant clause: $party_type='IN'"
+
 
 class QuestionSerializerTest(TestCase):
     def test_serialize(self):
@@ -1325,6 +1383,22 @@ class QuestionSerializerTest(TestCase):
                 assert q.label == 'Another question'
                 assert q.type == 'S1'
                 assert q.options.count() == 1
+
+    def test_create_question_with_invalid_relevant(self):
+        questionnaire = factories.QuestionnaireFactory.create()
+        data = {
+            'label': 'A question',
+            'name': 'question',
+            'type': 'TX',
+            'relevant': "$party_type='IN'"
+        }
+        serializer = serializers.QuestionSerializer(
+            data=data,
+            context={'questionnaire_id': questionnaire.id})
+        serializer.is_valid(raise_exception=True)
+        with pytest.raises(InvalidQuestionnaire) as e:
+            serializer.save()
+        assert str(e.value) == "Invalid relevant clause: $party_type='IN'"
 
 
 class QuestionOptionSerializerTest(TestCase):


### PR DESCRIPTION
### Proposed changes in this pull request

Adds syntax checking for the xlsform `relevant` bind statement to `questionnaire.managers.py`. The syntax checking is handled by a single method which implements a regex-based syntax checker. This method is then called from the `QuestionGroupManager`, the `QuestionManager` and during attribute schema creation. The relevant tests have been added to `test_managers.py`. 

### When should this PR be merged

Scheduled for a patch release after the Sprint 18 release.

### Risks

None forseen. 

### Follow-up actions

None

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
