### PR TITLE
Fixes #1672: Adds validator for relevant clauses

### DIFF
--- a/cadasta/questionnaires/managers.py
+++ b/cadasta/questionnaires/managers.py
@@ -16,13 +16,13 @@ from core.validators import sanitize_string
 from .choices import QUESTION_TYPES, XFORM_GEOM_FIELDS
 from .exceptions import InvalidQuestionnaire
 from .messages import MISSING_RELEVANT, INVALID_ACCURACY
-from .validators import validate_accuracy
+from .validators import validate_accuracy, validate_relevant
 
 ATTRIBUTE_GROUPS = settings.ATTRIBUTE_GROUPS
 
 
 def check_relevant_clause(relevant):
-    if not re.match(r"^\$\{\w+\}=('|\"|”|’)\w+('|\"|”|’)$", relevant):
+    if not validate_relevant(relevant):
         raise InvalidQuestionnaire(
             [_("Invalid relevant clause: {0}".format(relevant))])
 

--- a/cadasta/questionnaires/managers.py
+++ b/cadasta/questionnaires/managers.py
@@ -92,7 +92,7 @@ def create_attrs_schema(project=None, dict=None, content_type=None,
         relevant = bind.get('relevant', None)
         if relevant:
             clauses = relevant.split('=')
-            selector = re.sub("'", '', clauses[1])
+            selector = re.sub("('|\"|”)", '', clauses[1])
             selectors += (selector,)
 
     try:
@@ -275,6 +275,8 @@ class QuestionGroupManager(models.Manager):
         bind = dict.get('bind')
         if bind:
             relevant = bind.get('relevant', None)
+            if relevant:
+                check_relevant_clause(relevant)
 
         instance.name = dict.get('name')
         instance.label_xlat = dict.get('label', {})
@@ -309,6 +311,8 @@ class QuestionManager(models.Manager):
         bind = dict.get('bind')
         if bind:
             relevant = bind.get('relevant', None)
+            if relevant:
+                check_relevant_clause(relevant)
             required = True if bind.get('required', 'no') == 'yes' else False
 
         gps_accuracy = None

--- a/cadasta/questionnaires/managers.py
+++ b/cadasta/questionnaires/managers.py
@@ -15,7 +15,7 @@ from core.messages import SANITIZE_ERROR
 from core.validators import sanitize_string
 from .choices import QUESTION_TYPES, XFORM_GEOM_FIELDS
 from .exceptions import InvalidQuestionnaire
-from .messages import MISSING_RELEVANT, INVALID_ACCURACY
+from .messages import MISSING_RELEVANT, INVALID_ACCURACY, INVALID_RELEVANT
 from .validators import validate_accuracy, validate_relevant
 
 ATTRIBUTE_GROUPS = settings.ATTRIBUTE_GROUPS
@@ -24,7 +24,7 @@ ATTRIBUTE_GROUPS = settings.ATTRIBUTE_GROUPS
 def check_relevant_clause(relevant):
     if not validate_relevant(relevant):
         raise InvalidQuestionnaire(
-            [_("Invalid relevant clause: {0}".format(relevant))])
+            [_(INVALID_RELEVANT.format(relevant))])
 
 
 def create_children(children, errors=[], project=None,

--- a/cadasta/questionnaires/managers.py
+++ b/cadasta/questionnaires/managers.py
@@ -21,6 +21,12 @@ from .validators import validate_accuracy
 ATTRIBUTE_GROUPS = settings.ATTRIBUTE_GROUPS
 
 
+def check_relevant_clause(relevant):
+    if not re.match(r"^\$\{\w+\}=('|\"|”|’)\w+('|\"|”|’)$", relevant):
+        raise InvalidQuestionnaire(
+            [_("Invalid relevant clause: {0}".format(relevant))])
+
+
 def create_children(children, errors=[], project=None,
                     default_language='', kwargs={}):
     if children:

--- a/cadasta/questionnaires/messages.py
+++ b/cadasta/questionnaires/messages.py
@@ -11,4 +11,5 @@ MISSING_RELEVANT = _("Unable to assign question group to model entitity. Make "
                      "sure to add a 'relevant' clause to the question group "
                      "definition when adding more than one question group for "
                      "a model entity.")
+INVALID_RELEVANT = _("Invalid relevant clause: {0}")
 INVALID_ACCURACY = _("Accuracy threshold must be positive float.")

--- a/cadasta/questionnaires/serializers.py
+++ b/cadasta/questionnaires/serializers.py
@@ -10,7 +10,7 @@ from jsonattrs.models import Attribute, AttributeType, Schema
 from .messages import MISSING_RELEVANT, INVALID_ACCURACY
 from .exceptions import InvalidQuestionnaire
 from .validators import validate_questionnaire, validate_accuracy
-from .managers import fix_labels, check_relevant_clause
+from .managers import fix_labels
 from . import models, choices
 
 

--- a/cadasta/questionnaires/serializers.py
+++ b/cadasta/questionnaires/serializers.py
@@ -10,7 +10,7 @@ from jsonattrs.models import Attribute, AttributeType, Schema
 from .messages import MISSING_RELEVANT, INVALID_ACCURACY
 from .exceptions import InvalidQuestionnaire
 from .validators import validate_questionnaire, validate_accuracy
-from .managers import fix_labels
+from .managers import fix_labels, check_relevant_clause
 from . import models, choices
 
 

--- a/cadasta/questionnaires/tests/test_managers.py
+++ b/cadasta/questionnaires/tests/test_managers.py
@@ -11,9 +11,19 @@ from jsonattrs.models import Attribute
 from jsonattrs.models import create_attribute_types
 
 from . import factories
-from .. import models
-from ..managers import create_children, create_options, santize_form
+from .. import models, managers
 from ..messages import MISSING_RELEVANT
+
+
+class RelevantSyntaxValidationTest(TestCase):
+    def test_relevant_syntax_valid(self):
+        assert managers.check_relevant_clause("${party_type}='IN'") is None
+
+    def test_relevant_syntax_invalid(self):
+        relevant = "${party_type='IN'}"
+        with pytest.raises(InvalidQuestionnaire) as e:
+            managers.check_relevant_clause(relevant)
+        assert str(e.value) == "Invalid relevant clause: ${party_type='IN'}"
 
 
 class SanitizeFormTest(TestCase):
@@ -23,7 +33,7 @@ class SanitizeFormTest(TestCase):
             'relevant': '${age}>10'
         }
         try:
-            santize_form(data)
+            managers.santize_form(data)
         except InvalidQuestionnaire:
             assert False, "InvalidQuestionnaire raised unexpectedly"
         else:
@@ -35,7 +45,7 @@ class SanitizeFormTest(TestCase):
             'relevant': '${age}>10'
         }
         with pytest.raises(InvalidQuestionnaire):
-            santize_form(data)
+            managers.santize_form(data)
 
     def test_sanitize_valid_list(self):
         data = {
@@ -45,7 +55,7 @@ class SanitizeFormTest(TestCase):
             ]
         }
         try:
-            santize_form(data)
+            managers.santize_form(data)
         except InvalidQuestionnaire:
             assert False, "InvalidQuestionnaire raised unexpectedly"
         else:
@@ -59,7 +69,7 @@ class SanitizeFormTest(TestCase):
             ]
         }
         with pytest.raises(InvalidQuestionnaire):
-            santize_form(data)
+            managers.santize_form(data)
 
     def test_valid_multilang_labels(self):
         data = {
@@ -67,7 +77,7 @@ class SanitizeFormTest(TestCase):
             'label': {'en': 'English', 'de': 'German'}
         }
         try:
-            santize_form(data)
+            managers.santize_form(data)
         except InvalidQuestionnaire:
             assert False, "InvalidQuestionnaire raised unexpectedly"
         else:
@@ -79,14 +89,14 @@ class SanitizeFormTest(TestCase):
             'label': {'en': 'English 😆', 'de': 'German'}
         }
         with pytest.raises(InvalidQuestionnaire):
-            santize_form(data)
+            managers.santize_form(data)
 
 
 class CreateChildrenTest(TestCase):
 
     def test_create_children_where_children_is_none(self):
         children = None
-        create_children(children)
+        managers.create_children(children)
 
         assert models.QuestionGroup.objects.exists() is False
         assert models.Question.objects.exists() is False
@@ -112,7 +122,8 @@ class CreateChildrenTest(TestCase):
                 }
             ],
         }]
-        create_children(children, kwargs={'questionnaire': questionnaire})
+        managers.create_children(children,
+                                 kwargs={'questionnaire': questionnaire})
 
         assert models.QuestionGroup.objects.filter(
             questionnaire=questionnaire).count() == 1
@@ -157,7 +168,8 @@ class CreateChildrenTest(TestCase):
                 }
             ],
         }]
-        create_children(children, kwargs={'questionnaire': questionnaire})
+        managers.create_children(children,
+                                 kwargs={'questionnaire': questionnaire})
 
         assert models.QuestionGroup.objects.filter(
             questionnaire=questionnaire).count() == 2
@@ -166,6 +178,35 @@ class CreateChildrenTest(TestCase):
         assert models.Question.objects.filter(
             questionnaire=questionnaire,
             question_group__isnull=False).count() == 2
+
+    def test_invalid_relevant_clause_in_children(self):
+        questionnaire = factories.QuestionnaireFactory.create()
+        children = [{
+            'label': 'This form showcases the different question',
+            'name': 'intro',
+            'type': 'note'
+        }, {
+            'label': 'Text question type',
+            'name': 'text_questions',
+            'type': 'group',
+            'children': [
+                {
+                    'hint': 'Can be short or long but '
+                            'always one line (type = '
+                            'text)',
+                    'label': 'Text',
+                    'name': 'my_string',
+                    'type': 'text',
+                    'bind': {'relevant': '$geo_type="geoshape"'}  # invalid
+                }
+            ],
+        }]
+
+        with pytest.raises(InvalidQuestionnaire) as e:
+            managers.create_children(children,
+                                     kwargs={'questionnaire': questionnaire})
+
+        assert str(e.value) == 'Invalid relevant clause: $geo_type="geoshape"'
 
 
 class CreateOptionsTest(TestCase):
@@ -177,14 +218,14 @@ class CreateOptionsTest(TestCase):
             {'label': 'option 2', 'name': '2'},
             {'label': 'option 3', 'name': '3'}
         ]
-        create_options(options, question)
+        managers.create_options(options, question)
         assert models.QuestionOption.objects.filter(
             question=question).count() == 3
 
     def test_create_options_with_empty_list(TestCase):
         errors = []
         question = factories.QuestionFactory.create(name='qu')
-        create_options([], question, errors)
+        managers.create_options([], question, errors)
         assert "Please provide at least one option for field 'qu'" in errors
 
 
@@ -343,6 +384,21 @@ class QuestionGroupManagerTest(TestCase):
         assert model.question_groups.count() == 1
         assert questionnaire.question_groups.count() == 2
 
+    def test_invalid_relevant_clause(self):
+        question_group_dict = {
+            'label': 'Basic Select question types',
+            'name': 'select_questions',
+            'type': 'group',
+            'bind': {'relevant': "$party_type='IN'"}  # invalid
+        }
+        questionnaire = factories.QuestionnaireFactory.create()
+        with pytest.raises(InvalidQuestionnaire) as e:
+            models.QuestionGroup.objects.create_from_dict(
+                dict=question_group_dict,
+                questionnaire=questionnaire
+            )
+        assert str(e.value) == "Invalid relevant clause: $party_type='IN'"
+
 
 class QuestionManagerTest(TestCase):
 
@@ -397,6 +453,27 @@ class QuestionManagerTest(TestCase):
         assert model.name == question_dict['name']
         assert model.type == 'GP'
         assert model.gps_accuracy == 1.5
+
+    def test_invalid_relevant_clause(self):
+        question_dict = {
+            'hint': 'For this field (type=integer)',
+            'label': 'Integer',
+            'name': 'my_int',
+            'type': 'integer',
+            'default': 'default val',
+            'hint': 'An informative hint',
+            'bind': {
+                'relevant': "$party_id='abc123'",  # invalid
+                'required': 'yes'
+            }
+        }
+        questionnaire = factories.QuestionnaireFactory.create()
+        with pytest.raises(InvalidQuestionnaire) as e:
+            models.Question.objects.create_from_dict(
+                dict=question_dict,
+                questionnaire=questionnaire
+            )
+        assert str(e.value) == "Invalid relevant clause: $party_id='abc123'"
 
     def test_create_from_dict_ingnore_accuracy_threshold(self):
         """For non-geometry fields accuracy should be ignored"""

--- a/cadasta/questionnaires/tests/test_managers.py
+++ b/cadasta/questionnaires/tests/test_managers.py
@@ -456,7 +456,6 @@ class QuestionManagerTest(TestCase):
 
     def test_invalid_relevant_clause(self):
         question_dict = {
-            'hint': 'For this field (type=integer)',
             'label': 'Integer',
             'name': 'my_int',
             'type': 'integer',

--- a/cadasta/questionnaires/tests/test_serializers.py
+++ b/cadasta/questionnaires/tests/test_serializers.py
@@ -959,6 +959,37 @@ class QuestionnaireSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         assert questionnaire.question_groups.count() == 7
         assert Attribute.objects.count() == 13
 
+    def test_invalid_relevant_clause(self):
+        data = {
+            'title': 'yx8sqx6488wbc4yysnkrbnfq',
+            'id_string': 'yx8sqx6488wbc4yysnkrbnfq',
+            'default_language': 'en',
+            'questions': [{
+                'name': "start",
+                'label': 'Label',
+                'type': "ST",
+                'required': False,
+                'constraint': None,
+                'index': 0,
+                'relevant': "$party_type='IN'"
+            }, {
+                'name': "end",
+                'label': 'Label',
+                'type': "EN",
+                'index': 1
+            }]
+        }
+        project = ProjectFactory.create()
+
+        serializer = serializers.QuestionnaireSerializer(
+            data=data,
+            context={'project': project}
+        )
+        with pytest.raises(ValidationError) as e:
+            serializer.is_valid(raise_exception=True)
+        assert ("Invalid relevant clause: $party_type='IN'" in
+                e.value.detail['questions'][0]['relevant'])
+
 
 class QuestionGroupSerializerTest(UserTestCase, TestCase):
     def test_serialize(self):

--- a/cadasta/questionnaires/tests/test_serializers.py
+++ b/cadasta/questionnaires/tests/test_serializers.py
@@ -11,6 +11,7 @@ from core.tests.utils.cases import FileStorageTestCase, UserTestCase
 
 from . import factories
 from .. import serializers
+from ..messages import INVALID_RELEVANT
 from ..models import Questionnaire, QuestionOption, QuestionGroup
 
 
@@ -1160,6 +1161,30 @@ class QuestionGroupSerializerTest(UserTestCase, TestCase):
                 serializer.save()
         assert questionnaire.question_groups.count() == 0
 
+    def test_invalid_relevant(self):
+        questionnaire = factories.QuestionnaireFactory.create()
+        data = [{
+                    'label': 'A group',
+                    'name': 'party_attributes_individual',
+                    'relevant': '$party="IN"',
+                    'questions': [{
+                        'name': "start",
+                        'label': 'Start',
+                        'type': "TX",
+                        'index': 0
+                    }]
+                }]
+        serializer = serializers.QuestionGroupSerializer(
+            data=data,
+            many=True,
+            context={'questionnaire_id': questionnaire.id,
+                     'project': questionnaire.project,
+                     'default_language': 'en'})
+
+        assert serializer.is_valid() is False
+        assert (INVALID_RELEVANT.format('$party="IN"') in
+                serializer.errors[0]['relevant'])
+
     def test_bulk_create_group(self):
         questionnaire = factories.QuestionnaireFactory.create()
         data = [{
@@ -1387,6 +1412,23 @@ class QuestionSerializerTest(TestCase):
                 assert q.label == 'Another question'
                 assert q.type == 'S1'
                 assert q.options.count() == 1
+
+    def test_invalid_relevant(self):
+        questionnaire = factories.QuestionnaireFactory.create()
+        data = [{
+            'label': 'A question',
+            'name': 'question',
+            'type': 'TX',
+            'relevant': '$party="IN"',
+        }]
+        serializer = serializers.QuestionSerializer(
+            data=data,
+            many=True,
+            context={'questionnaire_id': questionnaire.id})
+
+        assert serializer.is_valid() is False
+        assert (INVALID_RELEVANT.format('$party="IN"') in
+                serializer.errors[0]['relevant'])
 
 
 class QuestionOptionSerializerTest(TestCase):

--- a/cadasta/questionnaires/tests/test_serializers.py
+++ b/cadasta/questionnaires/tests/test_serializers.py
@@ -987,7 +987,7 @@ class QuestionnaireSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         )
         with pytest.raises(ValidationError) as e:
             serializer.is_valid(raise_exception=True)
-        assert ("Invalid relevant clause: $party_type='IN'" in
+        assert ("Invalid relevant clause" in
                 e.value.detail['questions'][0]['relevant'])
 
 

--- a/cadasta/questionnaires/tests/test_validators.py
+++ b/cadasta/questionnaires/tests/test_validators.py
@@ -353,3 +353,522 @@ class QuestionOptionTestCase(TestCase):
         }]
         errors = validators.validate_question_options(data)
         assert errors == [{}, {'label': ['This field is required.']}]
+
+
+class ValidateRelevantTest(TestCase):
+    def test_compare_text(self):
+        assert validators.validate_relevant("${party_type}='IN'") is True
+        assert validators.validate_relevant("${party_type}=\"IN\"") is True
+        assert validators.validate_relevant("${party_type}=“IN”") is True
+        assert validators.validate_relevant("${party_type}=‘IN’") is True
+        assert validators.validate_relevant("${party_type}>'IN'") is True
+        assert validators.validate_relevant("${party_type}>\"IN\"") is True
+        assert validators.validate_relevant("${party_type}>“IN”") is True
+        assert validators.validate_relevant("${party_type}>‘IN’") is True
+        assert validators.validate_relevant("${party_type}>='IN'") is True
+        assert validators.validate_relevant("${party_type}>=\"IN\"") is True
+        assert validators.validate_relevant("${party_type}>=“IN”") is True
+        assert validators.validate_relevant("${party_type}>=‘IN’") is True
+        assert validators.validate_relevant("${party_type}<'IN'") is True
+        assert validators.validate_relevant("${party_type}<\"IN\"") is True
+        assert validators.validate_relevant("${party_type}<“IN”") is True
+        assert validators.validate_relevant("${party_type}<‘IN’") is True
+        assert validators.validate_relevant("${party_type}<='IN'") is True
+        assert validators.validate_relevant("${party_type}<=\"IN\"") is True
+        assert validators.validate_relevant("${party_type}<=“IN”") is True
+        assert validators.validate_relevant("${party_type}<=‘IN’") is True
+        assert validators.validate_relevant("${party_type}!='IN'") is True
+        assert validators.validate_relevant("${party_type}!=\"IN\"") is True
+        assert validators.validate_relevant("${party_type}!=“IN”") is True
+        assert validators.validate_relevant("${party_type}!=‘IN’") is True
+
+    def test_compare_numbers(self):
+        assert validators.validate_relevant("${party_type}=9") is True
+        assert validators.validate_relevant("${party_type}=9") is True
+        assert validators.validate_relevant("${party_type}=9") is True
+        assert validators.validate_relevant("${party_type}=9") is True
+        assert validators.validate_relevant("${party_type}>9") is True
+        assert validators.validate_relevant("${party_type}>9") is True
+        assert validators.validate_relevant("${party_type}>9") is True
+        assert validators.validate_relevant("${party_type}>9") is True
+        assert validators.validate_relevant("${party_type}>=9") is True
+        assert validators.validate_relevant("${party_type}>=9") is True
+        assert validators.validate_relevant("${party_type}>=9") is True
+        assert validators.validate_relevant("${party_type}>=9") is True
+        assert validators.validate_relevant("${party_type}<9") is True
+        assert validators.validate_relevant("${party_type}<9") is True
+        assert validators.validate_relevant("${party_type}<9") is True
+        assert validators.validate_relevant("${party_type}<9") is True
+        assert validators.validate_relevant("${party_type}<=9") is True
+        assert validators.validate_relevant("${party_type}<=9") is True
+        assert validators.validate_relevant("${party_type}<=9") is True
+        assert validators.validate_relevant("${party_type}<=9") is True
+        assert validators.validate_relevant("${party_type}!=9") is True
+        assert validators.validate_relevant("${party_type}!=9") is True
+        assert validators.validate_relevant("${party_type}!=9") is True
+        assert validators.validate_relevant("${party_type}!=9") is True
+
+        assert validators.validate_relevant("${party_type}=482") is True
+        assert validators.validate_relevant("${party_type}=482") is True
+        assert validators.validate_relevant("${party_type}=482") is True
+        assert validators.validate_relevant("${party_type}=482") is True
+        assert validators.validate_relevant("${party_type}>482") is True
+        assert validators.validate_relevant("${party_type}>482") is True
+        assert validators.validate_relevant("${party_type}>482") is True
+        assert validators.validate_relevant("${party_type}>482") is True
+        assert validators.validate_relevant("${party_type}>=482") is True
+        assert validators.validate_relevant("${party_type}>=482") is True
+        assert validators.validate_relevant("${party_type}>=482") is True
+        assert validators.validate_relevant("${party_type}>=482") is True
+        assert validators.validate_relevant("${party_type}<482") is True
+        assert validators.validate_relevant("${party_type}<482") is True
+        assert validators.validate_relevant("${party_type}<482") is True
+        assert validators.validate_relevant("${party_type}<482") is True
+        assert validators.validate_relevant("${party_type}<=482") is True
+        assert validators.validate_relevant("${party_type}<=482") is True
+        assert validators.validate_relevant("${party_type}<=482") is True
+        assert validators.validate_relevant("${party_type}<=482") is True
+        assert validators.validate_relevant("${party_type}!=482") is True
+        assert validators.validate_relevant("${party_type}!=482") is True
+        assert validators.validate_relevant("${party_type}!=482") is True
+        assert validators.validate_relevant("${party_type}!=482") is True
+
+    def test_selected(self):
+        assert validators.validate_relevant(
+            "selected(${assets}, ‘nets’)") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, 'nets')") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, \"nets\")") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, “nets”)") is True
+
+    def test_not_text(self):
+        assert validators.validate_relevant("not(${party_type}='IN')") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=\"IN\")") is True
+        assert validators.validate_relevant("not(${party_type}=“IN”)") is True
+        assert validators.validate_relevant("not(${party_type}=‘IN’)") is True
+        assert validators.validate_relevant("not(${party_type}>'IN')") is True
+        assert validators.validate_relevant(
+            "not(${party_type}>\"IN\")") is True
+        assert validators.validate_relevant("not(${party_type}>“IN”)") is True
+        assert validators.validate_relevant("not(${party_type}>‘IN’)") is True
+        assert validators.validate_relevant("not(${party_type}>='IN')") is True
+        assert validators.validate_relevant(
+            "not(${party_type}>=\"IN\")") is True
+        assert validators.validate_relevant("not(${party_type}>=“IN”)") is True
+        assert validators.validate_relevant("not(${party_type}>=‘IN’)") is True
+        assert validators.validate_relevant("not(${party_type}<'IN')") is True
+        assert validators.validate_relevant(
+            "not(${party_type}<\"IN\")") is True
+        assert validators.validate_relevant("not(${party_type}<“IN”)") is True
+        assert validators.validate_relevant("not(${party_type}<‘IN’)") is True
+        assert validators.validate_relevant("not(${party_type}<='IN')") is True
+        assert validators.validate_relevant(
+            "not(${party_type}<=\"IN\")") is True
+        assert validators.validate_relevant("not(${party_type}<=“IN”)") is True
+        assert validators.validate_relevant("not(${party_type}<=‘IN’)") is True
+        assert validators.validate_relevant("not(${party_type}!='IN')") is True
+        assert validators.validate_relevant(
+            "not(${party_type}!=\"IN\")") is True
+        assert validators.validate_relevant("not(${party_type}!=“IN”)") is True
+        assert validators.validate_relevant("not(${party_type}!=‘IN’)") is True
+
+    def test_not_number(self):
+        assert validators.validate_relevant("not(${party_type}=9)") is True
+        assert validators.validate_relevant("not(${party_type}=9)") is True
+        assert validators.validate_relevant("not(${party_type}=9)") is True
+        assert validators.validate_relevant("not(${party_type}=9)") is True
+        assert validators.validate_relevant("not(${party_type}>9)") is True
+        assert validators.validate_relevant("not(${party_type}>9)") is True
+        assert validators.validate_relevant("not(${party_type}>9)") is True
+        assert validators.validate_relevant("not(${party_type}>9)") is True
+        assert validators.validate_relevant("not(${party_type}>=9)") is True
+        assert validators.validate_relevant("not(${party_type}>=9)") is True
+        assert validators.validate_relevant("not(${party_type}>=9)") is True
+        assert validators.validate_relevant("not(${party_type}>=9)") is True
+        assert validators.validate_relevant("not(${party_type}<9)") is True
+        assert validators.validate_relevant("not(${party_type}<9)") is True
+        assert validators.validate_relevant("not(${party_type}<9)") is True
+        assert validators.validate_relevant("not(${party_type}<9)") is True
+        assert validators.validate_relevant("not(${party_type}<=9)") is True
+        assert validators.validate_relevant("not(${party_type}<=9)") is True
+        assert validators.validate_relevant("not(${party_type}<=9)") is True
+        assert validators.validate_relevant("not(${party_type}<=9)") is True
+        assert validators.validate_relevant("not(${party_type}!=9)") is True
+        assert validators.validate_relevant("not(${party_type}!=9)") is True
+        assert validators.validate_relevant("not(${party_type}!=9)") is True
+        assert validators.validate_relevant("not(${party_type}!=9)") is True
+
+        assert validators.validate_relevant("not(${party_type}=482)") is True
+        assert validators.validate_relevant("not(${party_type}=482)") is True
+        assert validators.validate_relevant("not(${party_type}=482)") is True
+        assert validators.validate_relevant("not(${party_type}=482)") is True
+        assert validators.validate_relevant("not(${party_type}>482)") is True
+        assert validators.validate_relevant("not(${party_type}>482)") is True
+        assert validators.validate_relevant("not(${party_type}>482)") is True
+        assert validators.validate_relevant("not(${party_type}>482)") is True
+        assert validators.validate_relevant("not(${party_type}>=482)") is True
+        assert validators.validate_relevant("not(${party_type}>=482)") is True
+        assert validators.validate_relevant("not(${party_type}>=482)") is True
+        assert validators.validate_relevant("not(${party_type}>=482)") is True
+        assert validators.validate_relevant("not(${party_type}<482)") is True
+        assert validators.validate_relevant("not(${party_type}<482)") is True
+        assert validators.validate_relevant("not(${party_type}<482)") is True
+        assert validators.validate_relevant("not(${party_type}<482)") is True
+        assert validators.validate_relevant("not(${party_type}<=482)") is True
+        assert validators.validate_relevant("not(${party_type}<=482)") is True
+        assert validators.validate_relevant("not(${party_type}<=482)") is True
+        assert validators.validate_relevant("not(${party_type}<=482)") is True
+        assert validators.validate_relevant("not(${party_type}!=482)") is True
+        assert validators.validate_relevant("not(${party_type}!=482)") is True
+        assert validators.validate_relevant("not(${party_type}!=482)") is True
+        assert validators.validate_relevant("not(${party_type}!=482)") is True
+
+    def test_not_selected(self):
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ‘nets’))") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, 'nets'))") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, \"nets\"))") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, “nets”))") is True
+
+    def test_logic(self):
+        assert validators.validate_relevant(
+            "selected(${assets}, ‘nets’) and ${party_type}='IN'") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, 'nets') and ${party_type}=\"IN\"") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, \"nets\") and ${party_type}=“IN”") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, “nets”) and ${party_type}=‘IN’") is True
+        assert validators.validate_relevant(
+            "${party_type}='IN' and selected(${assets}, ‘nets’)") is True
+        assert validators.validate_relevant(
+            "${party_type}=\"IN\" and selected(${assets}, 'nets')") is True
+        assert validators.validate_relevant(
+            "${party_type}=“IN” and selected(${assets}, \"nets\")") is True
+        assert validators.validate_relevant(
+            "${party_type}=‘IN’ and selected(${assets}, “nets”)") is True
+
+        assert validators.validate_relevant(
+            "selected(${assets}, ‘nets’) or ${party_type}='IN'") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, 'nets') or ${party_type}=\"IN\"") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, \"nets\") or ${party_type}=“IN”") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, “nets”) or ${party_type}=‘IN’") is True
+        assert validators.validate_relevant(
+            "${party_type}='IN' or selected(${assets}, ‘nets’)") is True
+        assert validators.validate_relevant(
+            "${party_type}=\"IN\" or selected(${assets}, 'nets')") is True
+        assert validators.validate_relevant(
+            "${party_type}=“IN” or selected(${assets}, \"nets\")") is True
+        assert validators.validate_relevant(
+            "${party_type}=‘IN’ or selected(${assets}, “nets”)") is True
+
+    def test_not_logic(self):
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ‘nets’)) and ${party_type}='IN'") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, 'nets')) "
+            "and ${party_type}=\"IN\"") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, \"nets\")) "
+            "and ${party_type}=“IN”") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, “nets”)) and ${party_type}=‘IN’") is True
+        assert validators.validate_relevant(
+            "not(${party_type}='IN') and selected(${assets}, ‘nets’)") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=\"IN\") and "
+            "selected(${assets}, 'nets')") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=“IN”) and "
+            "selected(${assets}, \"nets\")") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=‘IN’) and selected(${assets}, “nets”)") is True
+
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ‘nets’)) or ${party_type}='IN'") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, 'nets')) or ${party_type}=\"IN\"") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, \"nets\")) or ${party_type}=“IN”") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, “nets”)) or ${party_type}=‘IN’") is True
+        assert validators.validate_relevant(
+            "not(${party_type}='IN') or selected(${assets}, ‘nets’)") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=\"IN\") or selected(${assets}, 'nets')") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=“IN”) or selected(${assets}, \"nets\")") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=‘IN’) or selected(${assets}, “nets”)") is True
+
+        assert validators.validate_relevant(
+            "selected(${assets}, ‘nets’) and not(${party_type}='IN')") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, 'nets') and "
+            "not(${party_type}=\"IN\")") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, \"nets\") and "
+            "not(${party_type}=“IN”)") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, “nets”) and not(${party_type}=‘IN’)") is True
+        assert validators.validate_relevant(
+            "${party_type}='IN' and not(selected(${assets}, ‘nets’))") is True
+        assert validators.validate_relevant(
+            "${party_type}=\"IN\" and "
+            "not(selected(${assets}, 'nets'))") is True
+        assert validators.validate_relevant(
+            "${party_type}=“IN” and "
+            "not(selected(${assets}, \"nets\"))") is True
+        assert validators.validate_relevant(
+            "${party_type}=‘IN’ and not(selected(${assets}, “nets”))") is True
+
+        assert validators.validate_relevant(
+            "selected(${assets}, ‘nets’) or not(${party_type}='IN')") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, 'nets') or not(${party_type}=\"IN\")") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, \"nets\") or not(${party_type}=“IN”)") is True
+        assert validators.validate_relevant(
+            "selected(${assets}, “nets”) or not(${party_type}=‘IN’)") is True
+        assert validators.validate_relevant(
+            "${party_type}='IN' or not(selected(${assets}, ‘nets’))") is True
+        assert validators.validate_relevant(
+            "${party_type}=\"IN\" or not(selected(${assets}, 'nets'))") is True
+        assert validators.validate_relevant(
+            "${party_type}=“IN” or not(selected(${assets}, \"nets\"))") is True
+        assert validators.validate_relevant(
+            "${party_type}=‘IN’ or not(selected(${assets}, “nets”))") is True
+
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ‘nets’)) and "
+            "not(${party_type}='IN')") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, 'nets')) and "
+            "not(${party_type}=\"IN\")") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, \"nets\")) and "
+            "not(${party_type}=“IN”)") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, “nets”)) and "
+            "not(${party_type}=‘IN’)") is True
+        assert validators.validate_relevant(
+            "not(${party_type}='IN') and "
+            "not(selected(${assets}, ‘nets’))") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=\"IN\") and "
+            "not(selected(${assets}, 'nets'))") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=“IN”) and "
+            "not(selected(${assets}, \"nets\"))") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=‘IN’) and "
+            "not(selected(${assets}, “nets”))") is True
+
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ‘nets’)) or "
+            "not(${party_type}='IN')") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, 'nets')) or "
+            "not(${party_type}=\"IN\")") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, \"nets\")) or "
+            "not(${party_type}=“IN”)") is True
+        assert validators.validate_relevant(
+            "not(selected(${assets}, “nets”)) or "
+            "not(${party_type}=‘IN’)") is True
+        assert validators.validate_relevant(
+            "not(${party_type}='IN') or "
+            "not(selected(${assets}, ‘nets’))") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=\"IN\") or "
+            "not(selected(${assets}, 'nets'))") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=“IN”) or "
+            "not(selected(${assets}, \"nets\"))") is True
+        assert validators.validate_relevant(
+            "not(${party_type}=‘IN’) or "
+            "not(selected(${assets}, “nets”))") is True
+
+    def test_invalid_compare_text(self):
+        assert validators.validate_relevant("$party_type=”IN”") is False
+        assert validators.validate_relevant("${party_type}=”IN”") is False
+        assert validators.validate_relevant("${party_type}=’IN‘") is False
+        assert validators.validate_relevant("${party_type}=>'IN'") is False
+        assert validators.validate_relevant("${party_type}=>\"IN\"") is False
+        assert validators.validate_relevant("${party_type}=>”IN”") is False
+        assert validators.validate_relevant("${party_type}=>‘IN’") is False
+        assert validators.validate_relevant("${party_type}=<'IN'") is False
+        assert validators.validate_relevant("${party_type}=<\"IN\"") is False
+        assert validators.validate_relevant("${party_type}=<”IN”") is False
+        assert validators.validate_relevant("${party_type}=<‘IN’") is False
+        assert validators.validate_relevant("${party_type}=!'IN'") is False
+        assert validators.validate_relevant("${party_type}=!\"IN\"") is False
+        assert validators.validate_relevant("${party_type}=!”IN”") is False
+        assert validators.validate_relevant("${party_type}=!‘IN’") is False
+
+    def test_invalid_compare_number(self):
+        assert validators.validate_relevant("${party_type}=>9") is False
+        assert validators.validate_relevant("${party_type}=>9") is False
+        assert validators.validate_relevant("${party_type}=>9") is False
+        assert validators.validate_relevant("${party_type}=>9") is False
+        assert validators.validate_relevant("${party_type}=<9") is False
+        assert validators.validate_relevant("${party_type}=<9") is False
+        assert validators.validate_relevant("${party_type}=<9") is False
+        assert validators.validate_relevant("${party_type}=<9") is False
+        assert validators.validate_relevant("${party_type}=!9") is False
+        assert validators.validate_relevant("${party_type}=!9") is False
+        assert validators.validate_relevant("${party_type}=!9") is False
+        assert validators.validate_relevant("${party_type}=!9") is False
+
+        assert validators.validate_relevant("${party_type}=>482") is False
+        assert validators.validate_relevant("${party_type}=>482") is False
+        assert validators.validate_relevant("${party_type}=>482") is False
+        assert validators.validate_relevant("${party_type}=>482") is False
+        assert validators.validate_relevant("${party_type}=<482") is False
+        assert validators.validate_relevant("${party_type}=<482") is False
+        assert validators.validate_relevant("${party_type}=<482") is False
+        assert validators.validate_relevant("${party_type}=<482") is False
+        assert validators.validate_relevant("${party_type}=!482") is False
+        assert validators.validate_relevant("${party_type}=!482") is False
+        assert validators.validate_relevant("${party_type}=!482") is False
+        assert validators.validate_relevant("${party_type}=!482") is False
+
+    def test_invalid_selected(self):
+        assert validators.validate_relevant(
+            "selected($assets, ’nets‘)") is False
+        assert validators.validate_relevant(
+            "selected(${assets}, ’nets‘)") is False
+        assert validators.validate_relevant(
+            "selected(${assets}, ”nets”)") is False
+        assert validators.validate_relevant(
+            "selected(${assets}, 'nets'") is False
+        assert validators.validate_relevant(
+            "selected${assets}, 'nets')") is False
+        assert validators.validate_relevant(
+            "selected${assets}, 'nets'") is False
+        assert validators.validate_relevant(
+            "selected ${assets}, 'nets')") is False
+        assert validators.validate_relevant(
+            "selected ${assets}, 'nets'") is False
+
+    def test_invalid_not_text(self):
+        assert validators.validate_relevant(
+            "not(${party_type}=”IN”)") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=’IN‘)") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=>'IN')") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=>\"IN\")") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=>”IN”)") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=>‘IN’)") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=<'IN')") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=<\"IN\")") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=<”IN”)") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=<‘IN’)") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=!'IN')") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=!\"IN\")") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=!”IN”)") is False
+        assert validators.validate_relevant(
+            "not(${party_type}=!‘IN’)") is False
+
+    def test_invalid_not_number(self):
+        assert validators.validate_relevant("not(${party_type}=>9)") is False
+        assert validators.validate_relevant("not(${party_type}=>9)") is False
+        assert validators.validate_relevant("not(${party_type}=>9)") is False
+        assert validators.validate_relevant("not(${party_type}=>9)") is False
+        assert validators.validate_relevant("not(${party_type}=<9)") is False
+        assert validators.validate_relevant("not(${party_type}=<9)") is False
+        assert validators.validate_relevant("not(${party_type}=<9)") is False
+        assert validators.validate_relevant("not(${party_type}=<9)") is False
+        assert validators.validate_relevant("not(${party_type}=!9)") is False
+        assert validators.validate_relevant("not(${party_type}=!9)") is False
+        assert validators.validate_relevant("not(${party_type}=!9)") is False
+        assert validators.validate_relevant("not(${party_type}=!9)") is False
+
+        assert validators.validate_relevant("not(${party_type}=>482)") is False
+        assert validators.validate_relevant("not(${party_type}=>482)") is False
+        assert validators.validate_relevant("not(${party_type}=>482)") is False
+        assert validators.validate_relevant("not(${party_type}=>482)") is False
+        assert validators.validate_relevant("not(${party_type}=<482)") is False
+        assert validators.validate_relevant("not(${party_type}=<482)") is False
+        assert validators.validate_relevant("not(${party_type}=<482)") is False
+        assert validators.validate_relevant("not(${party_type}=<482)") is False
+        assert validators.validate_relevant("not(${party_type}=!482)") is False
+        assert validators.validate_relevant("not(${party_type}=!482)") is False
+        assert validators.validate_relevant("not(${party_type}=!482)") is False
+        assert validators.validate_relevant("not(${party_type}=!482)") is False
+
+        assert validators.validate_relevant("not(${party_type}='IN'") is False
+        assert validators.validate_relevant("not(${party_type}='IN' ") is False
+        assert validators.validate_relevant("not${party_type}='IN')") is False
+        assert validators.validate_relevant("not ${party_type}='IN')") is False
+
+    def test_invalid_not_selected(self):
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ’nets‘))") is False
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ”nets”))") is False
+        assert validators.validate_relevant(
+            "notselected(${assets}, 'nets'))") is False
+        assert validators.validate_relevant(
+            "not selected(${assets}, 'nets'))") is False
+        assert validators.validate_relevant(
+            "not(selected(${assets}, 'nets')") is False
+        assert validators.validate_relevant(
+            "notselected(${assets}, 'nets')") is False
+        assert validators.validate_relevant(
+            "not selected(${assets}, 'nets')") is False
+
+    def test_invalid_logic(self):
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ’nets‘))") is False
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ”nets”))") is False
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ‘nets’) and ${party_type}='IN'") is False
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ‘nets’) or ${party_type}='IN'") is False
+        assert validators.validate_relevant(
+            "selected(${assets}, ‘nets’) and not(${party_type}='IN'") is False
+        assert validators.validate_relevant(
+            "selected(${assets}, ‘nets’) or not(${party_type}='IN'") is False
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ‘nets’) and "
+            "not(${party_type}='IN'") is False
+        assert validators.validate_relevant(
+            "not(selected(${assets}, ‘nets’) or "
+            "not(${party_type}='IN'") is False
+
+        assert validators.validate_relevant(
+            "notselected(${assets}, ‘nets’)) and ${party_type}='IN'") is False
+        assert validators.validate_relevant(
+            "notselected(${assets}, ‘nets’)) or ${party_type}='IN'") is False
+        assert validators.validate_relevant(
+            "selected(${assets}, ‘nets’) and not${party_type}='IN')") is False
+        assert validators.validate_relevant(
+            "selected(${assets}, ‘nets’) or not${party_type}='IN')") is False
+        assert validators.validate_relevant(
+            "notselected(${assets}, ‘nets’)) and "
+            "not${party_type}='IN')") is False
+        assert validators.validate_relevant(
+            "notselected(${assets}, ‘nets’)) or "
+            "not${party_type}='IN')") is False

--- a/cadasta/questionnaires/validators.py
+++ b/cadasta/questionnaires/validators.py
@@ -47,6 +47,19 @@ def validate_type(type, value):
         return isinstance(value, list)
 
 
+valid_relevent = (
+    r"^(?P<is_not>not\()?"
+    "((\$\{\w+\}\s?(=|>|<|>=|<=|!=)\s?(('|\"|“|‘)\w+('|\"|”|’)|[0-9]*))|"
+    "(selected\(\$\{\w+\},\s?(('|\"|“|‘)\w+('|\"|”|’)|[0-9]*)\)))"
+    "(?(is_not)\))$"
+)
+
+
+def validate_relevant(relevant):
+    segments = re.split(r"\sand\s|\sor\s", relevant)
+    return all(re.match(valid_relevent, s) for s in segments)
+
+
 QUESTIONNAIRE_SCHEMA = {
     'title': {'type': 'string', 'required': True},
     'id_string': {'type': 'string', 'required': True},
@@ -64,19 +77,29 @@ QUESTION_SCHEMA = {
     'required': {'type': 'boolean'},
     'constraint': {'type': 'string'},
     'index': {'type': 'integer', 'required': True},
-    'gps_accuracy': {'type': 'number',
-                     'function': validate_accuracy,
-                     'errors': {
-                        'function': _("gps_accuracy must be positve float")
-                     },
-                     'relevant': gps_relevant}
+    'gps_accuracy': {
+        'type': 'number',
+        'function': validate_accuracy,
+        'errors': {
+            'function': _("gps_accuracy must be positve float")
+        },
+        'relevant': gps_relevant
+    },
+    'relevant': {
+        'type': 'string',
+        'function': validate_relevant,
+        'errors': {
+            'function': _("Invalid relevant clause")
+        },
+    }
 }
 
 QUESTION_GROUP_SCHEMA = {
     'name': {'type': 'string', 'required': True},
     'label': {'type': 'string'},
     'type': {'type': 'string', 'required': True},
-    'index': {'type': 'integer', 'required': True}
+    'index': {'type': 'integer', 'required': True},
+    'relevant': {'type': 'string', 'function': validate_relevant}
 }
 
 QUESTION_OPTION_SCHEMA = {
@@ -185,16 +208,3 @@ def validate_questionnaire(json):
 
     if errors:
         return errors
-
-
-valid_relevent = (
-    r"^(?P<is_not>not\()?"
-    "((\$\{\w+\}\s?(=|>|<|>=|<=|!=)\s?(('|\"|“|‘)\w+('|\"|”|’)|[0-9]*))|"
-    "(selected\(\$\{\w+\},\s?(('|\"|“|‘)\w+('|\"|”|’)|[0-9]*)\)))"
-    "(?(is_not)\))$"
-)
-
-
-def validate_relevant(relevant):
-    segments = re.split(r"\sand\s|\sor\s", relevant)
-    return all(re.match(valid_relevent, s) for s in segments)

--- a/cadasta/questionnaires/validators.py
+++ b/cadasta/questionnaires/validators.py
@@ -185,3 +185,16 @@ def validate_questionnaire(json):
 
     if errors:
         return errors
+
+
+valid_relevent = (
+    r"^(?P<is_not>not\()?"
+    "((\$\{\w+\}\s?(=|>|<|>=|<=|!=)\s?(('|\"|“|‘)\w+('|\"|”|’)|[0-9]*))|"
+    "(selected\(\$\{\w+\},\s?(('|\"|“|‘)\w+('|\"|”|’)|[0-9]*)\)))"
+    "(?(is_not)\))$"
+)
+
+
+def validate_relevant(relevant):
+    segments = re.split(r"\sand\s|\sor\s", relevant)
+    return all(re.match(valid_relevent, s) for s in segments)

--- a/cadasta/xforms/renderers.py
+++ b/cadasta/xforms/renderers.py
@@ -7,6 +7,7 @@ from rest_framework.compat import six
 from pyxform.builder import create_survey_element_from_dict
 from lxml import etree
 from rest_framework.renderers import BaseRenderer
+
 from questionnaires.managers import fix_languages
 from questionnaires.choices import QUESTION_TYPES
 


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes #1672: Implements a new validator to validate `relevant` values. 

The validator function takes a `relevant` value and splits the string at occurrences of `and` and `or`. Each segment is then matched against a regular expression that expects patterns:

- `${key}=12`, including `>`, `>=`, `<`, `<=`, `!=` comparisons
- `${key}="value"`
- `selected(${key}, "value")`
- and negations of all of the above, i.e. `not ${key}=12`

This will allow us to validate simple combinations; for example `${key}=12 and not selected(${other_key}, "value")` but not more complex patterns (See risks for further discussion.)

#### Other Changes

- Adds `validators.validate_relevant`, which validates `relevant` using the approach above. 
- Hook the validator into `validators.validate_schema`, which is used by Questionnaire serializers to validate questionnaire schemas via the API.
- Hook the validator into `managers.check_relevant_clause`, which is to validate schemas for uploaded XLSForms. 
- Refactored `models.Question.TYPE_CHOICES` into `choices.QUESTION_TYPE` to untangle a circular import of `validators`. 

### When should this PR be merged

If accepted this should go into the next release.

### Risks

The approach taken is very simple. All `relevant` values currently present in the production database can be successfully validated. However, more complex values can not be validated especially when using negations; for example:

- `not(${key}=12) and not(${other_key}="value")` can be validated
- `not(${key}=12) and ${other_key}="value")` is valid, but would currently fail. (So would anything more complex)

The approach taken is the best I could do given the information I had and given the amount of time I had to implement a solution. There is nothing that would prevent users from using complex but valid relevant values in XLSForms that would be rejected by the current implementation. 

### Follow-up actions

- Implement full support for relevant validation, including more complex value. 
- I can see that this solution is not good enough for what we need (see risks). If that's the case, we need to roll back [#dc0d717](https://github.com/Cadasta/cadasta-platform/commit/dc0d71799ca6863842b057b36717733b8aca9377).


### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
