### PR TITLE
Revert "Fix #1638: Check for xlsform relevant clause syntax errors (#…

### DIFF
--- a/cadasta/questionnaires/managers.py
+++ b/cadasta/questionnaires/managers.py
@@ -19,12 +19,6 @@ from core.validators import sanitize_string
 ATTRIBUTE_GROUPS = settings.ATTRIBUTE_GROUPS
 
 
-def check_relevant_clause(relevant):
-    if not re.match(r"^\$\{\w+\}=('|\"|”)\w+('|\"|”)$", relevant):
-        raise InvalidQuestionnaire(
-            [_("Invalid relevant clause: {0}".format(relevant))])
-
-
 def create_children(children, errors=[], project=None,
                     default_language='', kwargs={}):
     if children:
@@ -89,9 +83,8 @@ def create_attrs_schema(project=None, dict=None, content_type=None,
     if bind:
         relevant = bind.get('relevant', None)
         if relevant:
-            check_relevant_clause(relevant)
             clauses = relevant.split('=')
-            selector = re.sub("('|\"|”)", '', clauses[1])
+            selector = re.sub("'", '', clauses[1])
             selectors += (selector,)
 
     try:
@@ -274,8 +267,6 @@ class QuestionGroupManager(models.Manager):
         bind = dict.get('bind')
         if bind:
             relevant = bind.get('relevant', None)
-            if relevant:
-                check_relevant_clause(relevant)
 
         instance.name = dict.get('name')
         instance.label_xlat = dict.get('label', {})
@@ -310,8 +301,6 @@ class QuestionManager(models.Manager):
         bind = dict.get('bind')
         if bind:
             relevant = bind.get('relevant', None)
-            if relevant:
-                check_relevant_clause(relevant)
             required = True if bind.get('required', 'no') == 'yes' else False
 
         instance.type = type_dict[dict.get('type')]

--- a/cadasta/questionnaires/tests/test_managers.py
+++ b/cadasta/questionnaires/tests/test_managers.py
@@ -12,20 +12,8 @@ from jsonattrs.models import create_attribute_types
 
 from . import factories
 from .. import models
-from ..managers import (create_children, create_options, santize_form,
-                        check_relevant_clause)
+from ..managers import create_children, create_options, santize_form
 from ..messages import MISSING_RELEVANT
-
-
-class RelevantSyntaxValidationTest(TestCase):
-    def test_relevant_syntax_valid(self):
-        assert check_relevant_clause("${party_type}='IN'") is None
-
-    def test_relevant_syntax_invalid(self):
-        relevant = "${party_type='IN'}"
-        with pytest.raises(InvalidQuestionnaire) as e:
-            check_relevant_clause(relevant)
-        assert str(e.value) == "Invalid relevant clause: ${party_type='IN'}"
 
 
 class SanitizeFormTest(TestCase):
@@ -179,34 +167,6 @@ class CreateChildrenTest(TestCase):
             questionnaire=questionnaire,
             question_group__isnull=False).count() == 2
 
-    def test_invalid_relevant_clause_in_children(self):
-        questionnaire = factories.QuestionnaireFactory.create()
-        children = [{
-            'label': 'This form showcases the different question',
-            'name': 'intro',
-            'type': 'note'
-        }, {
-            'label': 'Text question type',
-            'name': 'text_questions',
-            'type': 'group',
-            'children': [
-                {
-                    'hint': 'Can be short or long but '
-                            'always one line (type = '
-                            'text)',
-                    'label': 'Text',
-                    'name': 'my_string',
-                    'type': 'text',
-                    'bind': {'relevant': '$geo_type="geoshape"'}  # invalid
-                }
-            ],
-        }]
-
-        with pytest.raises(InvalidQuestionnaire) as e:
-            create_children(children, kwargs={'questionnaire': questionnaire})
-
-        assert str(e.value) == 'Invalid relevant clause: $geo_type="geoshape"'
-
 
 class CreateOptionsTest(TestCase):
 
@@ -344,7 +304,7 @@ class QuestionGroupManagerTest(TestCase):
             'label': 'Basic Select question types',
             'name': 'select_questions',
             'type': 'group',
-            'bind': {'relevant': "${party_type}=”IN”"}
+            'bind': {'relevant': "${party_type}='IN'"}
         }
         questionnaire = factories.QuestionnaireFactory.create()
 
@@ -382,21 +342,6 @@ class QuestionGroupManagerTest(TestCase):
         assert model.type == 'repeat'
         assert model.question_groups.count() == 1
         assert questionnaire.question_groups.count() == 2
-
-    def test_invalid_relevant_clause(self):
-        question_group_dict = {
-            'label': 'Basic Select question types',
-            'name': 'select_questions',
-            'type': 'group',
-            'bind': {'relevant': "$party_type='IN'"}  # invalid
-        }
-        questionnaire = factories.QuestionnaireFactory.create()
-        with pytest.raises(InvalidQuestionnaire) as e:
-            models.QuestionGroup.objects.create_from_dict(
-                dict=question_group_dict,
-                questionnaire=questionnaire
-            )
-        assert str(e.value) == "Invalid relevant clause: $party_type='IN'"
 
 
 class QuestionManagerTest(TestCase):
@@ -452,27 +397,6 @@ class QuestionManagerTest(TestCase):
         assert model.label == question_dict['label']
         assert model.name == question_dict['name']
         assert model.type == 'IN'
-
-    def test_invalid_relevant_clause(self):
-        question_dict = {
-            'hint': 'For this field (type=integer)',
-            'label': 'Integer',
-            'name': 'my_int',
-            'type': 'integer',
-            'default': 'default val',
-            'hint': 'An informative hint',
-            'bind': {
-                'relevant': "$party_id='abc123'",  # invalid
-                'required': 'yes'
-            }
-        }
-        questionnaire = factories.QuestionnaireFactory.create()
-        with pytest.raises(InvalidQuestionnaire) as e:
-            models.Question.objects.create_from_dict(
-                dict=question_dict,
-                questionnaire=questionnaire
-            )
-        assert str(e.value) == "Invalid relevant clause: $party_id='abc123'"
 
 
 class MultilingualQuestionnaireTest(UserTestCase, FileStorageTestCase,


### PR DESCRIPTION
### Proposed changes in this pull request

This reverts commit dc0d71799ca6863842b057b36717733b8aca9377 to make sure we can still upload XLSForms with complex `relevant` conditions.

### When should this PR be merged

ASAP, before the next release


### Risks

Low

### Follow-up actions

Implement `relevant` parsing correctly/

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
