### PR TITLE
Use user.is_superuser to identify superusers

### DIFF
--- a/cadasta/core/fixtures/__init__.py
+++ b/cadasta/core/fixtures/__init__.py
@@ -24,9 +24,9 @@ class FixturesData:
         # the first two named users will have superuser access
         named_users = [
             {'username': 'superuser1', 'email': 'superuser1@cadasta.org',
-             'full_name': 'Super User1'},
+             'full_name': 'Super User1', 'is_superuser': True},
             {'username': 'superuser2', 'email': 'superuser2@cadasta.org',
-             'full_name': 'Super User2'}]
+             'full_name': 'Super User2', 'is_superuser': True}]
         # add users with names in languages that need to be tested.
         languages = ['el_GR', 'ja_JP', 'hi_IN', 'hr_HR', 'lt_LT']
         named_users.append({

--- a/cadasta/core/tests/test_views_default.py
+++ b/cadasta/core/tests/test_views_default.py
@@ -6,7 +6,6 @@ from django.test import TestCase
 
 from accounts.tests.factories import UserFactory
 from core.tests.utils.cases import UserTestCase
-from tutelary.models import Role
 from organization.tests.factories import OrganizationFactory, ProjectFactory
 from organization.models import OrganizationRole, Project
 from organization.serializers import ProjectGeometrySerializer
@@ -83,9 +82,7 @@ class DashboardTest(ViewTestCase, UserTestCase, TestCase):
         assert response.content == expected_content
 
     def test_get_with_superuser(self):
-        superuser = UserFactory.create()
-        self.superuser_role = Role.objects.get(name='superuser')
-        superuser.assign_policies(self.superuser_role)
+        superuser = UserFactory.create(is_superuser=True)
         response = self.request(user=superuser)
 
         gj = self._render_geojson(Project.objects.all())

--- a/cadasta/core/views/mixins.py
+++ b/cadasta/core/views/mixins.py
@@ -1,7 +1,5 @@
 from django.shortcuts import redirect
 
-from tutelary.models import Role
-
 
 class ArchiveMixin:
     def archive(self):
@@ -23,14 +21,7 @@ class SuperUserCheckMixin:
 
     @property
     def is_superuser(self):
-        if self.is_su is None:
-            role = Role.objects.filter(name='superuser')
-            self.is_su = False
-            if len(role) > 0:
-                if hasattr(self.request.user, 'assigned_policies'):
-                    if role[0] in self.request.user.assigned_policies():
-                        self.is_su = True
-        return self.is_su
+        return self.request.user.is_superuser
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)

--- a/cadasta/core/views/mixins.py
+++ b/cadasta/core/views/mixins.py
@@ -15,10 +15,6 @@ class ArchiveMixin:
 
 
 class SuperUserCheckMixin:
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_su = None
-
     @property
     def is_superuser(self):
         return self.request.user.is_superuser

--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -97,9 +97,7 @@ class OrganizationListTest(ViewTestCase, UserTestCase, TestCase):
             object_list=sorted(self.orgs, key=lambda p: p.slug))
 
     def test_get_with_superuser(self):
-        superuser = UserFactory.create()
-        self.superuser_role = Role.objects.get(name='superuser')
-        superuser.assign_policies(self.superuser_role)
+        superuser = UserFactory.create(is_superuser=True)
         response = self.request(user=superuser)
         assert response.status_code == 200
         assert response.content == self.render_content(user=superuser,
@@ -230,9 +228,7 @@ class OrganizationDashboardTest(ViewTestCase, UserTestCase, TestCase):
                                                        projects=[])
 
     def test_get_org_with_superuser(self):
-        superuser = UserFactory.create()
-        self.superuser_role = Role.objects.get(name='superuser')
-        superuser.assign_policies(self.superuser_role)
+        superuser = UserFactory.create(is_superuser=True)
         response = self.request(user=superuser)
         assert response.status_code == 200
         assert response.content == self.render_content(
@@ -686,9 +682,7 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
         assert '/account/login/' in response.location
 
     def test_get_with_superuser(self):
-        superuser = UserFactory.create()
-        superuser_role = Role.objects.get(name='superuser')
-        superuser.assign_policies(superuser_role)
+        superuser = UserFactory.create(is_superuser=True)
         response = self.request(user=superuser)
         assert response.status_code == 200
         assert response.content == self.render_content(is_superuser=True,

--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -172,9 +172,7 @@ class ProjectListTest(ViewTestCase, UserTestCase, TestCase):
             add_allowed=True)
 
     def test_get_with_superuser(self):
-        superuser = UserFactory.create()
-        self.superuser_role = Role.objects.get(name='superuser')
-        superuser.assign_policies(self.superuser_role)
+        superuser = UserFactory.create(is_superuser=True)
 
         response = self.request(user=superuser)
         assert response.status_code == 200
@@ -246,8 +244,8 @@ class ProjectDashboardTest(FileStorageTestCase, ViewTestCase, UserTestCase,
         assert response.content == self.expected_content
 
     def test_get_with_superuser(self):
-        superuser_role = Role.objects.get(name='superuser')
-        self.user.assign_policies(superuser_role)
+        self.user.is_superuser = True
+        self.user.save()
         response = self.request(user=self.user)
         assert response.status_code == 200
         expected = self.render_content(is_superuser=True,
@@ -373,8 +371,8 @@ class ProjectDashboardTest(FileStorageTestCase, ViewTestCase, UserTestCase,
         self.project.access = 'private'
         self.project.save()
 
-        self.superuser_role = Role.objects.get(name='superuser')
-        self.user.assign_policies(self.superuser_role)
+        self.user.is_superuser = True
+        self.user.save()
         response = self.request(user=self.user)
         assert response.status_code == 200
         expected = self.render_content(is_superuser=True,

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -159,8 +159,7 @@ class ProjectRoles(ProjectMixin):
 
 class ProjectQuerySetMixin:
     def get_queryset(self):
-        if (not isinstance(self.request.user, AnonymousUser) and
-                self.request.user.is_superuser):
+        if self.request.user.is_superuser:
             return Project.objects.all()
 
         if hasattr(self.request.user, 'organizations'):

--- a/cadasta/organization/views/mixins.py
+++ b/cadasta/organization/views/mixins.py
@@ -4,7 +4,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import get_object_or_404
 from django.db.models import Q, Prefetch
 
-from tutelary.models import Role, check_perms
+from tutelary.models import check_perms
 
 from core.views.mixins import SuperUserCheckMixin
 from ..models import Organization, Project, OrganizationRole, ProjectRole
@@ -159,12 +159,8 @@ class ProjectRoles(ProjectMixin):
 
 class ProjectQuerySetMixin:
     def get_queryset(self):
-        if not hasattr(self, 'su_role'):
-            self.su_role = Role.objects.get(name='superuser')
-
         if (not isinstance(self.request.user, AnonymousUser) and
-            any([isinstance(pol, Role) and pol == self.su_role
-                 for pol in self.request.user.assigned_policies()])):
+                self.request.user.is_superuser):
             return Project.objects.all()
 
         if hasattr(self.request.user, 'organizations'):


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #1628: Superuser permissions were not applied to superusers on production machines because tutelary's superuser policies were not applied to superusers. Superusers are only identified through the `is_superuser` field in the User table. 
- Given the precondition, that superusers can access all data and perform all actions throughout the platform, using Django's built-in `User.is_superuser` field is sufficient to identify superusers. `User.has_perm` will also work as expected because `True` will always be returned for any permissions if the user is a superuser. It's Django's default behaviour. 

#### Changes added

- Changed the `is_superuser` property of `core.views.mixins.SuperUserCheckMixin` to return the value of `is_superuser` of the user authenticated with the request. 
- Changed `get_queryset` of `organization.views.mixins.ProjectQuerySetMixin` to return all projects if the user authenticated with the request is a superuser. 
- Adapted tests according to the changes above. 
- Changed the fixtures to set the `is_superuser` field of users `superuser1` and `superuser2` to `True`. To apply these changes devs need to either tear down and re-create the database on their dev VMs or change the field manually. (See further instructions in "Follow-up actions".

(@bjohare, let me know if this approach conflicts with what you're working on and if we can follow another approach closer to yours)

### When should this PR be merged

When ready. 

### Risks

Low. 

### Follow-up actions

@Cadasta/cadasta-dev need to update set `is_superuser` to `True` for `superuser1` and `superuser2`. Assuming that everybody wants to keep their test data on their dev VMs here's how to do that manually.  

SSH'ed into the dev VM in directory `/vagrant/cadasta` run the following commands:

1. Start the dbshell: `./manage.py dbshell`

2. Update the superusers: `update accounts_user set is_superuser = 't' where username in ('superuser1', 'superuser2');` If this is successful you should see the output `UPDATE 2`.  (In case you haven't run the updates following PR #1618, run `update accounts_user set is_superuser = 't' where username in ('oroick', 'iross');` instead. 

3. Close the dbshell: `\q`

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
