### PR TITLE
Log and pass on TooBig errors from Memcached (fixes #1579)

### DIFF
--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -35,14 +35,14 @@ DATABASES = {
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+        'BACKEND': 'core.backends.MemorySafePyLibMCCache',
         'LOCATION': [
             os.environ['MEMCACHED_HOST'],
         ],
         'OPTIONS': {'distribution': 'consistent'}
     },
     'jsonattrs': {
-        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+        'BACKEND': 'core.backends.MemorySafePyLibMCCache',
         'LOCATION': [
             os.environ['MEMCACHED_HOST'],
         ],
@@ -114,6 +114,11 @@ LOGGING = {
     },
     'loggers': {
         'django': {
+            'handlers': ['file', 'email_admins', 'opbeat'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'core': {
             'handlers': ['file', 'email_admins', 'opbeat'],
             'level': 'DEBUG',
             'propagate': True,

--- a/cadasta/core/backends.py
+++ b/cadasta/core/backends.py
@@ -1,6 +1,21 @@
 from tutelary.backends import Backend as TutelaryBackend
 from django.contrib.auth.backends import ModelBackend
+from django.core.cache.backends.memcached import PyLibMCCache
+import pylibmc
+
+from .types import HandledErrors
 
 
 class Auth(TutelaryBackend, ModelBackend):
     pass
+
+
+class MemorySafePyLibMCCache(PyLibMCCache, metaclass=HandledErrors):
+    HANDLED_ERRORS = [
+        ('add', pylibmc.TooBig),
+        ('get_or_set', pylibmc.TooBig),
+        ('incr', pylibmc.TooBig),
+        ('incr_version', pylibmc.TooBig),
+        ('set', pylibmc.TooBig),
+        ('set_many', pylibmc.TooBig),
+    ]

--- a/cadasta/core/tests/test_backends.py
+++ b/cadasta/core/tests/test_backends.py
@@ -10,6 +10,9 @@ from core import backends
 
 class MemorySafePyLibMCCacheTest(TestCase):
 
+    def tearDown(cls):
+        importlib.reload(backends)
+
     @override_settings(CACHES={
         'default': {
             'BACKEND': 'core.backends.MemorySafePyLibMCCache',

--- a/cadasta/core/tests/test_backends.py
+++ b/cadasta/core/tests/test_backends.py
@@ -1,0 +1,61 @@
+import importlib
+from unittest.mock import patch, MagicMock
+
+from django.test import TestCase, override_settings
+from django.core.cache.backends.memcached import PyLibMCCache
+import pylibmc
+
+from core import backends
+
+
+class MemorySafePyLibMCCacheTest(TestCase):
+
+    @override_settings(CACHES={
+        'default': {
+            'BACKEND': 'core.backends.MemorySafePyLibMCCache',
+            'LOCATION': ['localhost'],
+        }
+    })
+    @patch('core.types.logging')
+    def _test_method(self, method, logging):
+        mock_logger = MagicMock()
+        logging.getLogger.return_value = mock_logger
+
+        # Patch the parent class of MemorySafePyLibMCCache, then reimport
+        with patch.object(PyLibMCCache, method) as mock_method:
+            importlib.reload(backends)
+            from core.backends import MemorySafePyLibMCCache
+
+            mock_method.__name__ = method
+            mock_method.side_effect = pylibmc.TooBig()
+            with patch('django.core.cache.cache', MemorySafePyLibMCCache):
+                from django.core.cache import cache
+
+                getattr(cache, method)('key', 1)
+
+                logging.getLogger.assert_called_once_with('core.backends')
+                mock_logger.exception.assert_called_once_with(
+                    "Silenced cache failure at core.backends."
+                    "MemorySafePyLibMCCache.{}()".format(method)
+                )
+
+                logging.getLogger.reset_mock()
+                mock_logger.exception.reset_mock()
+
+    def test_add(self):
+        return self._test_method('add')
+
+    def test_get_or_set(self):
+        return self._test_method('get_or_set')
+
+    def test_incr(self):
+        return self._test_method('incr')
+
+    def test_incr_version(self):
+        return self._test_method('incr_version')
+
+    def test_set(self):
+        return self._test_method('set')
+
+    def test_set_many(self):
+        return self._test_method('set_many')

--- a/cadasta/core/tests/test_types.py
+++ b/cadasta/core/tests/test_types.py
@@ -7,20 +7,20 @@ from core.types import HandledErrors
 
 class HandledErrorsTest(TestCase):
 
-    def test_HandledErrors_missing_property(self):
+    def test_handlederrors_missing_property(self):
         with self.assertRaises(AssertionError):
             class Foo(metaclass=HandledErrors):
                 # No HANDLED_ERRORS property
                 pass
 
-    def test_HandledErrors_missing_method(self):
+    def test_handlederrors_missing_method(self):
         with self.assertRaises(ValueError):
             class Foo(metaclass=HandledErrors):
                 # Foo doesn't exist as a method
                 HANDLED_ERRORS = [('foo', Exception)]
 
     @patch('core.types.logging')
-    def test_HandledErrors_caught_exception(self, logging):
+    def test_handlederrors_caught_exception(self, logging):
         mock_logger = MagicMock()
         logging.getLogger.return_value = mock_logger
 
@@ -38,14 +38,47 @@ class HandledErrorsTest(TestCase):
         )
 
     @patch('core.types.logging')
-    def test_HandledErrors_caught_custom_exception(self, logging):
+    def test_handlederrors_many_caught_exceptions(self, logging):
+        """
+        Ensure HandledErrors can accept multiple allowed exceptions
+        """
+        mock_logger = MagicMock()
+        logging.getLogger.return_value = mock_logger
+        caught_exceptions = (ValueError, AssertionError)
+
+        class Foo(metaclass=HandledErrors):
+            HANDLED_ERRORS = [('foo', caught_exceptions)]
+
+            def foo(self, exception):
+                raise exception("Error")
+
+        # Handled exceptions
+        for exception in caught_exceptions:
+            Foo().foo(exception)
+            logging.getLogger.assert_called_once_with(self.__module__)
+            mock_logger.exception.assert_called_once_with(
+                "Silenced cache failure at {}.{}.{}()"
+                "".format(self.__module__, 'Foo', 'foo')
+            )
+
+            logging.getLogger.reset_mock()
+            mock_logger.exception.reset_mock()
+
+        # Not handled exceptions
+        with self.assertRaises(NotImplementedError):
+            Foo().foo(NotImplementedError)
+        assert not logging.getLogger.called
+        assert not mock_logger.exception.called
+
+    @patch('core.types.logging')
+    def test_handlederrors_uncaught_exception(self, logging):
         mock_logger = MagicMock()
         logging.getLogger.return_value = mock_logger
 
         class Foo(metaclass=HandledErrors):
             HANDLED_ERRORS = [
                 ('foo', ValueError),
-                ('bar', ValueError)
+                ('bar', ValueError),
             ]
 
             def foo(self):
@@ -54,8 +87,14 @@ class HandledErrorsTest(TestCase):
             def bar(self):
                 raise ValueError("This should be caught")
 
+            def baz(self):
+                raise NotImplementedError("This should not be caught")
+
         with self.assertRaises(TypeError):
             Foo().foo()
+
+        with self.assertRaises(NotImplementedError):
+            Foo().baz()
 
         Foo().bar()
         logging.getLogger.assert_called_once_with(self.__module__)

--- a/cadasta/core/tests/test_types.py
+++ b/cadasta/core/tests/test_types.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch, MagicMock
+
+from django.test import TestCase
+
+from core.types import HandledErrors
+
+
+class HandledErrorsTest(TestCase):
+
+    def test_HandledErrors_missing_property(self):
+        with self.assertRaises(AssertionError):
+            class Foo(metaclass=HandledErrors):
+                # No HANDLED_ERRORS property
+                pass
+
+    def test_HandledErrors_missing_method(self):
+        with self.assertRaises(ValueError):
+            class Foo(metaclass=HandledErrors):
+                # Foo doesn't exist as a method
+                HANDLED_ERRORS = [('foo', Exception)]
+
+    @patch('core.types.logging')
+    def test_HandledErrors_caught_exception(self, logging):
+        mock_logger = MagicMock()
+        logging.getLogger.return_value = mock_logger
+
+        class Foo(metaclass=HandledErrors):
+            HANDLED_ERRORS = [('foo', ValueError)]
+
+            def foo(self):
+                raise ValueError("This should be caught")
+
+        Foo().foo()
+        logging.getLogger.assert_called_once_with(self.__module__)
+        mock_logger.exception.assert_called_once_with(
+            "Silenced cache failure at {}.{}.{}()"
+            "".format(self.__module__, 'Foo', 'foo')
+        )
+
+    @patch('core.types.logging')
+    def test_HandledErrors_caught_custom_exception(self, logging):
+        mock_logger = MagicMock()
+        logging.getLogger.return_value = mock_logger
+
+        class Foo(metaclass=HandledErrors):
+            HANDLED_ERRORS = [
+                ('foo', ValueError),
+                ('bar', ValueError)
+            ]
+
+            def foo(self):
+                raise TypeError("This should not be caught")
+
+            def bar(self):
+                raise ValueError("This should be caught")
+
+        with self.assertRaises(TypeError):
+            Foo().foo()
+
+        Foo().bar()
+        logging.getLogger.assert_called_once_with(self.__module__)
+        mock_logger.exception.assert_called_once_with(
+            "Silenced cache failure at {}.{}.{}()"
+            "".format(self.__module__, 'Foo', 'bar')
+        )

--- a/cadasta/core/types.py
+++ b/cadasta/core/types.py
@@ -1,0 +1,39 @@
+from functools import wraps
+import logging
+
+
+class HandledErrors(type):
+    """
+    Metaclass to suppress and log exceptions white-listed exceptions from
+    associated with method names in the implementing class' HANDLED_ERRORS
+    property. Rather than raising the error, an exception will be logged in
+    the implementing class' module logger.
+    """
+
+    def __init__(cls, name, bases, namespace, **kwargs):
+        super(HandledErrors, cls).__init__(name, bases, namespace)
+
+        METHOD_KEY = 'HANDLED_ERRORS'
+        assert hasattr(cls, METHOD_KEY), (
+            "Missing {!r} property, HandledErrors not correctly "
+            "implemented".format(METHOD_KEY)
+        )
+
+        def safe_func(f, handled_exceptions):
+            @wraps(f)
+            def wrapper(*args, **kwds):
+                try:
+                    return f(*args, **kwds)
+                except handled_exceptions:
+                    logging.getLogger(cls.__module__).exception(
+                        "Silenced cache failure at {}.{}.{}()"
+                        "".format(cls.__module__, name, f.__name__))
+            return wrapper
+
+        try:
+            for (method, errors) in getattr(cls, METHOD_KEY, []):
+                setattr(cls, method, safe_func(getattr(cls, method), errors))
+        except:
+            raise ValueError(
+                "Failed to implement class {!r} with metaclass "
+                "'HandledErrors'".format(name))

--- a/cadasta/core/types.py
+++ b/cadasta/core/types.py
@@ -4,10 +4,15 @@ import logging
 
 class HandledErrors(type):
     """
-    Metaclass to suppress and log exceptions white-listed exceptions from
-    associated with method names in the implementing class' HANDLED_ERRORS
-    property. Rather than raising the error, an exception will be logged in
-    the implementing class' module logger.
+    Metaclass to suppress and log white-listed exceptions within the
+    methods specified in the implementing class' HANDLED_ERRORS
+    property. Rather than raising the error, an exception will be logged
+    in the implementing class' module logger.
+
+    HANDLED_ERRORS is expected to be a an iterable of tuples containing
+    the method name to which the handling should be applied and an
+    exception or tuple of exceptions that should caught and logged
+    within the method.
     """
 
     def __init__(cls, name, bases, namespace, **kwargs):

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -24,7 +24,7 @@ django-buckets==0.1.20
 pyxform-cadasta==0.9.22
 python-magic==0.4.11
 Pillow==3.4.2
-django-jsonattrs==0.1.22
+django-jsonattrs==0.1.23
 openpyxl==2.4.1
 pytz==2016.4
 shapely==1.5.16

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -29,7 +29,7 @@ openpyxl==2.4.1
 pytz==2016.4
 shapely==1.5.16
 gdal==1.10.0
-pylibmc==1.5.1
+pylibmc==1.5.2
 awscli==1.11.23
 pandas==0.19.0
 argon2-cffi==16.3.0


### PR DESCRIPTION
### Proposed changes in this pull request

#1579 occurs due to the abundance of `Attribute` instances being put into the cache as pickled Python objects. This PR addresses the issues around the cache throwing exceptions when a key value is greater than the cache's max-permitted size (currently set at 1MB).

This PR creates a new cache backend class. It inherits from our currently used (in production) backend, `django.core.cache.backends.memcached.PyLibMCCache`, however this backend catches any `pylibmc.TooBig` exceptions and logs them rather than raising them.

`pylibmc` needed to be bumped in patch version as the `TooBig` exception did not exist previously 
(surprising that they call that a patch version change and not a minor version change).

The issue of _why_ the key values were so large is addressed in Cadasta/django-jsonattrs#20.

### When should this PR be merged

Soon.

### Risks

To ensure that these errors don't go unnoticed, I've added the `core` module to the Production `LOGGERS` setting.  This may cause OpBeat to be a become a bit noisier, however I felt this was a better option than allowing caching issues to go unchecked.

The solution was done in a bit of a grandiose fashion, using metaclasses. If that leaves a bad taste in anyones mouth, it can be swapped out for a more standard subclass of the `django.core.cache.backends.memcached.PyLibMCCache` and overriding each method.

### Follow-up actions

None to think of.


### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
