### PR TITLE
Send message on Password Reset and add separate unique email validation for serializers

### DIFF
--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -21,6 +21,7 @@ import time
 from simple_history.models import HistoricalRecords
 from .manager import UserManager
 from .utils import send_sms
+from . import messages as account_message
 
 PERMISSIONS_DIR = settings.BASE_DIR + '/permissions/'
 
@@ -126,13 +127,16 @@ def assign_default_policy(sender, instance, **kwargs):
 def password_changed_reset(sender, request, user, **kwargs):
     msg_body = render_to_string(
         'accounts/email/password_changed_notification.txt')
-    send_mail(
-        _("Change of password at Cadasta Platform"),
-        msg_body,
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email],
-        fail_silently=False
-    )
+    if user.email:
+        send_mail(
+            _("Change of password at Cadasta Platform"),
+            msg_body,
+            settings.DEFAULT_FROM_EMAIL,
+            [user.email],
+            fail_silently=False
+        )
+    if user.phone:
+        send_sms(user.phone, account_message.password_change_or_reset)
 
 
 def default_key():

--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -19,10 +19,6 @@ from .messages import phone_format
 class RegistrationSerializer(SanitizeFieldSerializer,
                              djoser_serializers.UserRegistrationSerializer):
     email = serializers.EmailField(
-        validators=[UniqueValidator(
-            queryset=User.objects.all(),
-            message=_("User with this Email address already exists.")
-        )],
         allow_blank=True,
         allow_null=True,
         required=False
@@ -75,7 +71,8 @@ class RegistrationSerializer(SanitizeFieldSerializer,
     def validate_email(self, email):
         if email:
             email = email.casefold()
-            if EmailAddress.objects.filter(email=email).exists():
+            if (EmailAddress.objects.filter(email=email).exists() or
+                    User.objects.filter(email=email).exists()):
                 raise serializers.ValidationError(
                     _("User with this Email address already exists."))
         else:
@@ -129,10 +126,6 @@ class RegistrationSerializer(SanitizeFieldSerializer,
 class UserSerializer(SanitizeFieldSerializer,
                      djoser_serializers.UserSerializer):
     email = serializers.EmailField(
-        validators=[UniqueValidator(
-            queryset=User.objects.all(),
-            message=_("User with this Email address already exists.")
-        )],
         allow_blank=True,
         allow_null=True,
         required=False
@@ -212,7 +205,8 @@ class UserSerializer(SanitizeFieldSerializer,
             email = email.casefold()
             # make sure that the new email updated by a user is not a duplicate
             # of an unverified email already linked to a different user
-            if EmailAddress.objects.filter(email=email).exists():
+            if (EmailAddress.objects.filter(email=email).exists() or
+                    User.objects.filter(email=email).exists()):
                 raise serializers.ValidationError(
                     _("User with this Email address already exists."))
         else:

--- a/cadasta/accounts/tests/test_views_default.py
+++ b/cadasta/accounts/tests/test_views_default.py
@@ -510,6 +510,8 @@ class PasswordResetFromPhoneViewTest(UserTestCase, TestCase):
         assert response.status_code == 302
         self.user.refresh_from_db()
         assert self.user.check_password('i@msher!0cked') is True
+        assert len(mail.outbox) == 1
+        assert self.user.email in mail.outbox[0].to
 
     def test_password_set_without_password_reset_id(self):
         data = {'password': 'i@msher!0cked'}

--- a/cadasta/accounts/views/default.py
+++ b/cadasta/accounts/views/default.py
@@ -13,6 +13,7 @@ import allauth.account.views as allauth_views
 from allauth.account.views import ConfirmEmailView, LoginView
 from allauth.account.utils import send_email_confirmation
 from allauth.account.models import EmailAddress
+from allauth.account import signals
 
 from ..models import User, VerificationDevice
 from .. import forms
@@ -127,8 +128,9 @@ class PasswordResetFromPhoneView(FormView, SuperUserCheckMixin):
     def form_valid(self, form):
         form.save()
         self.request.session.pop('password_reset_id', None)
-        # send message to user's phone informing that password
-        # was successfully changed.
+        signals.password_reset.send(sender=form.user.__class__,
+                                    request=self.request,
+                                    user=form.user)
         return super().form_valid(form)
 
 

--- a/cadasta/templates/allauth/account/password_reset_done.html
+++ b/cadasta/templates/allauth/account/password_reset_done.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 {% load account %}
+{% load widget_tweaks %}
 
 {% block head_title %}{% trans "Password Reset" %}{% endblock %}
 


### PR DESCRIPTION
### Proposed changes in this pull request

1. Make changes to `password_changed_reset` in `accounts/models.py`. Send email on password reset/change if user's email exists, and send SMS on password reset/change if user's phone exists.

2. Make changes to `PasswordResetFromPhoneView`. Add signal which is sent on password reset.
**Tests**
 -  `PasswordResetFromPhoneViewTest: test_password_successfully_set`

3. Remove `UniqueValidator` for email from `RegistrationSerializer` and `UserSerializer`. Add validation inside `validate_email`.
**Tests**
 - `test_update_insensitive_email_check` in `accounts/tests/test_serializer.py: UserSerializerTest`
 - `test_insensitive_email_check` in `accounts/tests/test_serializer.py: RegistrationSerializerTest`

### When should this PR be merged
- As soon as it's been reviewed and approved.

### Risks

- Low

### Follow-up actions

- None


### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
