### PR TITLE
Handle situations where request has no User object, closes #1746

### DIFF
--- a/cadasta/accounts/middleware.py
+++ b/cadasta/accounts/middleware.py
@@ -4,6 +4,9 @@ from django.utils import translation
 class UserLanguageMiddleware(object):
 
     def process_response(self, request, response):
+        if not hasattr(request, 'user'):
+            return response
+
         if not request.user.is_authenticated:
             return response
 

--- a/cadasta/accounts/tests/test_middleware.py
+++ b/cadasta/accounts/tests/test_middleware.py
@@ -40,3 +40,16 @@ class UserLanguageMiddlewareTest(TestCase):
         assert 1 == mock_translation.activate.call_count
         assert 'fr' == session_lang[self.LANGUAGE_SESSION_KEY]
         assert res is self.mock_response
+
+    @patch.object(middleware, 'translation')
+    def test_process_response_wsgi_request(self, mock_translation):
+        """
+        If Auth middleware isn't reached (eg if we return a redirect to
+        an endpoint with an appended slash if a slash is ommited from a
+        URL and settings.APPEND_SLASH=True), request will be a
+        WSGIRequest that does not contain a user property.
+        """
+        del self.mock_request.user
+        res = self.ulm.process_response(self.mock_request, self.mock_response)
+        assert 0 == mock_translation.activate.call_count
+        assert res is self.mock_response


### PR DESCRIPTION
### Proposed changes in this pull request

Going off of the description in [this StackOverflow article](https://stackoverflow.com/questions/11223597/django-wsgirequest-object-has-no-attribute-user-on-some-pages), #1746 appears to be related to situations where we have a redirect from `APPEND_SLASH=True`. Typically, a request works its way through the middleware stack, is sent to a view, and then a response works its way through the middleware (in opposite order). If a redirect occurs from the `CommonMiddleware` middleware but before `AuthenticationMiddleware`, the `AuthenticationMiddleware` is skipped (meaning the `user` object is not added to the `request`) and the response is sent through _all_ middleware. Our `UserLanguageMiddleware` expects that the `request` have a `user` property, but in the event of skipping the `AuthenticationMiddleware` this is not true. 

We could do a re-org of the middleware, but it seems more robust to just handle situations where there is no `user` property on the `request`.



### When should this PR be merged

ASAP, as this is a blocking bug.


### Risks

None foreseen.  I would have liked to write a test that worked through all the existing middleware, but felt that this was simpler and better for the sake of time.


### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
