### PR TITLE
Allow user to login with phone and add Resend Token Page

### DIFF
--- a/cadasta/accounts/exceptions.py
+++ b/cadasta/accounts/exceptions.py
@@ -1,2 +1,10 @@
 class EmailNotVerifiedError(BaseException):
     pass
+
+
+class PhoneNotVerifiedError(BaseException):
+    pass
+
+
+class AccountInactiveError(BaseException):
+    pass

--- a/cadasta/accounts/exceptions.py
+++ b/cadasta/accounts/exceptions.py
@@ -1,10 +1,25 @@
-class EmailNotVerifiedError(BaseException):
-    pass
+from django.utils.translation import ugettext as _
 
 
-class PhoneNotVerifiedError(BaseException):
-    pass
+class EmailNotVerifiedError(Exception):
+
+    def __init__(self, msg=None):
+        if not msg:
+            self.msg = _("The email has not been verified.")
+        super().__init__(msg)
 
 
-class AccountInactiveError(BaseException):
-    pass
+class PhoneNotVerifiedError(Exception):
+
+    def __init__(self, msg=None):
+        if not msg:
+            self.msg = _("The phone has not been verified.")
+        super().__init__(msg)
+
+
+class AccountInactiveError(Exception):
+
+    def __init__(self, msg=None):
+        if not msg:
+            self.msg = _("User account is disabled.")
+        super().__init__(msg)

--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -309,39 +309,7 @@ class ResendTokenForm(forms.Form):
                              error_messages={'invalid': phone_format},
                              required=False)
 
-    def clean_email(self):
-        if self.data.get('verify_email'):
-            email = self.data.get('email')
-            if email:
-                if User.objects.filter(
-                        email=email, email_verified=True).exists():
-                    raise forms.ValidationError(
-                        _("This Email address has already been verified."))
-
-                elif not EmailAddress.objects.filter(
-                        email=email).exists():
-                    raise forms.ValidationError(
-                        _("This Email address is not linked to any account."))
-            else:
-                raise forms.ValidationError(
-                    _("Enter your registered Email address to receive the"
-                        " Verification link."))
-            return email
-
-    def clean_phone(self):
-        if self.data.get('verify_phone'):
-            phone = self.data.get('phone')
-            if phone:
-                if User.objects.filter(
-                        phone=phone, phone_verified=True).exists():
-                    raise forms.ValidationError(
-                        _("This Phone number has already been verified."))
-                elif not VerificationDevice.objects.filter(
-                        unverified_phone=phone).exists():
-                    raise forms.ValidationError(
-                        _("This Phone number is not linked to any account."))
-            else:
-                raise forms.ValidationError(
-                    _("Enter your registered Phone number to receive the"
-                        " Verification token."))
-            return phone
+    def clean(self):
+        if not self.data.get('email') and not self.data.get('phone'):
+            raise forms.ValidationError(
+                _("You cannot leave both phone and email empty."))

--- a/cadasta/accounts/messages.py
+++ b/cadasta/accounts/messages.py
@@ -6,3 +6,12 @@ phone_format = _(
     " Up to 15 digits allowed. Do not include hyphen or"
     " blank spaces in between, at the beginning or at the end."
 )
+
+account_inactive = _(
+    "Your account has been set inactive. We request you to verify"
+    " your registered phone or email in order to access your account.")
+
+
+unverified_identifier = _(
+    "You have not verified your phone or email. We request you to verify"
+    " your registered phone or email in order to access your account.")

--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -12,7 +12,7 @@ from phonenumbers import parse as parse_phone
 from core.serializers import SanitizeFieldSerializer
 from .models import User, VerificationDevice
 from .validators import check_username_case_insensitive, phone_validator
-from .exceptions import EmailNotVerifiedError
+from . import exceptions
 from .messages import phone_format
 
 
@@ -267,8 +267,18 @@ class AccountLoginSerializer(djoser_serializers.LoginSerializer):
     def validate(self, attrs):
         attrs = super(AccountLoginSerializer, self).validate(attrs)
 
-        if not self.user.email_verified:
-            raise EmailNotVerifiedError
+        if ((attrs['username'] == self.user.username) and
+                ((not self.user.email_verified) and
+                    (not self.user.phone_verified))):
+            raise exceptions.AccountInactiveError
+
+        if (attrs['username'] == self.user.email and
+                (not self.user.email_verified)):
+            raise exceptions.EmailNotVerifiedError
+
+        if (attrs['username'] == self.user.phone and
+                (not self.user.phone_verified)):
+            raise exceptions.PhoneNotVerifiedError
 
         return attrs
 

--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -264,26 +264,28 @@ class UserSerializer(SanitizeFieldSerializer,
 
 
 class AccountLoginSerializer(djoser_serializers.LoginSerializer):
+
     def validate(self, attrs):
         attrs = super(AccountLoginSerializer, self).validate(attrs)
 
-        if ((attrs['username'] == self.user.username) and
-                ((not self.user.email_verified) and
-                    (not self.user.phone_verified))):
+        if (attrs['username'] == self.user.username and
+            not self.user.email_verified and
+                not self.user.phone_verified):
             raise exceptions.AccountInactiveError
 
         if (attrs['username'] == self.user.email and
-                (not self.user.email_verified)):
+                not self.user.email_verified):
             raise exceptions.EmailNotVerifiedError
 
         if (attrs['username'] == self.user.phone and
-                (not self.user.phone_verified)):
+                not self.user.phone_verified):
             raise exceptions.PhoneNotVerifiedError
 
         return attrs
 
 
 class ChangePasswordSerializer(djoser_serializers.SetPasswordRetypeSerializer):
+
     def validate(self, attrs):
 
         if not self.context['request'].user.change_pw:

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -23,6 +23,7 @@ from .factories import UserFactory
 
 
 class RegisterFormTest(UserTestCase, TestCase):
+
     def test_valid_data(self):
         data = {
             'username': 'imagine71',
@@ -1155,6 +1156,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
 
 
 class ChangePasswordFormTest(UserTestCase, TestCase):
+
     def test_valid_data(self):
         user = UserFactory.create(password='beatles4Lyfe!')
 
@@ -1271,6 +1273,7 @@ class ChangePasswordFormTest(UserTestCase, TestCase):
 
 
 class ResetPasswordKeyFormTest(UserTestCase, TestCase):
+
     def test_valid_data(self):
         user = UserFactory.create(password='beatles4Lyfe!')
 
@@ -1367,6 +1370,7 @@ class ResetPasswordKeyFormTest(UserTestCase, TestCase):
 
 
 class ResetPasswordFormTest(UserTestCase, TestCase):
+
     def test_email_not_sent_reset(self):
         data = {
             'email': 'john@thebeatles.uk'
@@ -1388,6 +1392,7 @@ class ResetPasswordFormTest(UserTestCase, TestCase):
 
 
 class PhoneVerificationFormTest(UserTestCase, TestCase):
+
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create(username='sherlock',
@@ -1461,81 +1466,34 @@ class PhoneVerificationFormTest(UserTestCase, TestCase):
 
 
 class ResendTokenFormTest(UserTestCase, TestCase):
-    def setUp(self):
-        super().setUp()
-        self.user = UserFactory.create(username='sherlock',
-                                       phone='+919327768250',
-                                       email='sherlock.holmes@bbc.uk',
-                                       password='221B@bakerstreet',
-                                       email_verified=True,
-                                       phone_verified=True)
-        VerificationDevice.objects.create(user=self.user,
-                                          unverified_phone='+12345678990')
-        EmailAddress.objects.create(user=self.user,
-                                    email='john.watson@bbc.uk')
-
-    def test_valid_phone(self):
-        data = {'phone': '+12345678990', 'verify_phone': 'Verify Phone'}
-        form = forms.ResendTokenForm(data)
-        assert form.is_valid() is True
 
     def test_invalid_phone(self):
-        data = {'phone': '12345678990', 'verify_phone': 'Verify Phone'}
+        data = {'phone': '12345678990'}
         form = forms.ResendTokenForm(data)
         assert form.is_valid() is False
         assert phone_format in form.errors.get('phone')
 
-        data = {'phone': 'Test Number', 'verify_phone': 'Verify Phone'}
+        data = {'phone': 'Test Number'}
         form = forms.ResendTokenForm(data)
         assert form.is_valid() is False
         assert phone_format in form.errors.get('phone')
 
-        data = {'phone': '+1 2345678990', 'verify_phone': 'Verify Phone'}
+        data = {'phone': '+1 2345678990'}
         form = forms.ResendTokenForm(data)
         assert form.is_valid() is False
         assert phone_format in form.errors.get('phone')
 
-    def test_phone_already_verified(self):
-        data = {'phone': '+919327768250', 'verify_phone': 'Verify Phone'}
+    def test_submit_empty(self):
+        data = {'email': ''}
         form = forms.ResendTokenForm(data)
         assert form.is_valid() is False
-        assert (_("This Phone number has already been verified.")
-                in form.errors.get('phone'))
+        assert (
+            _("You cannot leave both phone and email empty.")
+            in form.errors.get('__all__'))
 
-    def test_phone_not_linked_to_account(self):
-        data = {'phone': '+12345678991', 'verify_phone': 'Verify Phone'}
+        data = {'phone': ''}
         form = forms.ResendTokenForm(data)
         assert form.is_valid() is False
-        assert (_("This Phone number is not linked to any account.")
-                in form.errors.get('phone'))
-
-    def test_empty_phone_submited(self):
-        data = {'phone': '', 'verify_phone': 'Verify Phone'}
-        form = forms.ResendTokenForm(data)
-        assert form.is_valid() is False
-        assert (_("Enter your registered Phone number to receive the"
-                  " Verification token.") in form.errors.get('phone'))
-
-    def test_email_already_verified(self):
-        data = {
-            'email': 'sherlock.holmes@bbc.uk',
-            'verify_email': 'Verify Email'
-        }
-        form = forms.ResendTokenForm(data)
-        assert form.is_valid() is False
-        assert (_("This Email address has already been verified.")
-                in form.errors.get('email'))
-
-    def test_email_not_linked_to_account(self):
-        data = {'email': 'jim.moriarty@bbc.uk', 'verify_email': 'Verify Email'}
-        form = forms.ResendTokenForm(data)
-        assert form.is_valid() is False
-        assert (_("This Email address is not linked to any account.")
-                in form.errors.get('email'))
-
-    def test_empty_email_submited(self):
-        data = {'email': '', 'verify_email': 'Verify Email'}
-        form = forms.ResendTokenForm(data)
-        assert form.is_valid() is False
-        assert (_("Enter your registered Email address to receive the"
-                  " Verification link.") in form.errors.get('email'))
+        assert (
+            _("You cannot leave both phone and email empty.")
+            in form.errors.get('__all__'))

--- a/cadasta/accounts/tests/test_serializers.py
+++ b/cadasta/accounts/tests/test_serializers.py
@@ -913,8 +913,8 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
 
 class AccountLoginSerializerTest(UserTestCase, TestCase):
     def test_unverified_account(self):
-        """Serializer should raise exceptions.EmailNotVerifiedError exeception when the
-           user has not verified their email address"""
+        """Serializer should raise exceptions.EmailNotVerifiedError exeception
+            when the user has not verified their email address"""
 
         UserFactory.create(username='sgt_pepper',
                            password='iloveyoko79',

--- a/cadasta/accounts/tests/test_urls_default.py
+++ b/cadasta/accounts/tests/test_urls_default.py
@@ -35,3 +35,8 @@ class UserUrlsTest(TestCase):
             'account:verify_phone') == '/account/accountverification/'
         resolved = resolve('/account/accountverification/')
         assert resolved.func.__name__ == default.ConfirmPhone.__name__
+
+    def test_resend_token(self):
+        assert reverse('account:resend_token') == '/account/resendtokenpage/'
+        resolved = resolve('/account/resendtokenpage/')
+        assert resolved.func.__name__ == default.ResendTokenView.__name__

--- a/cadasta/accounts/urls/default.py
+++ b/cadasta/accounts/urls/default.py
@@ -17,4 +17,6 @@ urlpatterns = [
         name="account_reset_password"),
     url(r'^accountverification/$',
         default.ConfirmPhone.as_view(), name='verify_phone'),
+    url(r'^resendtokenpage/$',
+        default.ResendTokenView.as_view(), name='resend_token')
 ]

--- a/cadasta/accounts/validators.py
+++ b/cadasta/accounts/validators.py
@@ -44,11 +44,11 @@ class EmailSimilarityValidator(object):
     def validate(self, password, user=None):
         if not user:
             return None
-
-        email = user.email.split('@')
-        if len(email[0]) and email[0].casefold() in password.casefold():
-            raise ValidationError(
-                _("Passwords cannot contain your email."))
+        if user.email:
+            email = user.email.split('@')
+            if len(email[0]) and email[0].casefold() in password.casefold():
+                raise ValidationError(
+                    _("Passwords cannot contain your email."))
 
 
 def check_username_case_insensitive(username):

--- a/cadasta/accounts/validators.py
+++ b/cadasta/accounts/validators.py
@@ -42,13 +42,13 @@ class CharacterTypePasswordValidator(object):
 
 class EmailSimilarityValidator(object):
     def validate(self, password, user=None):
-        if not user:
+        if not user or not user.email:
             return None
-        if user.email:
-            email = user.email.split('@')
-            if len(email[0]) and email[0].casefold() in password.casefold():
-                raise ValidationError(
-                    _("Passwords cannot contain your email."))
+
+        email = user.email.split('@')
+        if len(email[0]) and email[0].casefold() in password.casefold():
+            raise ValidationError(
+                _("Passwords cannot contain your email."))
 
 
 def check_username_case_insensitive(username):

--- a/cadasta/accounts/views/api.py
+++ b/cadasta/accounts/views/api.py
@@ -113,7 +113,6 @@ class AccountLogin(djoser_views.LoginView):
             send_email_confirmation(self.request._request, user)
 
         except exceptions.PhoneNotVerifiedError as e:
-            user = serializer.user
             error = e.msg
 
         return Response(

--- a/cadasta/templates/accounts/account_verification.html
+++ b/cadasta/templates/accounts/account_verification.html
@@ -21,6 +21,6 @@
       <button type="submit" name="Verify" class="btn btn-primary btn-lg btn-block text-uppercase">{% trans "Verify Token" %}</button>
     </form>
   {% endif %}
-  <p>{% blocktrans %} Click <a href="#">here</a> if you did not receive any email or text.{% endblocktrans %}</p>
+  <p>{% blocktrans %} Click {% endblocktrans %}<a href="{% url 'account:resend_token' %}">{% blocktrans %}here</a> if you did not receive any email or text.{% endblocktrans %}</p>
 </div>
 {% endblock %}

--- a/cadasta/templates/accounts/account_verification.html
+++ b/cadasta/templates/accounts/account_verification.html
@@ -1,26 +1,42 @@
 {% extends "core/base.html" %}
+
 {% load i18n %}
+
 {% load widget_tweaks %}
+
 {% block head_title %} {% trans "Account Verification" %}{% endblock %}
+
 {% block content %}
   <div class="narrow">
-    <h1>{% trans "Account Verification" %}</h1>
+    <h1>
+      {% trans "Account Verification" %}
+    </h1>
     {% if email %}
-      <p>{% blocktrans %}To verify your email address, click on the verification link sent to your registered email address.{% endblocktrans %} </p>
+      <p>{% trans "To verify your email address, click on the verification link sent to your registered email address." %}</p>
     {% endif %}
+
     {% if phone %}
-      <p>{% blocktrans %}To verify your phone number, enter the one-time password sent to your registered phone number.{% endblocktrans%}</p>
-      
+      <p>{% trans "To verify your phone number, enter the one-time password sent to your registered phone number." %}</p>
       <form class="form-narrow" action="{% url 'account:verify_phone' %}" method="post">
         {% csrf_token %}
-        <div class="form-group{% if form.token.errors %} has-error{% endif %}">
-        <label class="input-group input-lg" for="{{ form.token.id_for_label }}">{% trans "Token" %}</label>
-        {% render_field form.token class+="form-control input-lg" data-parsley-required="true" data-parsley-sanitize="1" %}
-        <div class="error-block">{{ form.token.errors }}</div>
-      </div>
-      <button type="submit" name="Verify" class="btn btn-primary btn-lg btn-block text-uppercase">{% trans "Verify Token" %}</button>
-    </form>
-  {% endif %}
-  <p>{% blocktrans %} Click {% endblocktrans %}<a href="{% url 'account:resend_token' %}">{% blocktrans %}here</a> if you did not receive any email or text.{% endblocktrans %}</p>
-</div>
+        <div class="form-group {% if form.token.errors %} has-error {% endif %}">
+          <label class="input-group input-lg" for="{{ form.token.id_for_label }}">
+            {% trans "Token" %}
+          </label>
+          {% render_field form.token class+="form-control input-lg" data-parsley-required="true" data-parsley-sanitize="1" %}
+          <div class="error-block">
+            {{ form.token.errors }}
+          </div>
+        </div>
+        <button type="submit" name="Verify" class="btn btn-primary btn-lg btn-block text-uppercase">
+          {% trans "Verify Token" %}
+        </button>
+      </form>
+    {% endif %}
+  
+    {% url 'account:resend_token' as resend_url %}
+    <p>
+      {% blocktrans %} Click <a href="{{ resend_url }}">here</a> if you did not receive any email or text.{% endblocktrans %}
+    </p>
+  </div>
 {% endblock %}

--- a/cadasta/templates/accounts/profile.html
+++ b/cadasta/templates/accounts/profile.html
@@ -39,14 +39,14 @@
   <div class="form-group{% if form.email.errors %} has-error{% endif %}">
     <label class="control-label" for="{{ form.email.id_for_label }}">{% trans "Email" %}</label>
     {% render_field form.email class+="form-control input-lg" data-parsley-sanitize="1" %}
-    {% if emails_to_verify %}<p class="help-block small">{% trans "The email for this account has been changed recently, but the new email address has not yet been verified. You should have received an email with a link to verify the new email address." %}</p>{% endif %}
+    {% if emails_to_verify %}<p class="help-block small">{% trans "The email for this account has been changed recently, but the new email address has not yet been verified. You should have received an email with a link to verify the new email address.To manually verify the new email address, click" %}<a href="{% url 'account:resend_token' %}">{%trans " here." %}</a></p>{% endif %}
     <div class="error-block">{{ form.email.errors }}</div>
   </div>
 
   <div class="form-group{% if form.phone.errors %} has-error{%endif%}">
   <label class="control-label" for="id_phone">{% trans "Phone" %}</label>
   {% render_field form.phone class+='form-control input-lg'  %}
-    {% if phones_to_verify %}<p class="help-block small">{% trans "The phone for this account has been changed recently, but the new phone number has not yet been verified. To verify the new phone number, click" %}<a href="#">{%trans " here." %}</a></p>{% endif %}
+    {% if phones_to_verify %}<p class="help-block small">{% trans "The phone for this account has been changed recently, but the new phone number has not yet been verified. To verify the new phone number, click" %}<a href="{% url 'account:resend_token' %}">{%trans " here." %}</a></p>{% endif %}
     <div class="error-block">{{ form.phone.errors }}</div>
   </div>
 

--- a/cadasta/templates/accounts/profile.html
+++ b/cadasta/templates/accounts/profile.html
@@ -36,18 +36,23 @@
     <div class="error-block">{{ form.username.errors }}</div>
   </div>
 
+  {% url 'account:resend_token' as resend_url %}
   <div class="form-group{% if form.email.errors %} has-error{% endif %}">
     <label class="control-label" for="{{ form.email.id_for_label }}">{% trans "Email" %}</label>
     {% render_field form.email class+="form-control input-lg" data-parsley-sanitize="1" %}
-    {% if emails_to_verify %}<p class="help-block small">{% trans "The email for this account has been changed recently, but the new email address has not yet been verified. You should have received an email with a link to verify the new email address.To manually verify the new email address, click" %}<a href="{% url 'account:resend_token' %}">{%trans " here." %}</a></p>{% endif %}
-    <div class="error-block">{{ form.email.errors }}</div>
+    {% if emails_to_verify %}
+      <p class="help-block small">{% blocktrans %} The email for this account has been changed recently, but the new email address has not yet been verified. You should have received an email with a link to verify the new email address. To manually verify the new email address, click <a href="{{ resend_url }}">here.</a>{% endblocktrans %}</p>
+    {% endif %}
+  <div class="error-block">{{ form.email.errors }}</div>
   </div>
 
   <div class="form-group{% if form.phone.errors %} has-error{%endif%}">
-  <label class="control-label" for="id_phone">{% trans "Phone" %}</label>
-  {% render_field form.phone class+='form-control input-lg'  %}
-    {% if phones_to_verify %}<p class="help-block small">{% trans "The phone for this account has been changed recently, but the new phone number has not yet been verified. To verify the new phone number, click" %}<a href="{% url 'account:resend_token' %}">{%trans " here." %}</a></p>{% endif %}
-    <div class="error-block">{{ form.phone.errors }}</div>
+    <label class="control-label" for="{{ form.phone.id_for_label }}">{% trans "Phone" %}</label>
+    {% render_field form.phone class+='form-control input-lg'  %}
+      {% if phones_to_verify %}
+        <p class="help-block small">{% blocktrans %} The phone for this account has been changed recently, but the new phone number has not yet been verified. To verify the new phone number, click <a href="{{ resend_url }}"> here.</a>{% endblocktrans %}</p>
+      {% endif %}
+      <div class="error-block">{{ form.phone.errors }}</div>
   </div>
 
   <div class="form-group{% if form.full_name.errors %} has-error{% endif %}">

--- a/cadasta/templates/accounts/resend_token_page.html
+++ b/cadasta/templates/accounts/resend_token_page.html
@@ -1,47 +1,55 @@
 {% extends "core/base.html" %}
+
 {% load i18n %}
+
 {% load widget_tweaks %}
+
 {% block top-nav %}verify{% endblock %}
+
 {% block title %} | {% trans "Verify Account" %}{% endblock %}
+
 {% block content %}
-  {% if form.non_field_errors %}
-    <div id="messages">
-      {% for message in form.non_field_errors %}
-        <div class="alert alert-dismissible alert-danger"
-          role="alert">
-          <button type="button" class="close" data-dismiss="alert"
-          aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-          </button>
-          {{ message|escape }}
-        </div>
-      {% endfor %}
-    </div>
-  {% endif %}
-  
-  <div class="narrow">
-    <h1>{% trans "Verify Account" %}</h1>
-    <form method='POST' action="{% url 'account:resend_token' %}" class="form form-narrow" data-parsley-validate>
-      {% csrf_token %}
-      {{ form.non_field_errors }}
-      <div class="form-group{% if form.email.errors %} has-error{% endif %}">
-      <h4><label class="control-label" for="id_email">{% trans "Enter your registered Email address to receive a verification link." %}</label></h4>
-      {% render_field form.email class+="form-control input-lg" placeholder="Email" %}
-      <div class="error-block">{{ form.email.errors }}</div>
-    </div>
-    <input type="submit" name="verify_email" value="{% trans 'Verify Email' %}"
-    class="btn btn-primary btn-lg btn-block text-uppercase" />
-  </form>
-  <form method='POST' action="{% url 'account:resend_token' %}" class="form form-narrow" data-parsley-validate>
-    {% csrf_token %}
+<div class="narrow">
+    <h1>
+        {% trans "Verify Account" %}
+    </h1>
     {{ form.non_field_errors }}
-    <div class="form-group{% if form.phone.errors %} has-error{% endif %}">
-    <h4><label class="control-label" for="id_phone">{% trans " Enter your registered Phone number to receive a verification code." %}</label></h4>
-    {% render_field form.phone class+="form-control input-lg" placeholder="Phone" %}
-    <div class="error-block">{{ form.phone.errors }}</div>
-  </div><input type="submit" name="verify_phone" value="{% trans 'Verify Phone' %}"
-  class="btn btn-primary btn-lg btn-block text-uppercase" />
-</form>
+    
+    <form method='POST' action="{% url 'account:resend_token' %}" class="form form-narrow" data-parsley-validate>
+        {% csrf_token %}
+        <div class="form-group{% if form.email.errors %} has-error{% endif %}">
+            <h4>
+              <label class="control-label" for="id_email">
+                {% trans "Enter your registered Email address to receive a verification link." %}
+              </label>
+            </h4>
+            {% render_field form.email class+="form-control input-lg" placeholder="Email" %}
+            <div class="error-block">
+                {{ form.email.errors }}
+            </div>
+        </div>
+        <button type="submit" name="verify_email" class="btn btn-primary btn-lg btn-block text-uppercase">
+            {% trans 'Verify Email' %}
+        </button>
+    </form>
+    
+    <form method='POST' action="{% url 'account:resend_token' %}" class="form form-narrow" data-parsley-validate>
+        {% csrf_token %}
+        <div class="form-group{% if form.phone.errors %} has-error{% endif %}">
+            <h4>
+              <label class="control-label" for="id_phone">
+                {% trans " Enter your registered Phone number to receive a verification code." %}
+              </label>
+            </h4>
+            {% render_field form.phone class+="form-control input-lg" placeholder="Phone" %}
+            <div class="error-block">
+                {{ form.phone.errors }}
+            </div>
+        </div>
+        <button type="submit" name="verify_phone" class="btn btn-primary btn-lg btn-block text-uppercase" >
+            {% trans 'Verify Phone' %}
+        </button>
+    </form>
 </div>
 {% endblock %}
 

--- a/cadasta/templates/accounts/resend_token_page.html
+++ b/cadasta/templates/accounts/resend_token_page.html
@@ -1,0 +1,47 @@
+{% extends "core/base.html" %}
+{% load i18n %}
+{% load widget_tweaks %}
+{% block top-nav %}verify{% endblock %}
+{% block title %} | {% trans "Verify Account" %}{% endblock %}
+{% block content %}
+  {% if form.non_field_errors %}
+    <div id="messages">
+      {% for message in form.non_field_errors %}
+        <div class="alert alert-dismissible alert-danger"
+          role="alert">
+          <button type="button" class="close" data-dismiss="alert"
+          aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+          </button>
+          {{ message|escape }}
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+  
+  <div class="narrow">
+    <h1>{% trans "Verify Account" %}</h1>
+    <form method='POST' action="{% url 'account:resend_token' %}" class="form form-narrow" data-parsley-validate>
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+      <div class="form-group{% if form.email.errors %} has-error{% endif %}">
+      <h4><label class="control-label" for="id_email">{% trans "Enter your registered Email address to receive a verification link." %}</label></h4>
+      {% render_field form.email class+="form-control input-lg" placeholder="Email" %}
+      <div class="error-block">{{ form.email.errors }}</div>
+    </div>
+    <input type="submit" name="verify_email" value="{% trans 'Verify Email' %}"
+    class="btn btn-primary btn-lg btn-block text-uppercase" />
+  </form>
+  <form method='POST' action="{% url 'account:resend_token' %}" class="form form-narrow" data-parsley-validate>
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div class="form-group{% if form.phone.errors %} has-error{% endif %}">
+    <h4><label class="control-label" for="id_phone">{% trans " Enter your registered Phone number to receive a verification code." %}</label></h4>
+    {% render_field form.phone class+="form-control input-lg" placeholder="Phone" %}
+    <div class="error-block">{{ form.phone.errors }}</div>
+  </div><input type="submit" name="verify_phone" value="{% trans 'Verify Phone' %}"
+  class="btn btn-primary btn-lg btn-block text-uppercase" />
+</form>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
### Proposed changes in this pull request
This PR enables a user to login with their registered phone. A Resend Token Page has been added to allow user to explicitly get a verification link or a verification code for verifying their phone and email.
If a user tries to login with unverified email/phone, user will be redirected to the Resend Token Page.
If user has both email and phone unverified, user account will be set to inactive and user will be redirected to the Resend Token Page.

1. Define 2 new exceptions `AccountInactiveError` and `PhoneNotVerified` errors, which will be raised when a user tries to obtain an authentication token with and unverified phone or when the user account is inacitve.

2. Add a `ResendTokenForm` to `accounts/forms.py`. User enters phone or email they're trying to verify. If the phone/email has already been verified, or if `EmailAddress`(for email) or `VerificationDevice`(for phone) instance does not exist, validation error will be raised. Else verification link or code will be sent to user's email/phone.

3. Modify `validate()` in `AccountLoginSerializer` to raise Validation Errors. It raises `PhoneNotVerifiedError` when a user tries to get authentication token with an unverified phone. It raises `AccountInactiveError` when a user tries to obtain authentication token with both unverified email and phone, and it sets account to inactive when that error is raised.

4. Added a url `account/resendtokenpage/` to `accounts/urls/default.py` for directing user to Resend Token Page.

5. Modify `AccountLogin` in `accounts/views/api.py`. When `AccountInactiveError`, `PhoneNotVerified` or `EmailNotVerified` errors are caught, it throws `HTTP_401_UNAUTHORIZED` status and sends an error message in the response.

6. Modify `AccountLogin` in `accounts/views/default.py`.  If both email and phone are unverified, It sets a user account to inactive and redirects the user to the Resend Token Page. If login credential is email and email is unverified, or if login credential is a phone and phone is unverified, it redirects the user to Resend Token Page. If a user has at least one identifier(phone, email) verified, a user will be allowed to login with the username and the verified identifier.

7. Add a link in `templates/accounts/account_verification_page.html`  to allow user to go to Resend Token Page if they do not receive a verification link or code.

8. Add a template `resend_token_page.html` to `templates/accounts`. If has 2 forms, one for submitting phone and another for email. Both forms are submitted to the same form class `ResendTokenForm` in `accounts/forms.py`.

9. Add tests for all the changes.
 Main tests:
-Test successful login with username with only email verified.
-Test successful login with username with only phone verified.
-Test successful login with username with both phone and email verified.
-Test successful login with email.
-Test successful login with phone.
-Test unsuccessful login with username with both phone and email unverified.
-Test unsuccessful login with email.
-Test unsuccessful login with phone. 
-Test unsuccessful login with incorrect password. (only for serializers)

### When should this PR be merged
- Once all the changes have been approved and there are no security concerns(if any) remaining.

### Risks
- None

### Follow-up actions
- None

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
