### PR TITLE
add language dropdown at registration

### DIFF
--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -17,11 +17,18 @@ class RegisterForm(SanitizeFieldsForm, forms.ModelForm):
     email = forms.EmailField(required=True)
     password = forms.CharField(widget=forms.PasswordInput())
     MIN_LENGTH = 10
+    language = forms.ChoiceField(
+        required=False,
+        choices=settings.LANGUAGES,
+        error_messages={
+            'invalid_choice': _('Language invalid or not available')
+        }
+    )
 
     class Meta:
         model = User
         fields = ['username', 'email', 'password',
-                  'full_name']
+                  'full_name', 'language']
 
     class Media:
         js = ('js/sanitize.js', )

--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -17,13 +17,6 @@ class RegisterForm(SanitizeFieldsForm, forms.ModelForm):
     email = forms.EmailField(required=True)
     password = forms.CharField(widget=forms.PasswordInput())
     MIN_LENGTH = 10
-    language = forms.ChoiceField(
-        required=False,
-        choices=settings.LANGUAGES,
-        error_messages={
-            'invalid_choice': _('Language invalid or not available')
-        }
-    )
 
     class Meta:
         model = User

--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -69,18 +69,6 @@ class RegisterForm(SanitizeFieldsForm, forms.ModelForm):
 
 class ProfileForm(SanitizeFieldsForm, forms.ModelForm):
     password = forms.CharField(widget=forms.PasswordInput())
-    language = forms.ChoiceField(
-        choices=settings.LANGUAGES,
-        error_messages={
-            'invalid_choice': _('Language invalid or not available')
-        }
-    )
-    measurement = forms.ChoiceField(
-        choices=settings.MEASUREMENTS,
-        error_messages={
-            'invalid_choice': _('Measurement system invalid or not available')
-        }
-    )
 
     class Meta:
         model = User

--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext as _
 from django.contrib.auth.password_validation import validate_password
 
-from rest_framework.serializers import ChoiceField, EmailField, ValidationError
+from rest_framework.serializers import EmailField, ValidationError
 from rest_framework.validators import UniqueValidator
 from djoser import serializers as djoser_serializers
 
@@ -74,20 +74,6 @@ class UserSerializer(SanitizeFieldSerializer,
             message=_("Another user is already registered with this "
                       "email address")
         )]
-    )
-    language = ChoiceField(
-        choices=settings.LANGUAGES,
-        default=settings.LANGUAGE_CODE,
-        error_messages={
-            'invalid_choice': _('Language invalid or not available')
-        }
-    )
-    measurement = ChoiceField(
-        choices=settings.MEASUREMENTS,
-        default=settings.MEASUREMENT_DEFAULT,
-        error_messages={
-            'invalid_choice': _('Measurement system invalid or not available')
-        }
     )
 
     class Meta:

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -23,6 +23,7 @@ class RegisterFormTest(UserTestCase, TestCase):
             'email': 'john@beatles.uk',
             'password': 'iloveyoko79!',
             'full_name': 'John Lennon',
+            'language': 'fr',
         }
         form = forms.RegisterForm(data)
         form.save()
@@ -207,6 +208,20 @@ class RegisterFormTest(UserTestCase, TestCase):
         assert (_("Username cannot be “add” or “new”.")
                 in form.errors.get('username'))
         assert User.objects.count() == 0
+
+    def test_signup_with_invalid_language(self):
+        data = {
+            'username': 'imagine71',
+            'email': 'john@beatles.uk',
+            'password': 'iloveyoko79!',
+            'full_name': 'John Lennon',
+            'language': 'invalid',
+        }
+        form = forms.RegisterForm(data)
+        assert form.is_valid() is False
+        assert User.objects.count() == 0
+        assert ('Language invalid or not available'
+                in form.errors.get('language'))
 
     def test_sanitize(self):
         data = {

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -209,20 +209,6 @@ class RegisterFormTest(UserTestCase, TestCase):
                 in form.errors.get('username'))
         assert User.objects.count() == 0
 
-    def test_signup_with_invalid_language(self):
-        data = {
-            'username': 'imagine71',
-            'email': 'john@beatles.uk',
-            'password': 'iloveyoko79!',
-            'full_name': 'John Lennon',
-            'language': 'invalid',
-        }
-        form = forms.RegisterForm(data)
-        assert form.is_valid() is False
-        assert User.objects.count() == 0
-        assert ('Select a valid choice. invalid is not one of the '
-                'available choices.' in form.errors.get('language'))
-
     def test_sanitize(self):
         data = {
             'username': '😛😛😛😛',
@@ -429,40 +415,6 @@ class ProfileFormTest(UserTestCase, TestCase):
         assert form.is_valid() is False
         assert ("Please provide the correct password for your account." in
                 form.errors['password'])
-
-    def test_update_with_invalid_language(self):
-        user = UserFactory.create(email='john@beatles.uk',
-                                  password='imagine71',
-                                  language='en')
-        data = {
-            'username': 'imagine71',
-            'email': 'john2@beatles.uk',
-            'full_name': 'John Lennon',
-            'password': 'stg-pepper',
-            'language': 'invalid'
-        }
-        form = forms.ProfileForm(data, instance=user)
-        assert form.is_valid() is False
-        assert user.language == 'en'
-        assert ('Language invalid or not available'
-                in form.errors.get('language'))
-
-    def test_update_user_with_invalid_measurement(self):
-        user = UserFactory.create(email='john@beatles.uk',
-                                  password='imagine71',
-                                  measurement='metric')
-        data = {
-            'username': 'imagine71',
-            'email': 'john2@beatles.uk',
-            'full_name': 'John Lennon',
-            'password': 'stg-pepper',
-            'measurement': 'invalid'
-        }
-        form = forms.ProfileForm(data, instance=user)
-        assert form.is_valid() is False
-        assert user.measurement == 'metric'
-        assert ('Measurement system invalid or not available'
-                in form.errors['measurement'])
 
     def test_sanitize(self):
         user = UserFactory.create(email='john@beatles.uk',

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -220,8 +220,8 @@ class RegisterFormTest(UserTestCase, TestCase):
         form = forms.RegisterForm(data)
         assert form.is_valid() is False
         assert User.objects.count() == 0
-        assert ('Language invalid or not available'
-                in form.errors.get('language'))
+        assert ('Select a valid choice. invalid is not one of the '
+                'available choices.' in form.errors.get('language'))
 
     def test_sanitize(self):
         data = {

--- a/cadasta/accounts/tests/test_serializers.py
+++ b/cadasta/accounts/tests/test_serializers.py
@@ -310,42 +310,6 @@ class UserSerializerTest(UserTestCase, TestCase):
         assert serializer2.errors['username'] == [
             _("Username cannot be “add” or “new”.")]
 
-    def test_update_with_invalid_language(self):
-        serializer = serializers.UserSerializer(data=BASIC_TEST_DATA)
-        assert serializer.is_valid() is True
-        user = serializer.save()
-        data = {
-            'username': 'imagine71',
-            'email': 'john@beatles.uk',
-            'language': 'invalid',
-        }
-        request = APIRequestFactory().patch('/user/imagine71', data)
-        force_authenticate(request, user=user)
-        serializer2 = serializers.UserSerializer(
-            user, data=data, context={'request': Request(request)}
-        )
-        assert serializer2.is_valid() is False
-        assert ('Language invalid or not available'
-                in serializer2.errors['language'])
-
-    def test_update_with_invalid_measurement_system(self):
-        serializer = serializers.UserSerializer(data=BASIC_TEST_DATA)
-        assert serializer.is_valid() is True
-        user = serializer.save()
-        data = {
-            'username': 'imagine71',
-            'email': 'john@beatles.uk',
-            'measurement': 'invalid',
-        }
-        request = APIRequestFactory().patch('/user/imagine71', data)
-        force_authenticate(request, user=user)
-        serializer2 = serializers.UserSerializer(
-            user, data=data, context={'request': Request(request)}
-        )
-        assert serializer2.is_valid() is False
-        assert ('Measurement system invalid or not available'
-                in serializer2.errors['measurement'])
-
     def test_sanitize(self):
         user = UserFactory.create(username='imagine71')
         data = {

--- a/cadasta/accounts/tests/test_serializers.py
+++ b/cadasta/accounts/tests/test_serializers.py
@@ -310,6 +310,38 @@ class UserSerializerTest(UserTestCase, TestCase):
         assert serializer2.errors['username'] == [
             _("Username cannot be “add” or “new”.")]
 
+    def test_update_with_invalid_language(self):
+        serializer = serializers.UserSerializer(data=BASIC_TEST_DATA)
+        assert serializer.is_valid() is True
+        user = serializer.save()
+        data = {
+            'username': 'imagine71',
+            'email': 'john@beatles.uk',
+            'language': 'invalid',
+        }
+        request = APIRequestFactory().patch('/user/imagine71', data)
+        force_authenticate(request, user=user)
+        serializer2 = serializers.UserSerializer(
+            user, data=data, context={'request': Request(request)}
+        )
+        assert serializer2.is_valid() is False
+
+    def test_update_with_invalid_measurement_system(self):
+        serializer = serializers.UserSerializer(data=BASIC_TEST_DATA)
+        assert serializer.is_valid() is True
+        user = serializer.save()
+        data = {
+            'username': 'imagine71',
+            'email': 'john@beatles.uk',
+            'measurement': 'invalid',
+        }
+        request = APIRequestFactory().patch('/user/imagine71', data)
+        force_authenticate(request, user=user)
+        serializer2 = serializers.UserSerializer(
+            user, data=data, context={'request': Request(request)}
+        )
+        assert serializer2.is_valid() is False
+
     def test_sanitize(self):
         user = UserFactory.create(username='imagine71')
         data = {

--- a/cadasta/templates/allauth/account/signup.html
+++ b/cadasta/templates/allauth/account/signup.html
@@ -76,6 +76,12 @@
     <div class="error-block">{{ form.full_name.errors }}</div>
   </div>
 
+  <div class="form-group{% if form.language.errors %} has-error{% endif %}">
+    <label class="control-label" for="id_language">{% trans "Your preferred language" %}</label>
+    {% render_field form.language class+="form-control input-lg" %}
+    <div class="error-block">{{ form.language.errors }}</div>
+  </div>
+
   {% if redirect_field_value %}
   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}


### PR DESCRIPTION
### Proposed changes in this pull request

Address issue #1654 for applying existing feature at the registration. Part of User Dashboard #1491 epic.

- Add dropdown language menu option by adding the language field both in the `signup.html` template and in the `RegisterForm`.
- Add language item in data used in testing a valid signup
- Simplify existing `language` and `measurement` fields by deleting respective `form.fields`, custom messages and tests

### When should this PR be merged
- As soon as it has been reviewed

### Risks
- None

### Follow-up actions
- None

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
