### PR TITLE
Add feature to create user avatar thumbnail

### DIFF
--- a/cadasta/accounts/tests/test_models.py
+++ b/cadasta/accounts/tests/test_models.py
@@ -33,3 +33,47 @@ class UserTest(TestCase):
                                  avatar=test_avatar_path,
                                  )
         assert user.avatar_url == user.avatar.url
+
+    def test_avatar_has_changed_property(self):
+        first_avatar_path = '/accounts/tests/files/avatar.png'
+        second_avatar_path = '/resources/tests/files/image.jpg'
+        user1 = UserFactory.build(username='John',
+                                  full_name='John Lennon',
+                                  email='john@beatles.uk',
+                                  avatar=first_avatar_path,
+                                  )
+        assert user1._avatar_has_changed is False
+
+        user2 = UserFactory.build(username='John',
+                                  full_name='John Lennon',
+                                  email='john@beatles.uk',
+                                  avatar=first_avatar_path,
+                                  )
+        user2.avatar.url = second_avatar_path
+        assert user2._avatar_has_changed is True
+
+    def test_avatar_is_custom_property(self):
+        test_avatar_path = '/accounts/tests/files/avatar.png'
+        user1 = UserFactory.build(username='John',
+                                  full_name='John Lennon',
+                                  email='john@beatles.uk',
+                                  avatar=test_avatar_path,
+                                  )
+        assert user1._avatar_is_custom is True
+
+        user2 = UserFactory.build(username='John',
+                                  full_name='John Lennon',
+                                  email='john@beatles.uk',
+                                  avatar=settings.DEFAULT_AVATAR,
+                                  )
+        assert user2._avatar_is_custom is False
+
+    def test_avatar_thumbnail_without_thumbnail_attribute(self):
+        test_avatar_path = '/accounts/tests/files/avatar.png'
+        user = UserFactory.build(username='John',
+                                 full_name='John Lennon',
+                                 email='john@beatles.uk',
+                                 avatar=test_avatar_path,
+                                 )
+        avatar_thumbnail_path = user.avatar_thumbnail
+        assert user._thumbnail == avatar_thumbnail_path

--- a/cadasta/core/static/css/reg.scss
+++ b/cadasta/core/static/css/reg.scss
@@ -128,24 +128,26 @@ body.tinted-bg { // photo for login and register forms
 /* =S3 avatar image-upload work
 -------------------------------------------------------------- */
 #preview-box {
-  width: 200px;
-  height: 200px;
+  width: 150px;
+  height: 150px;
   background-color: white;
   border-radius: 3px;
   overflow: hidden;
   position: relative;
-  text-align: center;
-}
+  text-align: center; }
 
 #avatar-preview {
   width: auto;
-  height: 200px;
+  height: 150px;
   position: absolute;
   top: -9999px;
   bottom: -9999px;
   left: -9999px;
   right: -9999px;
-  margin: auto;
+  margin: auto; }
+
+.s3-buckets .file-input {
+  margin-bottom: 0;
 }
 
 .s3-buckets > ul.errors {

--- a/cadasta/resources/tests/test_utils.py
+++ b/cadasta/resources/tests/test_utils.py
@@ -1,13 +1,16 @@
 import os
+from unittest.mock import patch
 from PIL import Image
 from django.test import TestCase
 from django.conf import settings
 from ..utils import thumbnail
+from accounts.tests.factories import UserFactory
+from core.tests.utils.cases import UserTestCase
 
 path = os.path.dirname(settings.BASE_DIR)
 
 
-class ThumbnailTest(TestCase):
+class ThumbnailTest(TestCase, UserTestCase):
     def test_is_landscape(self):
         assert thumbnail.is_landscape(200, 100) is True
         assert thumbnail.is_landscape(100, 200) is False
@@ -35,3 +38,16 @@ class ThumbnailTest(TestCase):
         thumb = thumbnail.make(image, (100, 100))
         assert thumb.size[0] == 100
         assert thumb.size[1] == 100
+
+    @patch.object(thumbnail, 'make')
+    def test_create_image_thumbnails_without_filefield_or_url(self, mock_make):
+        user = UserFactory.build(username='MotherOfDragons',
+                                 email='dragons@wester.os',
+                                 password='G4me0fThr0ne5',
+                                 )
+        # user instance does not have attribute S3 field named 'picture'
+        thumbnail.create_image_thumbnails(user, 'picture')
+
+        # no avatar image is yet stored, so user.avatar.url = ''
+        thumbnail.create_image_thumbnails(user, 'avatar')
+        assert mock_make.call_count == 0

--- a/cadasta/templates/accounts/profile.html
+++ b/cadasta/templates/accounts/profile.html
@@ -23,9 +23,9 @@
     <label class="control-label" for="{{ form.avatar.id_for_label }}">{% trans "Profile picture" %}</label>
     <div class="well">
       <div id="preview-box" class="center-block">
-        <img src='{{user.avatar_url}}' id="avatar-preview"/>
+        <img src='{{ user.avatar_thumbnail }}' id="avatar-preview"/>
       </div>
-      <p class="help-block small">{% trans "For best results upload a square image, ideally 200x200 pixels." %}</p>
+      <p class="help-block small" id="upload-help">{% trans "For best results upload a square image." %}</p>
       {% render_field form.avatar class+="form-control input-lg" data-parsley-sanitize="1" %}
     </div>
   </div>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR creates a thumbnail out of the `user.avatar` image in order to display the `user.avatar` in the user dashboard (work in progress). Merging this would enable future use of `user.avatar` image across the platform with any desired size. Part of epic User Dashboard #1491. 

- I copied the existing function `resources/models.create_thumbnails` and pasted into `resources/utils/thumbnail.py`
- I changed the name of this copied-and-pasted function into `create_image_thumbnails`
- I set *3 parameters `instance, s3_image_field_name, size=(150, 150)`*. This enables us to use this function freely from any model with a S3 file field while also allowing to set the desired thumbnail size
- Given that `user.avatar` accepts only `image/png, image/jpg` types, this function currently works *only* for image files. This simply means that you call this function ***after*** checking if the file is an image. *(see follow-up action)
- I created a couple of private property functions so that we call `create_image_thumbnails` only when necessary (that is when the `_avatar_has_changed` and the `_avatar_is_custom`)
- In `accounts/profile.html` I changed the `<img src="{{ user.avatar_url }}">` to `<img src="{{ user.avatar_thumbnail }}">` and I made some minor adjustments to the CSS. Here you see the views of `accounts.profile.html` after the changes:
<img src="https://user-images.githubusercontent.com/16849118/28992354-2ccd30de-794e-11e7-8e74-d2fd4da02855.png" height="150"><img src="https://user-images.githubusercontent.com/16849118/28992365-5ed8b3a0-794e-11e7-9e79-024b0929669d.png" height="150">
- I added tests in `resources/tests/test_utils.py` using patch and mocking `thumbnail.make()` in order to cover the cases when:
1. the passed `s3_image_field_name` name does not exist in the given `instance`
2. the `url` attribute of `s3_image_field_name` is empty.
- I added tests in `accounts/tests/test_models.py` to cover all new property functions

### When should this PR be merged

As soon is approved.

### Risks

Low.

### Follow-up actions

- Ideally expand this and combine with the current parallel work in `PR Outreachy PDF Form generation #1409` in order to achieve an easy-to-customize version that enables to use the thumbnail functionality from ***any*** model with a file stored in S3 and that covers even *non-image cases* (e.g. icons).

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
