### PR TITLE
Create User Dashboard

### DIFF
--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -79,6 +79,10 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
                     {'error_message':
                      _("You don't have permission to update user details")})]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__original_avatar_url = self.avatar_url
+
     def __repr__(self):
         repr_string = ('<User username={obj.username}'
                        ' full_name={obj.full_name}'
@@ -100,7 +104,9 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
 
     @property
     def avatar_url(self):
-        return self.avatar.url or settings.DEFAULT_AVATAR
+        if not self.avatar or not self.avatar.url:
+            return settings.DEFAULT_AVATAR
+        return self.avatar.url
 
 
 @receiver(models.signals.post_save, sender=User)

--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -57,6 +57,8 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
     last_updated = models.DateTimeField(auto_now=True)
 
     history = HistoricalRecords()
+    _dict_languages = dict(settings.LANGUAGES)
+    _dict_measurements = dict(settings.MEASUREMENTS)
 
     USERNAME_FIELD = 'username'
     REQUIRED_FIELDS = ['email', 'full_name']
@@ -78,10 +80,6 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
                    ('user.update',
                     {'error_message':
                      _("You don't have permission to update user details")})]
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__original_avatar_url = self.avatar_url
 
     def __repr__(self):
         repr_string = ('<User username={obj.username}'
@@ -107,6 +105,15 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
         if not self.avatar or not self.avatar.url:
             return settings.DEFAULT_AVATAR
         return self.avatar.url
+
+    @property
+    def language_verbose(self):
+        language_code = self.language.split('-')[0]
+        return self._dict_languages[language_code]
+
+    @property
+    def measurement_verbose(self):
+        return self._dict_measurements[self.measurement]
 
 
 @receiver(models.signals.post_save, sender=User)

--- a/cadasta/accounts/tests/test_models.py
+++ b/cadasta/accounts/tests/test_models.py
@@ -33,3 +33,17 @@ class UserTest(TestCase):
                                  avatar=test_avatar_path,
                                  )
         assert user.avatar_url == user.avatar.url
+
+    def test_language_verbose_property(self):
+        user = UserFactory.build(username='John',
+                                 email='john@beatles.uk',
+                                 language='en',
+                                 )
+        assert user.language_verbose == 'English'
+
+    def test_measurement_verbose_property(self):
+        user = UserFactory.build(username='John',
+                                 email='john@beatles.uk',
+                                 measurement='metric',
+                                 )
+        assert user.measurement_verbose == 'Metric'

--- a/cadasta/accounts/tests/test_views_default.py
+++ b/cadasta/accounts/tests/test_views_default.py
@@ -229,8 +229,8 @@ class PasswordResetViewTest(ViewTestCase, UserTestCase, TestCase):
         assert len(mail.outbox) == 0
 
 
-class AccountListProjectsTest(ViewTestCase, UserTestCase, TestCase):
-    view_class = default.AccountListProjects
+class UserDashboardTest(ViewTestCase, UserTestCase, TestCase):
+    view_class = default.UserDashboard
     template = 'accounts/user_dashboard.html'
 
     def test_without_organizations(self):

--- a/cadasta/accounts/tests/test_views_default.py
+++ b/cadasta/accounts/tests/test_views_default.py
@@ -272,10 +272,10 @@ class AccountListProjectsTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 200
         assert response.content == self.render_content(
             user_orgs_and_projects=[
-                (org2, is_admin_org2, [
-                    (proj3, 'Administrator'),
-                    (proj4, 'Administrator')]),
                 (org1, is_not_admin_org1, [
                     (proj2, 'Public User'),
                     (proj1, 'Data Collector')]),
+                (org2, is_admin_org2, [
+                    (proj3, 'Administrator'),
+                    (proj4, 'Administrator')]),
                 ])

--- a/cadasta/accounts/tests/test_views_default.py
+++ b/cadasta/accounts/tests/test_views_default.py
@@ -272,10 +272,10 @@ class AccountListProjectsTest(ViewTestCase, UserTestCase, TestCase):
         assert response.status_code == 200
         assert response.content == self.render_content(
             user_orgs_and_projects=[
-                (org1, is_not_admin_org1, [
-                    (proj1, 'Data Collector'),
-                    (proj2, 'Public User')]),
                 (org2, is_admin_org2, [
                     (proj3, 'Administrator'),
                     (proj4, 'Administrator')]),
+                (org1, is_not_admin_org1, [
+                    (proj2, 'Public User'),
+                    (proj1, 'Data Collector')]),
                 ])

--- a/cadasta/accounts/urls/default.py
+++ b/cadasta/accounts/urls/default.py
@@ -14,4 +14,6 @@ urlpatterns = [
         name="account_reset_password_from_key"),
     url(r'^password/reset/$', default.PasswordResetView.as_view(),
         name="account_reset_password"),
+    url(r'^account-projects/$', default.AccountListProjects.as_view(),
+        name='dashboard'),
 ]

--- a/cadasta/accounts/urls/default.py
+++ b/cadasta/accounts/urls/default.py
@@ -14,6 +14,6 @@ urlpatterns = [
         name="account_reset_password_from_key"),
     url(r'^password/reset/$', default.PasswordResetView.as_view(),
         name="account_reset_password"),
-    url(r'^account-projects/$', default.AccountListProjects.as_view(),
+    url(r'^dashboard/$', default.AccountListProjects.as_view(),
         name='dashboard'),
 ]

--- a/cadasta/accounts/urls/default.py
+++ b/cadasta/accounts/urls/default.py
@@ -14,6 +14,6 @@ urlpatterns = [
         name="account_reset_password_from_key"),
     url(r'^password/reset/$', default.PasswordResetView.as_view(),
         name="account_reset_password"),
-    url(r'^dashboard/$', default.AccountListProjects.as_view(),
+    url(r'^dashboard/$', default.UserDashboard.as_view(),
         name='dashboard'),
 ]

--- a/cadasta/accounts/views/default.py
+++ b/cadasta/accounts/views/default.py
@@ -165,8 +165,10 @@ class AccountListProjects(ListView):
             )
 
         # Orgs without Projects
-        qs = user.organizationrole_set.filter(organization__projects=None)
-        qs = qs.exclude(organization__archived=True, admin=False)
-        qs = qs.prefetch_related('organization')
-        for org_role in qs:
+        org_roles = user.organizationrole_set.filter(
+            organization__projects=None,
+            organization__archived=False,
+            admin=True
+        ).prefetch_related('organization')
+        for org_role in org_roles:
             yield (org_role.organization, org_role.admin, [])

--- a/cadasta/accounts/views/default.py
+++ b/cadasta/accounts/views/default.py
@@ -71,6 +71,8 @@ class AccountProfile(LoginRequiredMixin, UpdateView):
 
 
 class AccountLogin(LoginView):
+    success_url = reverse_lazy('account:dashboard')
+
     def form_valid(self, form):
         user = form.user
         if not user.email_verified and timezone.now() > user.verify_email_by:
@@ -94,7 +96,7 @@ class ConfirmEmail(ConfirmEmailView):
         return response
 
 
-class AccountListProjects(ListView):
+class UserDashboard(ListView):
     model = User
     template_name = 'accounts/user_dashboard.html'
 
@@ -126,8 +128,8 @@ class AccountListProjects(ListView):
             organization__organizationrole__admin=True
         )
 
-        # Projects for which user is not an org admin, niether project nor org
-        # are archived, and user not directly associatted with project (i.e.
+        # Projects for which user is not an org admin, neither project nor org
+        # are archived, and user not directly associated with project (i.e.
         # user has no project role)
         public_user_projects = Project.objects.filter(
             organization__organizationrole__user=user,
@@ -167,8 +169,7 @@ class AccountListProjects(ListView):
         # Orgs without Projects
         org_roles = user.organizationrole_set.filter(
             organization__projects=None,
-            organization__archived=False,
-            admin=True
+            organization__archived=False
         ).prefetch_related('organization')
         for org_role in org_roles:
             yield (org_role.organization, org_role.admin, [])

--- a/cadasta/core/static/css/datatables.scss
+++ b/cadasta/core/static/css/datatables.scss
@@ -141,12 +141,14 @@ table.dataTable {
 
 @media (max-width: 420px) {
   #project-single .dataTables_wrapper .col-sm-6,
-  #organization-single .dataTables_wrapper .col-sm-6 {
+  #organization-single .dataTables_wrapper .col-sm-6,
+  #user-single .dataTables_wrapper .col-sm-6 {
     width: 100% !important; // fix for col-xs-6
     float: left !important;
   }
   #project-single div.dataTables_wrapper div.dataTables_filter,
-  #organization-single div.dataTables_wrapper div.dataTables_filter {
+  #organization-single div.dataTables_wrapper div.dataTables_filter,
+  #user-single div.dataTables_wrapper div.dataTables_filter {
     text-align: left !important;
   }
   .dataTables_wrapper {

--- a/cadasta/core/static/css/header.scss
+++ b/cadasta/core/static/css/header.scss
@@ -180,7 +180,8 @@ header {
 #dashboard .header,
 #project-single .header,
 #project-wizard .header,
-#organization-single .header {
+#organization-single .header,
+#user-single .header {
   position: fixed;
 }
 

--- a/cadasta/core/static/css/main.scss
+++ b/cadasta/core/static/css/main.scss
@@ -219,7 +219,8 @@ body.tinted-bg #page-content { // for bg image
 #registration #page-content,
 #project-single #page-content,
 #project-wizard.map #page-content,
-#organization-single #page-content { // for single project and org pages with left subnav
+#organization-single #page-content,
+#user-single #page-content { // for single project, org, and user pages with or without left subnav
   width: 100%;
   max-width: 100%;
   margin: 0 auto;
@@ -244,6 +245,7 @@ body.tinted-bg #page-content { // for bg image
   #project-single #page-content,
   #project-wizard.page #page-content,
   #organization-single #page-content,
+  #user-single #page-content,
   #registration #page-content {
     position: relative;
     top: 0;
@@ -655,6 +657,26 @@ section {
   .panel-topimage { // above header that spans panel
     padding-bottom: 20px;
     border-bottom: 1px solid $table-border-color;
+    #preview-box {
+      margin: 20px auto 10px auto;
+      width: 150px;
+      height: 150px;
+      background-color: white;
+      border-radius: 3px;
+      overflow: hidden;
+      position: relative;
+      text-align: center;
+    }
+    #avatar-preview {
+      width: auto;
+      height: 150px;
+      position: absolute;
+      top: -9999px;
+      bottom: -9999px;
+      left: -9999px;
+      right: -9999px;
+      margin: auto;
+    }
   }
   .panel-heading {
     @include clearfix;

--- a/cadasta/core/static/css/main.scss
+++ b/cadasta/core/static/css/main.scss
@@ -512,7 +512,7 @@ a.tile-box.btn,
   z-index: 2;
   width: 100%;
   .overlay {
-    background: rgba(14, 48, 94, 0.1);
+    background: #f2f4f7;
     min-height: 150px;
     padding: 20px;
     text-align: center;
@@ -548,6 +548,7 @@ a.tile-box.btn,
 
   }
 }
+
 .overlay-wrapper.map {
   padding: 15px;
   position: absolute;
@@ -562,6 +563,44 @@ a.tile-box.btn,
     min-height: 100%;
     padding: 40px 20% 0;
     margin-bottom: 0;
+  }
+}
+
+/*= User Dashboard
+--------------------------------------------------------------*/
+
+#org-wrapper {
+  &.well {
+    background: transparent;
+  }
+  h3 {
+    margin-top: 0;
+    .role {
+      text-transform: none;
+      margin-left: 3px;
+      color: $gray-medium;
+    }
+  }
+  .table-search { // search
+    display: none;
+  }
+  .overlay.smaller {
+    min-height: auto;
+  }
+  .btn-full.smaller {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+#user-single #org-wrapper {
+  .panel-heading {
+    padding: 10px 15px;
+    background-color: $body-bg;
+  }
+  p {
+    font-size: 14px;
+    min-width: auto;
   }
 }
 

--- a/cadasta/core/static/css/reg.scss
+++ b/cadasta/core/static/css/reg.scss
@@ -118,8 +118,8 @@ body.tinted-bg { // photo for login and register forms
 /* =S3 avatar image-upload work
 -------------------------------------------------------------- */
 #preview-box {
-  width: 200px;
-  height: 200px;
+  width: 150px;
+  height: 150px;
   background-color: white;
   border-radius: 3px;
   overflow: hidden;
@@ -129,7 +129,7 @@ body.tinted-bg { // photo for login and register forms
 
 #avatar-preview {
   width: auto;
-  height: 200px;
+  height: 150px;
   position: absolute;
   top: -9999px;
   bottom: -9999px;

--- a/cadasta/core/static/css/single.scss
+++ b/cadasta/core/static/css/single.scss
@@ -803,33 +803,6 @@ dl.contacts { // contact lists
   }
 }
 
-/*= User Dashboard
---------------------------------------------------------------*/
-
-#org-wrapper {
-  &.well {
-    background: transparent;
-  }
-  h3 {
-    margin-top: 0;
-    .role {
-      text-transform: none;
-      margin-left: 3px;
-      color: $gray-medium;
-    }
-  }
-  .table-search { // search
-    display: none;
-  }
-  .overlay.smaller {
-    min-height: auto;
-  }
-  .btn-full.smaller {
-    margin: 0;
-    padding: 0;
-  }
-}
-
 /* =Tooltips
 -------------------------------------------------------------- */
 

--- a/cadasta/core/static/css/single.scss
+++ b/cadasta/core/static/css/single.scss
@@ -81,7 +81,8 @@
 -------------------------------------------------------------- */
 
 #project-single .page-header,
-#organization-single .page-header { // navy band on pages for single project or organization
+#organization-single .page-header,
+#user-single .page-header { // navy band on pages for single project, organization, or user
   display: table;
   background: $brand-darkblue;
   height: 100px;
@@ -143,7 +144,8 @@
 
 @media (max-width: $screen-sm-max) {
   #project-single .page-header,
-  #organization-single .page-header {
+  #organization-single .page-header,
+  #user-single .page-header {
     overflow: visible;
     padding-top: 8px;
     padding-bottom: 8px;
@@ -694,6 +696,9 @@
       background-color: $table-bg-hover;
     }
   }
+  .alert-dismissible.alert-warning {
+    margin-top: 10px;
+  }
 }
 
 .overview #project-map .leaflet-clickable { // forces cursor on non-interactive map
@@ -795,6 +800,33 @@ dl.contacts { // contact lists
       font-size: 13px;
       padding-bottom: 4px;
     }
+  }
+}
+
+/*= User Dashboard
+--------------------------------------------------------------*/
+
+#org-wrapper {
+  &.well {
+    background: transparent;
+  }
+  h3 {
+    margin-top: 0;
+    .role {
+      text-transform: none;
+      margin-left: 3px;
+      color: $gray-medium;
+    }
+  }
+  .table-search { // search
+    display: none;
+  }
+  .overlay.smaller {
+    min-height: auto;
+  }
+  .btn-full.smaller {
+    margin: 0;
+    padding: 0;
   }
 }
 

--- a/cadasta/organization/models.py
+++ b/cadasta/organization/models.py
@@ -330,6 +330,7 @@ class ProjectRole(RandomIDModel):
                             default='PU')
 
     history = HistoricalRecords()
+    _dict_role_choices = dict(ROLE_CHOICES)
 
     # Audit history
     created_date = models.DateTimeField(auto_now_add=True)
@@ -343,6 +344,10 @@ class ProjectRole(RandomIDModel):
                        ' project={obj.project.slug}'
                        ' role={obj.role}>')
         return repr_string.format(obj=self)
+
+    @property
+    def role_verbose(self):
+        return self._dict_role_choices[self.role]
 
 
 def assign_prj_policies(role, delete=False):

--- a/cadasta/organization/tests/test_models.py
+++ b/cadasta/organization/tests/test_models.py
@@ -343,3 +343,7 @@ class ProjectRoleTest(UserTestCase, TestCase):
         self._has('PU', state=True)
         ProjectRole.objects.get(project=self.project, user=self.user).delete()
         self._has('PU', state=False)
+
+    def test_role_verbose(self):
+        role_instance = self._add_role('DC')
+        assert role_instance.role_verbose == 'Data Collector'

--- a/cadasta/templates/accounts/profile.html
+++ b/cadasta/templates/accounts/profile.html
@@ -23,9 +23,9 @@
     <label class="control-label" for="{{ form.avatar.id_for_label }}">{% trans "Profile picture" %}</label>
     <div class="well">
       <div id="preview-box" class="center-block">
-        <img src='{{user.avatar_url}}' id="avatar-preview"/>
+        <img src='{{ user.avatar_url }}' id="avatar-preview"/>
       </div>
-      <p class="help-block small">{% trans "For best results upload a square image, ideally 200x200 pixels." %}</p>
+      <p class="help-block small">{% trans "For best results upload a square image." %}</p>
       {% render_field form.avatar class+="form-control input-lg" data-parsley-sanitize="1" %}
     </div>
   </div>

--- a/cadasta/templates/accounts/user_dashboard.html
+++ b/cadasta/templates/accounts/user_dashboard.html
@@ -1,0 +1,222 @@
+{% extends "core/base.html" %}
+
+{% load i18n %}
+{% load widget_tweaks %}
+{% load staticfiles %}
+
+{% block top-nav %}user-single{% endblock %}
+
+{% block extra_script %}{% endblock %}
+
+{% block title %} | {% block page_title %}{% endblock %}User dashboard{% endblock %}
+
+{% block main-width %}-fluid{% endblock %}
+
+{% block page-header %}
+
+<!-- User dashboard header -->
+<div class="header page-header">
+  <div class="page-title">
+    <h1>{% trans "My dashboard" %}</h1>
+  </div>
+</div>
+<!-- / user dashboard header -->
+
+{% endblock %}
+
+{% block content %}
+
+<div class="col-md-12 content-single">
+  <div class="row">
+    <!-- main body -->
+    {% if not user.email_verified %}
+      <div role="alert" class="alert alert-dismissible alert-warning">
+        <button type="button" class="close" data-dismiss="alert" aria-label='{% trans "Close" %}'>
+          <span aria-hidden="true">×</span>
+        </button>
+        <p>{% blocktrans %}
+          We’ve noticed your account has not been verified.
+          Please verify your account by <b>{{ user.verify_email_by }}</b>
+          or if you haven’t received your verification link, {% endblocktrans %}
+          <a href="{% url 'account_email' %}">{% trans "request a new one" %}</a>.
+        </p>
+      </div>
+    {% endif %}
+    <div class="main-text">
+      <div class="col-md-8">
+        <!-- Panel with list of organizations and projects -->
+        <section>
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3 class="panel-title inline">{% trans "Projects" %}</h3>
+              <a href="{% url 'project:add' %}">
+                <i class="glyphicon glyphicon-plus" data-toggle="tooltip" data-trigger="hover" data-placement="left" title="{% trans 'Add project' %}"></i>
+              </a>
+            </div>
+            <div class="panel-body">
+              {% if user_orgs_and_projects %}
+                {% for org, is_admin, projects in user_orgs_and_projects %}
+
+                  <!-- start organization block -->
+                  {% if is_admin or not org.archived %}
+                  <div id="org-wrapper" class="panel panel-default">
+                    <div class="panel-heading">
+                      <h3 class="panel-title">
+                        <a href="{% url 'organization:dashboard' slug=org.slug %}"
+                       data-toggle="tooltip" data-trigger="hover" title="{% trans 'Go to organization dashboard' %}">
+                        {{ org.name }}
+                        </a>
+                        <span class="role small">{% if is_admin %}{% trans "Administrator" %}{% endif %}</span>
+                        {% if org.archived %}
+                          <span class="label label-danger">{% trans "Archived" %}</span>
+                        {% endif %}
+                      </h3>
+                    </div>
+                    <div class="panel-body">
+                      {% if org.description %}<p>{{ org.description }}</p>{% endif %}
+                      {% if projects %}
+                        <table class="table table-hover datatable" data-paging-type="simple">
+                          <thead>
+                          <tr>
+                            <th class="col-md-5">{% trans "Project" %}</th>
+                            <th class="col-md-3 hidden-xs">{% trans "Role" %}</th>
+                            <th class="col-md-2 hidden-xs">{% trans "Country" %}</th>
+                            <th class="col-md-2">{% trans "Last updated" %}</th>
+                          </tr>
+                          </thead>
+                          <tbody>
+                          {% for proj, proj_role in projects %}
+                            <tr class="linked" onclick="window.document.location='{% url 'organization:project-dashboard' organization=org.slug project=proj.slug %}';">
+                              <td>
+                                <h4>
+                                  <a href="{% url 'organization:project-dashboard' organization=org.slug project=proj.slug %}">{{ proj.name }}</a>
+                                  {% if proj.access == "private" %}
+                                    <span class="label label-info">{% trans "Private" %}</span>
+                                  {% endif %}
+                                  {% if proj.archived %}
+                                    <span class="label label-danger">{% trans "Archived" %}</span>
+                                  {% endif %}
+                                </h4>
+                                {% if proj.description %}<p>{{ proj.description }}</p>{% endif %}
+                              </td>
+                              <td class="hidden-xs">{{ proj_role }}</td>
+                              <td class="hidden-xs">{{ proj.country }}</td>
+                              <td data-sort="{{ proj.last_updated|date:'U' }}">{{ proj.last_updated }}</td>
+                            </tr>
+                          {% endfor %}
+                          </tbody>
+                        </table>
+                      {% elif is_admin %}
+                        <div class="overlay-wrapper">
+                        <div class="overlay smaller">
+                          <div class="btn-full smaller">
+                            <a class="btn btn-primary" href="{% url 'organization:project-add' org.slug %}" role="button">
+                              <i class="glyphicon glyphicon-plus" aria-hidden="true"></i> {% trans "Add first project" %}
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                      {% else %}
+                        <div class="overlay-wrapper">
+                          <div class="overlay smaller">
+                            <p class="text-center">{% trans "Looks like this organization has no projects. As projects are created, they'll appear here." %}</p>
+                            <div class="btn-full smaller">
+                              <a class="btn btn-primary" href="{% url 'organization:dashboard' slug=org.slug %}" role="button">
+                                <i class="glyphicon glyphicon-plus" aria-hidden="true"></i> {% trans "View this organization" %}
+                              </a>
+                            </div>
+                          </div>
+                        </div>
+                      {% endif %}
+                    </div>
+                  </div>
+                  {% endif %}
+                  <!-- / organization block -->
+
+                {% endfor %}
+              {% else %}
+                <!-- invitation to add first organization -->
+                <div class="overlay-wrapper">
+                  <div class="overlay">
+                    <span class="glyphicon glyphicon-ok-circle large"></span>
+                    <p class="text-center">{% trans "Your account is all set. Now add your first organization." %}</p>
+                    <div class="btn-full">
+                      <a class="btn btn-primary" href="{% url 'organization:add' %}" role="button">
+                        <i class="glyphicon glyphicon-plus" aria-hidden="true"></i> {% trans "Add organization" %}
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              {% endif %}
+            </div>
+          </div>
+        </section>
+      </div>
+      <div class="col-md-4">
+        <!-- User about -->
+        <section>
+          <div class="panel panel-default panel-about">
+            <div class="panel-topimage">
+              <div id="preview-box">
+                <img src="{{ user.avatar_url }}" alt="{{ user.name }}" id="avatar-preview">
+              </div>
+            </div>
+            <div class="panel-heading">
+              <h3 class="panel-title inline">
+                {% if user.full_name %}
+                  {{ user.full_name }}
+                {% else %}
+                  {{ user.username }}
+                {% endif %}
+              </h3>
+              <a href="{% url 'account:profile' %}">
+                <i class="glyphicon glyphicon-cog" data-toggle="tooltip" data-trigger="hover" data-placement="left" title="{% trans 'Edit profile' %}"></i>
+              </a>
+            </div>
+            <div class="panel-body">
+              <table class="table table-location">
+                <tbody>
+                  <tr>
+                    <td class="col-md-6"><label>{% trans "Username" %}<label></td>
+                    <td class="col-md-6">{{ user.username }}</td>
+                  </tr>
+                  {% if user.email %}
+                    <tr>
+                      <td><label>{% trans "Email" %}<label></td>
+                      <td>{{ user.email }}</td>
+                    </tr>
+                  {% else %}
+                    <tr>
+                      <td></span><label>{% trans "Phone number" %}<label></td>
+                      <td>{{ user.tel }}</td>
+                    </tr>
+                  {% endif %}
+                  <tr>
+                    <td><label>{% trans "Language" %}<label></td>
+                    <td>{{ user.language }}</td>
+                  </tr>
+                  <tr>
+                    <td><label>{% trans "Measurement" %}<label></td>
+                    <td>{{ user.measurement }}</td>
+                  </tr>
+                  <tr>
+                    <td><label>{% trans "Joined on" %}<label></td>
+                    <td>{{ user.date_joined | date }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+        <!-- / user about -->
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block modals %}{% endblock %}
+
+
+

--- a/cadasta/templates/accounts/user_dashboard.html
+++ b/cadasta/templates/accounts/user_dashboard.html
@@ -193,11 +193,11 @@
                   {% endif %}
                   <tr>
                     <td><label>{% trans "Language" %}<label></td>
-                    <td>{{ user.language }}</td>
+                    <td>{{ user.language_verbose }}</td>
                   </tr>
                   <tr>
                     <td><label>{% trans "Measurement" %}<label></td>
-                    <td>{{ user.measurement }}</td>
+                    <td>{{ user.measurement_verbose }}</td>
                   </tr>
                   <tr>
                     <td><label>{% trans "Joined on" %}<label></td>

--- a/cadasta/templates/accounts/user_dashboard.html
+++ b/cadasta/templates/accounts/user_dashboard.html
@@ -8,7 +8,7 @@
 
 {% block extra_script %}{% endblock %}
 
-{% block title %} | {% block page_title %}{% endblock %}User dashboard{% endblock %}
+{% block title %} | {% block page_title %}{% endblock %}{% trans "User Dashboard" %}{% endblock %}
 
 {% block main-width %}-fluid{% endblock %}
 

--- a/cadasta/templates/accounts/user_dashboard.html
+++ b/cadasta/templates/accounts/user_dashboard.html
@@ -29,21 +29,6 @@
 <div class="col-md-12 content-single">
   <div class="row">
     <!-- main body -->
-    {% if not user.email_verified %}
-      <div role="alert" class="alert alert-dismissible alert-warning">
-        <button type="button" class="close" data-dismiss="alert" aria-label='{% trans "Close" %}'>
-          <span aria-hidden="true">×</span>
-        </button>
-        {% url 'account_email' as email_url %}
-        <p>{% blocktrans %}
-          We’ve noticed your account has not been verified.
-          Please verify your account by <b>{{ user.verify_email_by }}</b>
-          or if you haven’t received your verification link,
-           <a href="{{ email_url }}">request a new one</a>.
-          {% endblocktrans %}
-        </p>
-      </div>
-    {% endif %}
     <div class="main-text">
       <div class="col-md-8">
         <!-- Panel with list of organizations and projects -->
@@ -77,9 +62,9 @@
                         <table class="table table-hover datatable" data-paging-type="simple">
                           <thead>
                           <tr>
-                            <th class="col-md-5">{% trans "Project" %}</th>
-                            <th class="col-md-3 hidden-xs">{% trans "Role" %}</th>
-                            <th class="col-md-2 hidden-xs">{% trans "Country" %}</th>
+                            <th class="col-md-7">{% trans "Project" %}</th>
+                            <th class="col-md-2 hidden-xs">{% trans "Role" %}</th>
+                            <th class="col-md-1 hidden-xs">{% trans "Country" %}</th>
                             <th class="col-md-2">{% trans "Last updated" %}</th>
                           </tr>
                           </thead>
@@ -161,6 +146,13 @@
               </a>
             </div>
             <div class="panel-body">
+              {% if not user.email_verified %}
+                <!-- Unverified account message -->
+                <div class="alert alert-info alert-full" role="alert">
+                  {% url 'account_email' as email_url %}
+                  {% blocktrans %}We’ve noticed your account has not been verified. If you haven’t received your verification link, please <a href="{{ email_url }}">request a new one</a>.{% endblocktrans %}
+                </div>
+              {% endif %}
               <table class="table table-location">
                 <tbody>
                   <tr>

--- a/cadasta/templates/accounts/user_dashboard.html
+++ b/cadasta/templates/accounts/user_dashboard.html
@@ -34,11 +34,13 @@
         <button type="button" class="close" data-dismiss="alert" aria-label='{% trans "Close" %}'>
           <span aria-hidden="true">×</span>
         </button>
+        {% url 'account_email' as email_url %}
         <p>{% blocktrans %}
           We’ve noticed your account has not been verified.
           Please verify your account by <b>{{ user.verify_email_by }}</b>
-          or if you haven’t received your verification link, {% endblocktrans %}
-          <a href="{% url 'account_email' %}">{% trans "request a new one" %}</a>.
+          or if you haven’t received your verification link,
+           <a href="{{ email_url }}">request a new one</a>.
+          {% endblocktrans %}
         </p>
       </div>
     {% endif %}
@@ -48,10 +50,7 @@
         <section>
           <div class="panel panel-default">
             <div class="panel-heading">
-              <h3 class="panel-title inline">{% trans "Projects" %}</h3>
-              <a href="{% url 'project:add' %}">
-                <i class="glyphicon glyphicon-plus" data-toggle="tooltip" data-trigger="hover" data-placement="left" title="{% trans 'Add project' %}"></i>
-              </a>
+              <h3 class="panel-title">{% trans "Projects" %}</h3>
             </div>
             <div class="panel-body">
               {% if user_orgs_and_projects %}
@@ -107,26 +106,14 @@
                           </tbody>
                         </table>
                       {% elif is_admin %}
-                        <div class="overlay-wrapper">
-                        <div class="overlay smaller">
-                          <div class="btn-full smaller">
-                            <a class="btn btn-primary" href="{% url 'organization:project-add' org.slug %}" role="button">
-                              <i class="glyphicon glyphicon-plus" aria-hidden="true"></i> {% trans "Add first project" %}
-                            </a>
-                          </div>
+                        <p class="text-center">{% trans "This organization is all set. Now add your first project." %}</p>
+                        <div class="btn-full smaller">
+                          <a class="btn btn-primary" href="{% url 'organization:project-add' org.slug %}" role="button">
+                            <i class="glyphicon glyphicon-plus" aria-hidden="true"></i> {% trans "Add a project" %}
+                          </a>
                         </div>
-                      </div>
                       {% else %}
-                        <div class="overlay-wrapper">
-                          <div class="overlay smaller">
-                            <p class="text-center">{% trans "Looks like this organization has no projects. As projects are created, they'll appear here." %}</p>
-                            <div class="btn-full smaller">
-                              <a class="btn btn-primary" href="{% url 'organization:dashboard' slug=org.slug %}" role="button">
-                                <i class="glyphicon glyphicon-plus" aria-hidden="true"></i> {% trans "View this organization" %}
-                              </a>
-                            </div>
-                          </div>
-                        </div>
+                        <p>{% trans "Looks like this organization has no projects. As projects are created, they'll appear here." %}</p>
                       {% endif %}
                     </div>
                   </div>

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -46,6 +46,9 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
+                  <a href="{% url 'account:dashboard' %}">{% trans "My dashboard" %}</a>
+                </li>
+                <li>
                   <a href="{% url 'account:profile' %}">{% trans "Edit profile" %}</a>
                 </li>
                 <li role="separator" class="divider"></li>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR creates a User Dashboard (UD) as defined in the Epic issue User Dashboard #1491. Specifically it addresses these open issues: [#1492](https://github.com/Cadasta/cadasta-platform/issues/1492), [ #1483](https://github.com/Cadasta/cadasta-platform/issues/1483), [#1482](https://github.com/Cadasta/cadasta-platform/issues/1482), [#1485](https://github.com/Cadasta/cadasta-platform/issues/1485), [#610](https://github.com/Cadasta/cadasta-platform/issues/610).

**Added user functionalities:** 
- A user can access their UD page by clicking on "My Dashboard" in the top-left navigation bar drop-down menu:
<img src="https://user-images.githubusercontent.com/16849118/29342081-871e58c8-81dd-11e7-8790-2f41f578a6d8.png" height="100">

- In the UD, a user can see the list of organizations (if any) and respective projects (if any) that the user is part of
- The user can see their roles for each organizations and/or projects in the above list
- The user is invited to add an organization if there aren't any yet
- If the user is admin of a listed organization, the user is invited to add a project in case there aren't projects yet
- If the user is not admin of a listed organization with zero projects, a message appears to notify the user that projects will appear once created and a link invites the user to visit the organization dashboard
- The user sees an alert message in case their e-mail is not verified (as for a conversation with Parthvi, there is no reference to the `user.verify_email_by` field)
- The user can remove the alert and/or click to request a new verification e-mail (user goes to the existing `{% url 'account_email' %}`)
- The user can view their avatar and profile information
- The user can click on a link to edit their profile information (user goes to `accounts/profile.html`)

**Added changes to implement the above functionalities:**
1. Added a url path in `accounts/urls/default.py` which brings to the `AccountListProjects(ListView)` class where we refer to a new template `accounts/user_dashboard.html`
2. In `AccountListProjects(ListView)` I queried the db in order to access:
    - `user.organizations` and projects associated with each of those organizations;
    - `OrganizationRole.admin` and `ProjectRole.role` for each organization and project.

Because of the nature of the information and the goal, in order to access data accordingly I **structured the data as follows**:
```
context['user_orgs_and_projects'] = [
        (org1, org1_role, [(proj1, proj1_role), (proj2, proj2_role)]),
        (org2, org2_role, [(proj3, proj3_role), (proj4, proj4_role)]),
        (org3, org3_role, []),
]
```
3. In `accounts/user_dashboard.html` I displayed a box titled **PROJECTS** with all the organizations and projects of the user. To do so, I simply made **2 iterations**:
```
{% for org, org_role, projects in user_orgs_and_projects %}
    # display org information
    {% for proj, proj_role in projects %}
        # display proj information in DataTable
```
4. In `accounts/user_dashboard.html` I displayed the `user.avatar` by applying the existing CSS used in the template `accounts/profile.html`. In this way we mitigate the lack of an existing `thumbnail` approach.
5. In order to display the `verbose` value of `ProjectRole.role` on the template, in `organization.models.ProjectRole`I added;
    - **_a private field_** `_dict_role_choices = dict(ROLE_CHOICES)` shared by all instances (in this way the dictionary is created only once);
    - _**a simple `@property` function**_ that returns the verbose value given the `ProjectRole.role` key.
6. Added all required tests in `organization/tests/test_models.py` and `accounts/tests/test_views_default.py`.
7. @clash99 changed the CSS so that `accounts/user_dashboard.html` has the same base rules of  both project and organization dashboards as defined in `core/static/css/single.scss`

### Sample screenshot of Mario Rossi user dashboard
<img src="https://user-images.githubusercontent.com/16849118/29342111-c7c9e7a2-81dd-11e7-92fb-016d933572e4.png" height="300">


### When should this PR be merged
- As soon as it is reviewed and approved.
- I'd advice 3 approvals given the size of the PR.

### Risks
- Low risk
- Browsers compatibility (?)

### Follow-up actions
- Add the remaining list of features in the Epic issue UD #1491.
- Integrate the thumbnail functionality once its approach is changed and approved.
- Close the following issues: [#1492](https://github.com/Cadasta/cadasta-platform/issues/1492), [ #1483](https://github.com/Cadasta/cadasta-platform/issues/1483), [#1482](https://github.com/Cadasta/cadasta-platform/issues/1482), [#1485](https://github.com/Cadasta/cadasta-platform/issues/1485), [#610](https://github.com/Cadasta/cadasta-platform/issues/610).

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
