### PR TITLE
Fixes #1630:: translate success form message with new selected language

### DIFF
--- a/cadasta/accounts/middleware.py
+++ b/cadasta/accounts/middleware.py
@@ -14,3 +14,17 @@ class UserLanguageMiddleware(object):
         translation.activate(user_language)
         request.session[translation.LANGUAGE_SESSION_KEY] = user_language
         return None
+
+    def process_response(self, request, response):
+        if not request.user.is_authenticated:
+            return response
+
+        user_language = request.user.language
+        current_language = translation.get_language()
+        if user_language == current_language:
+            return response
+
+        translation.activate(user_language)
+        request.session[translation.LANGUAGE_SESSION_KEY] = user_language
+
+        return response

--- a/cadasta/accounts/middleware.py
+++ b/cadasta/accounts/middleware.py
@@ -2,18 +2,6 @@ from django.utils import translation
 
 
 class UserLanguageMiddleware(object):
-    def process_request(self, request):
-        if not request.user.is_authenticated:
-            return None
-
-        user_language = request.user.language
-        current_language = translation.get_language()
-        if user_language == current_language:
-            return None
-
-        translation.activate(user_language)
-        request.session[translation.LANGUAGE_SESSION_KEY] = user_language
-        return None
 
     def process_response(self, request, response):
         if not request.user.is_authenticated:

--- a/cadasta/accounts/tests/test_middleware.py
+++ b/cadasta/accounts/tests/test_middleware.py
@@ -7,6 +7,7 @@ class UserLanguageMiddlewareTest(TestCase):
 
     def setUp(self):
         self.mock_request = Mock()
+        self.mock_response = Mock()
         self.LANGUAGE_SESSION_KEY = ''
         self.mock_request.session = {self.LANGUAGE_SESSION_KEY: ''}
         self.ulm = middleware.UserLanguageMiddleware()
@@ -39,3 +40,32 @@ class UserLanguageMiddlewareTest(TestCase):
         assert 1 == mock_translation.activate.call_count
         assert 'fr' == session_lang[self.LANGUAGE_SESSION_KEY]
         assert response is None
+
+    @patch.object(middleware, 'translation')
+    def test_process_response_user_not_authenticated(self, mock_translation):
+        self.mock_request.user.is_authenticated = False
+        res = self.ulm.process_response(self.mock_request, self.mock_response)
+        assert 0 == mock_translation.activate.call_count
+        assert res is self.mock_response
+
+    @patch.object(middleware, 'translation')
+    def test_process_response_with_same_language(self, mock_translation):
+        self.mock_request.user.is_authenticated = True
+        self.mock_request.user.language = 'en'
+        mock_translation.get_language.return_value = 'en'
+        res = self.ulm.process_response(self.mock_request, self.mock_response)
+        assert 0 == mock_translation.activate.call_count
+        assert res is self.mock_response
+
+    @patch.object(middleware, 'translation')
+    def test_process_response_activate_user_language(self, mock_translation):
+        self.mock_request.user.is_authenticated = True
+        self.mock_request.user.language = 'fr'
+        mock_translation.get_language.return_value = 'en'
+        user_lang = self.mock_request.user.language
+        session_lang = self.mock_request.session
+        session_lang[self.LANGUAGE_SESSION_KEY] = user_lang
+        res = self.ulm.process_response(self.mock_request, self.mock_response)
+        assert 1 == mock_translation.activate.call_count
+        assert 'fr' == session_lang[self.LANGUAGE_SESSION_KEY]
+        assert res is self.mock_response

--- a/cadasta/accounts/tests/test_middleware.py
+++ b/cadasta/accounts/tests/test_middleware.py
@@ -13,35 +13,6 @@ class UserLanguageMiddlewareTest(TestCase):
         self.ulm = middleware.UserLanguageMiddleware()
 
     @patch.object(middleware, 'translation')
-    def test_process_request_user_not_authenticated(self, mock_translation):
-        self.mock_request.user.is_authenticated = False
-        response = self.ulm.process_request(self.mock_request)
-        assert 0 == mock_translation.activate.call_count
-        assert response is None
-
-    @patch.object(middleware, 'translation')
-    def test_process_request_with_same_language(self, mock_translation):
-        self.mock_request.user.is_authenticated = True
-        self.mock_request.user.language = 'en'
-        mock_translation.get_language.return_value = 'en'
-        response = self.ulm.process_request(self.mock_request)
-        assert 0 == mock_translation.activate.call_count
-        assert response is None
-
-    @patch.object(middleware, 'translation')
-    def test_process_request_activate_user_language(self, mock_translation):
-        self.mock_request.user.is_authenticated = True
-        self.mock_request.user.language = 'fr'
-        mock_translation.get_language.return_value = 'en'
-        user_lang = self.mock_request.user.language
-        session_lang = self.mock_request.session
-        session_lang[self.LANGUAGE_SESSION_KEY] = user_lang
-        response = self.ulm.process_request(self.mock_request)
-        assert 1 == mock_translation.activate.call_count
-        assert 'fr' == session_lang[self.LANGUAGE_SESSION_KEY]
-        assert response is None
-
-    @patch.object(middleware, 'translation')
     def test_process_response_user_not_authenticated(self, mock_translation):
         self.mock_request.user.is_authenticated = False
         res = self.ulm.process_response(self.mock_request, self.mock_response)

--- a/cadasta/accounts/views/default.py
+++ b/cadasta/accounts/views/default.py
@@ -1,5 +1,5 @@
 from django.core.urlresolvers import reverse_lazy
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.utils import timezone

--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -932,6 +932,5 @@ class OrganizationMembersRemoveTest(ViewTestCase, UserTestCase, TestCase):
                                                user=self.member).exists()
         assert response.status_code == 302
         assert ("You don't have permission to remove members from this "
-                "organization"
-                in response.messages)
+                "organization" in response.messages)
         assert role is True


### PR DESCRIPTION
### Proposed changes in this pull request
This PR fixes [#1630](https://github.com/Cadasta/cadasta-platform/issues/1630) _When changing the user-preferred language, the alert message is in the previous language_.
  
The fix has been done by: 
  - Adding the `process_response` function in `accounts/middleware.py` -- This enables translation also when the `form_valid` function returns a response.
  - Changing `ugettext` to `ugettext_lazy` -- As adviced in [here](https://stackoverflow.com/questions/4160770/when-should-i-use-ugettext-lazy/4164683#4164683), `ugettext_lazy` should be used in `froms` and `models` definitions. The `ugettext_lazy` translates strings whenever they're used, mitigating the issue of changing languages.

### When should this PR be merged
- as soon as it's reviewed and approved

### Risks
- low

### Follow-up actions
- close issue #1630 _When changing the user-preferred language, the alert message is in the previous language_
- make PR to change all `import ugettext ` into `import ugettext_lazy` when used in `models` and `forms`

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
