### PR TITLE
Address #1264:: Add preview in resource edit page

### DIFF
--- a/cadasta/templates/resources/edit.html
+++ b/cadasta/templates/resources/edit.html
@@ -29,6 +29,27 @@
               <span class="label label-danger">{% trans "Deleted" %}</span>
               {% endif %}
             </h2>
+            <div class="row">
+              <div class="media col-md-6">
+                <div class="media-left">
+                  <img src="{{ resource.thumbnail }}" class="thumb-128">
+                </div>
+                <div class="media-body">
+                <p class="media-heading">{{ resource.description }}</p>
+                <table class="table table-condensed table-media">
+                  <tr>
+                    <td class="small text-nowrap">{% trans "File name" %}:</td>
+                    <td class="small name-break">{{ resource.original_file }}</td>
+                  </tr>
+                  <tr>
+                    <td class="small text-nowrap">{% trans "Uploaded on" %}:</td>
+                    <td class="small">{% blocktrans with date=resource.last_updated user=resource.contributor.get_display_name %}{{ date }} by {{ user }}{% endblocktrans %}</td>
+                  </tr>
+                </table>
+              </div>
+              </div>
+            </div>
+            <hr>
             {% include "resources/form.html" %}
           </div>
           <div class="panel-footer panel-buttons">

--- a/cadasta/templates/resources/project_detail.html
+++ b/cadasta/templates/resources/project_detail.html
@@ -100,7 +100,6 @@
     </div>
   </div>
 </div>
-
 {% endblock %}
 
 {% block form_modal %}


### PR DESCRIPTION
### Proposed changes in this pull request

This is a very simple PR that adds only some HTML into an existing template. The PR applies the existing thumbnail preview to the `resources/edit.html` template as requested by the open issue #1264.

The preview is copied-and-pasted by the one applied in the `resources/project_detail.html` template, so for now it always displays the _preview of the current stored resource_.

A small video demo on the work-flow of this feature is available [here](https://drive.google.com/file/d/0BzK57GHhuoRPRzdTTUlPcXBkSE0/view).

### When should this PR be merged
As soon as it has been approved.

### Risks
Very low.

### Follow-up actions
- Close issue **Add thumbnail preview to edit resources page** #1264 .
- Investigate on how to improve UX in case the user upload a new file

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
