### PR TITLE
Integrate the cadasta-test functional test suite into the platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,36 +13,40 @@ addons:
 before_install:
   - export DEBIAN_FRONTEND=noninteractive
   - sudo -E apt-get -yq update &>> ~/apt-get-update.log
-  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install squid3
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install squid3; fi
   - sudo apt-get -yq install libgdal-dev
   - gdal-config --version
-  - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
   - export C_INCLUDE_PATH=/usr/include/gdal
   - export CPLUS_INCLUDE_PATH=/usr/include/gdal
+  - if [[ $TOX_ENV == 'py35-functional' ]]; then sudo apt-get -yq install xvfb chromium-browser chromium-chromedriver; fi
+  - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
+  - if [[ $TOX_ENV == 'py35-functional' ]]; then export PATH=/usr/lib/chromium-browser:$PATH; fi
 
 install:
   - pip install tox==2.3.1
 
 before_script:
-  - sudo cp provision/roles/testing/files/squid.conf /etc/squid3/squid.conf
-  - sudo service squid3 restart
-  - export http_proxy=http://localhost:3128/
-  - export https_proxy=https://localhost:3128/
   - export DJANGO_SETTINGS_MODULE=config.settings.travis
-  - psql template1 postgres -c 'create extension hstore;'
-  - psql -c 'create database cadasta;' -U postgres
-  - psql -U postgres -d cadasta -c "create extension postgis;"
-  - mkdir cadasta/geography/data
-  - export WBDATA=ne_10m_admin_0_countries.zip
-  - export DATADIR=cadasta/geography/data
-  - wget -O $DATADIR/$WBDATA https://cadasta-miscellaneous.s3.amazonaws.com/$WBDATA
-  - unzip $DATADIR/$WBDATA -d $DATADIR
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then sudo cp provision/roles/testing/files/squid.conf /etc/squid3/squid.conf; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then sudo service squid3 restart; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then export http_proxy=http://localhost:3128/; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then export https_proxy=https://localhost:3128/; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then psql template1 postgres -c 'create extension hstore;'; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then psql -c 'create database cadasta;' -U postgres; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then psql -U postgres -d cadasta -c "create extension postgis;"; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then mkdir cadasta/geography/data; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then export WBDATA=ne_10m_admin_0_countries.zip; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then export DATADIR=cadasta/geography/data; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then wget -O $DATADIR/$WBDATA https://cadasta-miscellaneous.s3.amazonaws.com/$WBDATA; fi
+  - if [[ $TOX_ENV != 'py35-flake8' ]]; then unzip $DATADIR/$WBDATA -d $DATADIR; fi
+  - if [[ $TOX_ENV == 'py35-functional' ]]; then echo '<span class="site-name">Travis</span>' > cadasta/templates/core/identifier.html; fi
 
 env:
   matrix:
     - TOX_ENV=py35-flake8
-    - TOX_ENV=py35-django1.9-migration
-    - TOX_ENV=py35-django1.9-unit
+    - TOX_ENV=py35-django-migration
+    - TOX_ENV=py35-django-unit
+    - TOX_ENV=py35-functional
 
 matrix:
   fast_finish: true

--- a/cadasta/config/settings/travis.py
+++ b/cadasta/config/settings/travis.py
@@ -39,3 +39,26 @@ CACHES = {
         'LOCATION': 'jsonattrs'
     }
 }
+
+# Debug logging (match the behavior of dev settings)
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.NullHandler',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'xform.submissions': {
+            'handlers': ['file'],
+            'level': 'DEBUG'
+        }
+    },
+}

--- a/provision/roles/testing/tasks/main.yml
+++ b/provision/roles/testing/tasks/main.yml
@@ -5,6 +5,14 @@
   with_items:
       - xvfb
       - squid3
+      - chromium-browser
+      - chromium-chromedriver
+
+- name: Add path to ChromeDriver
+  become: yes
+  become_user: "{{ app_user }}"
+  lineinfile: dest=/home/vagrant/.bashrc
+              line="export PATH=/usr/lib/chromium-browser:$PATH"
 
 - name: Download Firefox 46 install bundle
   become: yes

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,3 +10,4 @@ django-debug-toolbar==1.8
 django-extensions==1.8.1
 django-skivvy==0.1.8
 ipython==6.1.0
+git+https://github.com/Cadasta/cadasta-test.git@master

--- a/run-functests-travis
+++ b/run-functests-travis
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+cd cadasta/core
+npm install bootstrap-sass
+cd ..
+./manage.py migrate
+./manage.py loadstatic
+./manage.py runserver 0.0.0.0:8000 &
+cd ..
+sleep 5  # Wait for the server to start up
+./runtests.py --functional
+ret=$?
+killall python  # Kill the server
+exit $ret

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
        py35-flake8,
-       py35-django1.9-migration,
-       py35-django1.9-unit
+       py35-django-migration,
+       py35-django-unit,
+       py35-functional
 
 [testenv]
 passenv = DJANGO_SETTINGS_MODULE
@@ -13,14 +14,17 @@ setenv =
 deps = -r{toxinidir}/requirements/dev.txt
 install_command = pip install --find-links https://s3.amazonaws.com:443/cadasta-wheelhouse/index.html {opts} {packages}
 
-[testenv:py35-django1.9-unit]
-commands = ./runtests.py
-
-[testenv:py35-django1.9-migration]
-commands = python ./cadasta/manage.py makemigrations --check
-
 [testenv:py35-flake8]
 commands = ./runtests.py --lint
 deps =
        pytest==3.2.0
        flake8==3.4.1
+
+[testenv:py35-django-migration]
+commands = python ./cadasta/manage.py makemigrations --check
+
+[testenv:py35-django-unit]
+commands = ./runtests.py
+
+[testenv:py35-functional]
+commands = ./run-functests-travis


### PR DESCRIPTION
### Proposed changes in this pull request
This PR integrates the **cadasta-test** repository functional test suite into the platform and allows automatic running of functional tests as part of the **cadasta-platform** Travis check.

The integrated functional test suite is currently designed to run in 2 environments:
- The test suite can be run against the platform as served from the Django server in the dev VM.
- The test suite can be run against an ad hoc Django server that is run as part of the Travis CI build.

#### Dev VM
Changes:
- Add the **master** branch of the **cadasta-test** repository to **requirements/dev.txt**.
- Update an Ansible provisioning script to install the Chromium and the ChromeDriver for Selenium packages, and to include Chromium into the `PATH` environment variable.
- Update the **runtests.py** script to run the test suite when the `--functional` argument is provided. Any additional options are passed on to pytest. If no additional options were provided by the user, pytest is called with `--pyargs cadasta.test` which means that it will try to run all discoverable tests inside the **cadasta-test** repository, and with `-v` for verbose mode.
    - Before executing the **runtests.py** script, the dev VM server must already be running in the background.
    - The **runtests.py** script is currently not yet updated to allow running of tests on arbitrary platform servers. This means that the test suite will only run against http://localhost:8000.

#### Travis CI
The Travis build lifecycle already does most of the needed provisioning in order to run the test suite. So some files are updated to complete the process:
- Update **.travis.yml** to install Xvfb, Chromium, and ChromeDriver packages, to include Chromium into the `PATH` environment variable, and to create the **cadasta/templates/core/identifier.html** file.
- Update **.travis.yml** to include running the test suite as another job in the build matrix.
- Update **tox.ini** to include running the test suite as another job in test environment by calling a new shell script: **run-functests-travis**.
- Update **cadasta/config/settings/travis.py** to match the logging settings of the dev VM.

To run the test suite in Travis, a new shell script called **run-functests-travis** is provided:
- This script installs bootstrap-sass, runs all migrations, loads the static objects into the database, and finally starts the Django server.
- Thereafter, the script executes the **runtests.py** Python script with the following options: `--functional`
- After the functional tests have run, the Django server is killed.

#### Other changes
Update **.travis,yml** to only execute some commands depending on which job is run. For example, most commands are not needed for the lint check.

### When should this PR be merged
This PR requires that [PR #37 on the **cadasta-test** repo](https://github.com/Cadasta/cadasta-test/pull/37) is merged first.

### Risks
No risks foreseen. This PR should only affect QA and not the actual platform function.

### Follow-up actions
None for now (aside from coding/improving the actual functional tests).

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
