### PR TITLE
Fixes #1544: Org admins cannot remove themselves through the URL

### DIFF
--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -24,6 +24,7 @@ from resources.models import ContentObject, Resource
 from core.form_mixins import get_types
 from party.choices import TENURE_RELATIONSHIP_TYPES
 from spatial.choices import TYPE_CHOICES
+from django.contrib import messages
 
 from . import mixins
 from ..choices import ROLE_CHOICES
@@ -290,6 +291,15 @@ class OrganizationMembersRemove(mixins.OrganizationMixin,
     permission_required = update_permissions('org.users.remove')
     permission_denied_message = error_messages.ORG_USERS_REMOVE
 
+    def admin_is_deleting_themselves(self):
+        organization = Organization.objects.get(slug=self.kwargs['slug'])
+        member_to_remove = self.kwargs['username']
+        user = self.request.user.username
+        user_is_admin = OrganizationRole.objects.get(
+            organization=organization,
+            user=self.request.user).admin
+        return user_is_admin and user == member_to_remove
+
     def get_object(self):
         return OrganizationRole.objects.get(
             organization__slug=self.kwargs['slug'],
@@ -303,7 +313,16 @@ class OrganizationMembersRemove(mixins.OrganizationMixin,
         )
 
     def get(self, *args, **kwargs):
-        return self.post(*args, **kwargs)
+        return self.delete(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        if self.admin_is_deleting_themselves():
+            messages.add_message(self.request, messages.ERROR,
+                                 _("Administrators cannot remove themselves."))
+            return redirect('organization:members_edit',
+                            slug=self.kwargs['slug'],
+                            username=self.kwargs['username'])
+        return super().delete(*args, **kwargs)
 
 
 class UserList(LoginPermissionRequiredMixin, generic.ListView):


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes #1544 _Organization admins can remove themselves through the URL_.
Why this problem occurred? This happened because we don't have a permission action that refers to this user case: an administrator deleting themselves. 

Since it's difficult to define this very conditional action in the permission policies, I proposed to simply add a final check inside the `OrganizationMembersRemove` class before posting the member to be deleted. To do so:
1. I created a function called `admin_is_not_deleting_themselves` that checks if the current user is an administrator and if the `current_user.username == member_to_remove.username`.
3. Inside the `get()` function, I call `self.admin_is_not_deleting_themselves()` to check if the current user is an administrator trying to remove themselves.
4. If `admin_is_not_deleting_themselves() == True` --> behaves as before and we post the object to be removed.
5. If `admin_is_not_deleting_themselves == False` --> the member cannot be removed and so we redirect to the admin/member edit page and we display an error message.

Here you can see a [silent short video demo](https://drive.google.com/file/d/0BzK57GHhuoRPTEtkb2dLVXBNb1k/view) of how this currently works.


### When should this PR be merged
- As soon as it is reviewed and approved.

### Risks
- This solution cancel the current risk for an organization to remain without an administrator.
- Very low risks.

### Follow-up actions
- Close #1544 

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
