### PR TITLE
Fixes #1680: displays edit and delete buttons only if user has permission

### DIFF
--- a/cadasta/party/views/default.py
+++ b/cadasta/party/views/default.py
@@ -255,7 +255,13 @@ class PartyRelationshipDetail(LoginPermissionRequiredMixin,
                         option.label_xlat)
                 except QuestionOption.DoesNotExist:
                     pass
-
+        user = self.request.user
+        context['is_allowed_delete_rel'] = user.has_perm(
+            'tenure_rel.delete', context['relationship']
+        )
+        context['is_allowed_update_rel'] = user.has_perm(
+            'tenure_rel.update', context['relationship']
+        )
         return context
 
 

--- a/cadasta/templates/party/relationship_detail.html
+++ b/cadasta/templates/party/relationship_detail.html
@@ -9,11 +9,15 @@
       <h2><a href="{% url 'locations:detail' object.organization.slug object.slug location.id %}"><span class="entity">{% trans "Location" %} </span>{{ location.name }}</a></h2>
       <hr class="border-btm">
       <h3 class="inline">{% trans "Relationship Detail" %}</h3>
-      <div class="top-btn pull-right">
-        <!-- Action buttons -->
-        <a class="btn btn-default btn-action btn-sm" href="{% url 'parties:relationship_edit' object.organization.slug object.slug relationship.id %}" title="{% trans 'Edit relationship' %}" aria-label="{% trans 'Edit relationship' %}"><span class="glyphicon glyphicon-pencil"></span></a>
-        <a class="btn btn-default btn-action btn-sm" href="{% url 'parties:relationship_delete' object.organization.slug object.slug relationship.id %}" title="{% trans 'Delete relationship' %}" aria-label="{% trans 'Delete relationship' %}"><span class="glyphicon glyphicon-trash"></span></a>
-      </div>
+        <div class="top-btn pull-right">
+          <!-- Action buttons -->
+          {% if is_allowed_update_rel %}
+            <a class="btn btn-default btn-action btn-sm" href="{% url 'parties:relationship_edit' object.organization.slug object.slug relationship.id %}" title="{% trans 'Edit relationship' %}" aria-label="{% trans 'Edit relationship' %}"><span class="glyphicon glyphicon-pencil"></span></a>
+          {% endif %}
+          {% if is_allowed_delete_rel %}
+            <a class="btn btn-default btn-action btn-sm" href="{% url 'parties:relationship_delete' object.organization.slug object.slug relationship.id %}" title="{% trans 'Delete relationship' %}" aria-label="{% trans 'Delete relationship' %}"><span class="glyphicon glyphicon-trash"></span></a>
+          {% endif %}
+        </div>
     </div>
 
     <!-- Relationship information -->


### PR DESCRIPTION
### Proposed changes in this pull request
**If you review this, please review also #1735  since they are the same.**
Note: after doing this PR I read that the issue was "on hold". I still think that it's worth fixing this issue since it's linked to direct permission over deleting things. Once the permission system is changed, this can be changed easily as well. But I think it's worth integrating this small change for now.

This PR fixes #1680 by applying an approach already used in two similar cases:
- in the existing code in master: see [template](https://github.com/Cadasta/cadasta-platform/blob/d9239c8d7891b42bb393a7a2f74d34222c8a1869/cadasta/templates/spatial/location_detail.html#L22-L27), [view](https://github.com/Cadasta/cadasta-platform/blob/d9239c8d7891b42bb393a7a2f74d34222c8a1869/cadasta/spatial/views/default.py#L118-L123), [test](https://github.com/Cadasta/cadasta-platform/blob/d9239c8d7891b42bb393a7a2f74d34222c8a1869/cadasta/spatial/tests/test_views_default.py#L33).
- in the open PR #1735 

This approach consists of:
- adding `{% if is_allowed_update_rel %}` and `{% if is_allowed_delete_rel %}` in the template `party/relation_detail.html`
- adding the values of `is_allowed_delete_rel` and `is_allowed_update_rel` in `party/views/default.PartyRelationshipDetail` by checking if `user.has_perm`
- adding default values in `PartyRelationshipDetailTest.setup_template_context` to pass existing tests: 
```
'is_allowed_delete_rel': True,
'is_allowed_update_rel': True,
```
- adding a test in `PartyRelationshipDetailTest` to cover the case for which the user does not have permissions to edit and delete the relationship.
- setting a second parameter to `assign_policies` so that we we test the case of a user with denied `'tenure_rel.update'` and '`tenure_rel.delete'` permissions. The second parameters is a Boolean set to False, so it behaves as normal for all existing cases.

### When should this PR be merged
- as soon as it's reviewed and approved

### Risks
- Very low

### Follow-up actions
- Close #1680 
- Consider to search for similar situations in the platform where this recurrent problem may occur. This approach may be needed in all the following cases:
    1. there is a template `* _detail.html` (e.g. `location_detail.html`, `relationship_detail.html` and `party_detail.html`)
    2. the template view class checks only the `*.view` permission of the _object_ (e.g. `'spatial.view'`, `'tenure_rel.view'`, `'party.view'`)
    3. the template also provides the option to edit and delete the _object_

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
