### PR TITLE
Fix #1690: Display the resource contributor's username if they don't have a full name

### DIFF
--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -37,13 +37,7 @@
               aria-haspopup="true" aria-expanded="false">
                 <img src="/static/img/avatar.jpg" class="avatar thumbnail">
                 <span class="visible-xs-inline glyphicon glyphicon-user"></span>
-                <span class="username visible-sm-inline visible-md-inline visible-lg-inline">
-                  {% if user.full_name %}
-                  {{ user.full_name }}
-                  {% else %}
-                  {{ user.username }}
-                  {% endif %}
-                </span>
+                <span class="username visible-sm-inline visible-md-inline visible-lg-inline">{{ user.get_display_name }}</span>
                 {% if is_superuser %}
                   <span class="badge" data-toggle="tooltip" data-trigger="hover" data-placement="left" title="{% trans 'You have superuser permissions' %}">SU</span>
                 {% endif %}

--- a/cadasta/templates/resources/project_detail.html
+++ b/cadasta/templates/resources/project_detail.html
@@ -48,7 +48,7 @@
                   </tr>
                   <tr>
                     <td class="small text-nowrap">{% trans "Uploaded on" %}:</td>
-                    <td class="small">{% blocktrans with date=resource.last_updated user=resource.contributor.full_name|default:resource.contributor.username %}{{ date }} by {{ user }}{% endblocktrans %}</td>
+                    <td class="small">{% blocktrans with date=resource.last_updated user=resource.contributor.get_display_name %}{{ date }} by {{ user }}{% endblocktrans %}</td>
                   </tr>
                 </table>
               </div>

--- a/cadasta/templates/resources/project_detail.html
+++ b/cadasta/templates/resources/project_detail.html
@@ -48,7 +48,7 @@
                   </tr>
                   <tr>
                     <td class="small text-nowrap">{% trans "Uploaded on" %}:</td>
-                    <td class="small">{% blocktrans with date=resource.last_updated user=resource.contributor.full_name %}{{ date }} by {{ user }}{% endblocktrans %}</td>
+                    <td class="small">{% blocktrans with date=resource.last_updated user=resource.contributor.full_name|default:resource.contributor.username %}{{ date }} by {{ user }}{% endblocktrans %}</td>
                   </tr>
                 </table>
               </div>


### PR DESCRIPTION
### Proposed changes in this pull request
Fix #1690:
- Display the resource contributor's username if they don't have a full name. 

### When should this PR be merged
ASAP; this is a bugfix for the next release.

### Risks
None.

### Follow-up actions
None.

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
