### PR TITLE
Fixes #1693: displays edit and delete button in party detail page only if has permission

### DIFF
--- a/cadasta/party/views/default.py
+++ b/cadasta/party/views/default.py
@@ -137,7 +137,10 @@ class PartiesDetail(LoginPermissionRequiredMixin,
                 if location_opts:
                     rel.location_labels = template_xlang_labels(
                         location_opts.get(rel.spatial_unit.type))
-
+        context['is_allowed_update_party'] = self.request.user.has_perm(
+            'party.update', context['party'])
+        context['is_allowed_delete_party'] = self.request.user.has_perm(
+            'party.delete', context['party'])
         return context
 
 

--- a/cadasta/templates/party/party_detail.html
+++ b/cadasta/templates/party/party_detail.html
@@ -11,11 +11,17 @@
     <div class="col-md-12 main-text">
       <div class="page-title">
         <h2 class="short">{% trans "Party detail" %}</h2>
-        <div class="top-btn pull-right">
-          <!-- Action buttons -->
-          <a class="btn btn-default btn-action btn-sm" href="{% url 'parties:edit' object.organization.slug object.slug party.id %}" title="{% trans 'Edit party' %}" aria-label="{% trans 'Edit party' %}"><span class="glyphicon glyphicon-pencil"></span></a>
-          <a class="btn btn-default btn-action btn-sm" href="{% url 'parties:delete' object.organization.slug object.slug party.id %}" title="{% trans 'Delete party' %}" aria-label="{% trans 'Delete party' %}"><span class="glyphicon glyphicon-trash"></span></a>
-        </div>
+          <div class="top-btn pull-right">
+            <!-- Action buttons -->
+            {% if is_allowed_update_party %}
+              <a class="btn btn-default btn-action btn-sm" href="{% url 'parties:edit' object.organization.slug object.slug party.id %}" title="{% trans 'Edit party' %}" aria-label="{% trans 'Edit party' %}"><span class="glyphicon glyphicon-pencil"></span></a>
+            {% endif %}
+            {% if is_allowed_delete_party %}
+              <a class="btn btn-default btn-action btn-sm" href="{% url 'parties:delete' object.organization.slug object.slug party.id %}" title="{% trans 'Delete party' %}" aria-label="{% trans 'Delete party' %}"><span class="glyphicon glyphicon-trash"></span></a>
+            {% endif %}
+          </div>
+
+
       </div>
       <div class="panel panel-default">
         <div class="panel-body">


### PR DESCRIPTION
### Proposed changes in this pull request
**If you review this, please review also #1738 since they are the same.**
Note: after doing this PR I read that the issue was "on hold". I still think that it's worth fixing this issue since it's linked to direct permission over deleting things. Once the permission system is changed, this will still work. See #1739 to know why.

This PR fixes  #1693 _Party detail page shows edit and delete buttons to project users_ by applying the same strategy that has been used previously in the already-merged PR _Hide location action buttons unless user has permission to do the action_ #1268. 
Specifically:
- In `party/views/default.PartyDetail` I added the parameters `is_allowed_update_party` and 
 `is_allowed_delete_party` to the context.
- In `templates/party/party_detail.html` I wrapped the edit and delete buttons with a check 
`{% if  is_allowed_update_party %}` and `{% if is_allowed_delete_party %}`
- In `party/tests/test_views_default.PartyDetailTest.setup_template_context` I added the following parameters so that the existing tests pass.
```
is_allowed_update_party:True,
is_allowed_delete_party:True,
```
- In `party/tests/test_views_default.PartyDetailTest` I added a test to cover the case for which the user does not have permission with
```
expected_content = self.render_content(
        is_allowed_delete_party=False,
        is_allowed_update_party=False
)
```
- In order to pass this test, in `assign_policies` I added a second Boolean parameter which by default behaves as normal, but if it's passed as True (e.g. `assign_policies(user, True)`) the actions `'party.delete'` and `'party.update'` are denied. This is the exact same approached applied [here](https://github.com/Cadasta/cadasta-platform/blame/76495ef318a8dc46e1926292012d6abea1c5b198/cadasta/spatial/tests/test_views_default.py#L33) in the existing code.

### When should this PR be merged
When reviewed and approved.

### Risks
- Very low

### Follow-up actions
- Close #1693 _Party detail page shows edit and delete buttons to project users_
- Fix #1680 0 _Relationship detail page shows edit and delete buttons to project users_ applying this same approach, for consistency. In this way, the same issue will have been fixed equally 3 times.

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
