### PR TITLE
Fix migration failure

### DIFF
--- a/cadasta/organization/migrations/0006_add_project_area_trigger.py
+++ b/cadasta/organization/migrations/0006_add_project_area_trigger.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
             (
-                'UPDATE organization_project SET area = (SELECT sum(area) from spatial_spatialunit where "spatial_spatialunit".project_id = "organization_project".id)'
+                'UPDATE organization_project SET area = (SELECT COALESCE(sum(area), 0) from spatial_spatialunit where "spatial_spatialunit".project_id = "organization_project".id)'
             ),
             reverse_sql=migrations.RunSQL.noop
         ),

--- a/cadasta/organization/tests/test_migrations.py
+++ b/cadasta/organization/tests/test_migrations.py
@@ -30,8 +30,10 @@ class MigrationTestCase(TestCase):
         call_command('migrate', 'organization', self.migrate_from)
 
         org = Organization.objects.create(name='Test Org')
-        Project.objects.create(id=1, name='No Locations Proj', organization=org)
-        project = Project.objects.create(id=2, name='Test Proj', organization=org)
+        Project.objects.create(
+            id=1, name='No Locations Proj', organization=org)
+        project = Project.objects.create(
+            id=2, name='Test Proj', organization=org)
 
         su1 = SpatialUnit.objects.create(
             id='abc',

--- a/cadasta/organization/tests/test_migrations.py
+++ b/cadasta/organization/tests/test_migrations.py
@@ -30,6 +30,7 @@ class MigrationTestCase(TestCase):
         call_command('migrate', 'organization', self.migrate_from)
 
         org = Organization.objects.create(name='Test Org')
+        Project.objects.create(name='No Locations Proj', organization=org)
         project = Project.objects.create(name='Test Proj', organization=org)
 
         su1 = SpatialUnit.objects.create(

--- a/cadasta/organization/tests/test_migrations.py
+++ b/cadasta/organization/tests/test_migrations.py
@@ -3,8 +3,6 @@ from django.core.management import call_command
 from django.db import connection
 from django.db.migrations.loader import MigrationLoader
 
-from organization.tests.factories import ProjectFactory
-
 
 class MigrationTestCase(TestCase):
     migrate_from = '0005_add_area_to_project'
@@ -32,8 +30,8 @@ class MigrationTestCase(TestCase):
         call_command('migrate', 'organization', self.migrate_from)
 
         org = Organization.objects.create(name='Test Org')
-        ProjectFactory.create(name='No Locations Proj', organization=org)
-        project = ProjectFactory.create(name='Test Proj', organization=org)
+        Project.objects.create(id=1, name='No Locations Proj', organization=org)
+        project = Project.objects.create(id=2, name='Test Proj', organization=org)
 
         su1 = SpatialUnit.objects.create(
             id='abc',

--- a/cadasta/organization/tests/test_migrations.py
+++ b/cadasta/organization/tests/test_migrations.py
@@ -3,6 +3,8 @@ from django.core.management import call_command
 from django.db import connection
 from django.db.migrations.loader import MigrationLoader
 
+from organization.tests.factories import ProjectFactory
+
 
 class MigrationTestCase(TestCase):
     migrate_from = '0005_add_area_to_project'
@@ -30,8 +32,8 @@ class MigrationTestCase(TestCase):
         call_command('migrate', 'organization', self.migrate_from)
 
         org = Organization.objects.create(name='Test Org')
-        Project.objects.create(name='No Locations Proj', organization=org)
-        project = Project.objects.create(name='Test Proj', organization=org)
+        ProjectFactory.create(name='No Locations Proj', organization=org)
+        project = ProjectFactory.create(name='Test Proj', organization=org)
 
         su1 = SpatialUnit.objects.create(
             id='abc',


### PR DESCRIPTION
Fix bug where migration fails if no spatial units are associated with project.

As mentioned in [#1716](https://github.com/Cadasta/cadasta-platform/pull/1716#issuecomment-324097777).

### Proposed changes in this pull request

Use `COALESCE` to fallback to `0` if `sum(<spatial_unit_areas>) == null`, in the event that a Project has no associated SpatialUnit instances.


### When should this PR be merged

Before releasing #1716.

### Risks

[List any risks that could arise from merging your pull request.]

-

### Follow-up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
