### PR TITLE
fix bug #820: unarchiving organization does not cascade to projects

### DIFF
--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -482,7 +482,7 @@ class OrganizationUnarchiveTest(ViewTestCase, UserTestCase, TestCase):
         assert '/account/login/' in response.location
         assert self.org.archived is True
 
-    def test_unarchive_cascade_to_projects(self):
+    def test_unarchive_does_not_cascade_to_projects(self):
         project = ProjectFactory.create(organization=self.org, archived=True)
         user = UserFactory.create()
         assign_policies(user)
@@ -495,7 +495,7 @@ class OrganizationUnarchiveTest(ViewTestCase, UserTestCase, TestCase):
         assert ('/organizations/{}/'.format(self.org.slug)
                 in response.location)
         assert self.org.archived is False
-        assert project.archived is False
+        assert project.archived is True
 
 
 class OrganizationMembersTest(ViewTestCase, UserTestCase, TestCase):

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -135,13 +135,14 @@ class OrgArchiveView(LoginPermissionRequiredMixin,
         return reverse('organization:dashboard', kwargs=self.kwargs)
 
     def archive(self):
-        assert hasattr(self, 'do_archive'), "Please set do_archive attribute"
+        assert hasattr(self, 'do_archive'), 'Please set do_archive attribute'
         self.object = self.get_object()
         self.object.archived = self.do_archive
         self.object.save()
-        for project in self.object.projects.all():
-            project.archived = self.do_archive
-            project.save()
+        if self.do_archive:
+            for project in self.object.projects.all():
+                project.archived = True
+                project.save()
         return redirect(self.get_success_url())
 
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes #820 with a second approach after the discussion in the closed PR _Fixes#820: maintains project.archived value when their org is archived/unarchived_ #1734.
This PR fixes the bug by keeping all projects archived even when an already-archived organization is unarchived.

For example: 

- Project 1 is archived, Project 2 is active
- Organization is archived
- Organization is unarchived
- Project 1 and Project 2 are both archived.

### When should this PR be merged
- As soon as it's reviewed and approved

### Risks
- Low

### Follow-up actions
- Close #820 

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
