### PR TITLE
Adds more allowed mime types

### DIFF
--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -514,7 +514,30 @@ ICON_LOOKUPS = {
     'image/gif': 'gif',
     'image/tif': 'tiff',
     'image/tiff': 'tiff',
-    'application/gpx+xml': 'gpx'
+    'image/bmp': 'image',
+    'image/x-windows-bmp': 'image',
+    'application/gpx+xml': 'gpx',
+    'application/rtf': 'doc',
+    'application/x-rtf': 'doc',
+    'application/postscript': 'doc',
+    'application/x-troff-msvideo': 'video',
+    'video/avi': 'avi',
+    'video/msvideo': 'wmv',
+    'video/x-msvideo': 'wmv',
+    'video/x-ms-wmv': 'wmv',
+    'video/quicktime': 'video',
+    'application/ogg': 'audio',
+    'image/svg+xml': 'svg',
+    'audio/x-ms-wma': 'audio',
+    'application/vnd.oasis.opendocument.spreadsheet': 'ods',
+    'application/vnd.oasis.opendocument.text': 'odt',
+    'application/vnd.oasis.opendocument.presentation': 'odd',
+    'application/vnd.ms-powerpoint': 'ppt',
+    'application/vnd.openxmlformats-officedocument.presentationml.'
+    'presentation': 'pptx',
+    'application/x-iwork-keynote-sffkey': 'key',
+    'video/x-m4v': 'mp4',
+    'video/x-matroska': 'video',
 }
 
 MIME_LOOKUPS = {

--- a/cadasta/resources/models.py
+++ b/cadasta/resources/models.py
@@ -103,7 +103,8 @@ class Resource(RandomIDModel):
     def thumbnail(self):
         if not hasattr(self, '_thumbnail'):
             icon = settings.ICON_LOOKUPS.get(self.mime_type, None)
-            if 'image' in self.mime_type and 'tif' not in self.mime_type:
+            if ('image' in self.mime_type and
+                    all(img not in self.mime_type for img in ['tif', 'svg'])):
                 ext = self.file_name.split('.')[-1]
                 base_url = self.file.url[:self.file.url.rfind('.')]
                 self._thumbnail = base_url + '-128x128.' + ext
@@ -156,7 +157,7 @@ def archive_file(sender, instance, **kwargs):
 
 def create_thumbnails(instance, created):
     if created or instance._original_url != instance.file.url:
-        if 'image' in instance.mime_type:
+        if 'image' in instance.mime_type and 'svg' not in instance.mime_type:
             io.ensure_dirs()
             file_name = instance.file.url.split('/')[-1]
             name = file_name[:file_name.rfind('.')]

--- a/cadasta/resources/tests/test_models.py
+++ b/cadasta/resources/tests/test_models.py
@@ -164,6 +164,14 @@ class ResourceTest(UserTestCase, FileStorageTestCase, TestCase):
                 'https://s3-us-west-2.amazonaws.com/cadasta-resources'
                 '/icons/xml.png')
 
+    def test_thumbnail_svg(self):
+        resource = ResourceFactory.build(
+            file='http://example.com/dir/filename.svg',
+            mime_type='image/svg+xml')
+        assert (resource.thumbnail ==
+                'https://s3-us-west-2.amazonaws.com/cadasta-resources'
+                '/icons/svg.png')
+
     def test_thumbnail_other(self):
         resource = ResourceFactory.build(
             file='http://example.com/dir/filename.pdf',


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #1135: Adds more mime types to the list of accepted types. 
- Excludes SVG images from creating thumbnails because vector graphics are not support by Pillow. 
- New thumbnails for non-images are already on the production buckts.

### When should this PR be merged

When ready. 

### Risks

None

### Follow-up actions

None. 

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
