### PR TITLE
Fixes #1747 -- Provide redirect only when not on sign-up or login page

### DIFF
--- a/cadasta/core/templatetags/tags.py
+++ b/cadasta/core/templatetags/tags.py
@@ -1,0 +1,7 @@
+from django import template
+register = template.Library()
+
+
+@register.assignment_tag
+def define(value=None):
+    return value

--- a/cadasta/core/tests/test_tags.py
+++ b/cadasta/core/tests/test_tags.py
@@ -1,0 +1,12 @@
+from django.test import TestCase
+from ..templatetags.tags import define
+
+
+class FilterTest(TestCase):
+    def test_val(self):
+        """Tag function should return the same value"""
+        assert define('Blah') == 'Blah'
+
+    def test_val_undefined(self):
+        """If value is not defined tag function should return None"""
+        assert define() is None

--- a/cadasta/templates/allauth/account/login.html
+++ b/cadasta/templates/allauth/account/login.html
@@ -76,7 +76,7 @@
 
       <p class="text-center">
         {% trans "Don't have an account?" %}
-        <a href="{% url 'account_signup' %}?next={{ redirect_field_value }}">{% trans "Register here" %}</a>
+        <a href="{% url 'account_signup' %}{% if redirect_field_value %}?next={{ redirect_field_value }}{% endif %}">{% trans "Register here" %}</a>
       </p>
     </div>
 

--- a/cadasta/templates/core/base.html
+++ b/cadasta/templates/core/base.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load sass_tags %}
 {% load staticfiles %}
+{% load tags %}
 
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 
@@ -57,8 +58,12 @@
             <!-- New user menu -->
             <div class="divider pull-left"></div>
             <div class="btn-group" role="group">
-              <a href="{% url 'account_login' %}?next={{ request.path }}" class="btn btn-reg" aria-label="Sign in">{% trans "Sign in" %}</a>
-              <a href="{% url 'account_signup' %}?next={{ request.path }}" class="btn btn-reg" aria-label="Register">{% trans "Register" %}</a>
+              {% if request.path != '/account/signup/' and request.path != '/account/login/'  %}
+                {% define request.path as redirect_url %}
+              {% endif %}
+              
+              <a href="{% url 'account_login' %}{% if redirect_url %}?next={{ request.path }}{% endif %}" class="btn btn-reg" aria-label="Sign in">{% trans "Sign in" %}</a>
+              <a href="{% url 'account_signup' %}{% if redirect_url %}?next={{ request.path }}{% endif %}" class="btn btn-reg" aria-label="Register">{% trans "Register" %}</a>
             </div>
             {% endif %}
           </div>


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #1747: On the login page, only add the `next` URL parameter to the "Register" link if the URL is defined.
- Also, fixes #1731 (If I understand the issue correctly): When you're on the signup page, then go to log-in the redirect is set to the sign-up page. So after you've logged you will be redirected to the sign-up page. I fixed this by adding the redirect links only if you're not coming from with the login page or the signup page. I introduced the template tag `define` so you can set a variable in a template, something which isn't possible with standard Django functionality. 

### When should this PR be merged

While the issues don't cause any significant damage, it still is a major inconvenience to new users. I'd vouch that we include this into the next release. 

### Risks

None

### Follow-up actions

None

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
