### PR TITLE
BugFix #1745, case insensitive org/project name

### DIFF
--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -33,6 +33,10 @@ class OrganizationSerializer(core_serializers.SanitizeFieldSerializer,
         if slugify(value, allow_unicode=True) in invalid_names:
             raise serializers.ValidationError(
                 _("Organization name cannot be “Add” or “New”."))
+        not_unique = Organization.objects.filter(name__iexact=value)
+        if not_unique:
+            raise serializers.ValidationError(
+                _("Organization with this name already exists."))
         return value
 
     def create(self, *args, **kwargs):
@@ -81,7 +85,7 @@ class ProjectSerializer(core_serializers.SanitizeFieldSerializer,
             org_slug = self.instance.organization.slug
         queryset = Project.objects.filter(
             organization__slug=org_slug,
-            name=value,
+            name__iexact=value,
         )
         if is_create:
             not_unique = queryset.exists()
@@ -201,6 +205,7 @@ class EntityUserSerializer(SuperUserCheck, serializers.Serializer):
 
 
 class OrganizationUserSerializer(EntityUserSerializer):
+
     class Meta:
         role_model = OrganizationRole
         context_key = 'organization'
@@ -241,6 +246,7 @@ class OrganizationUserSerializer(EntityUserSerializer):
 
 
 class ProjectUserSerializer(EntityUserSerializer):
+
     class Meta:
         role_model = ProjectRole
         context_key = 'project'


### PR DESCRIPTION
### Proposed changes in this pull request

1. Make changes to `OrganizationForm` , `ProjectAddDetails` and `ProjectEditDetails` in `organization/forms.py`.
Use `name__iexact` instead of `name` when filtering out org/project. `name__iexact` is used for case-insensitive exact match, check [here](https://docs.djangoproject.com/en/1.11/ref/models/querysets/#iexact).
Add an explicit uniqueness validation in `OrganizationForm`.
**Tests**
   - `OrganizationTest`: test_duplicate_name_error_case_insensitive
   - `ProjectAddDetailsTest`: test_add_new_project_with_duplicate_name_case_insensitive
   - `ProjectEditDetailsTest`: test_update_project_with_duplicate_name_case_insensitive

2. Make changes to `ProjectSerializer` and `OrganizationSerializer`.
Use `name__iexact` instead of `name` when filtering out org/project. `name__iexact` is used for the case-insensitive exact match.
Add an explicit uniqueness validation in `OrganizationSerializer`.
**Tests**
   - `OrganizationSerializerTest`: test_duplicate_organization_name_case_insensitive
   - `OrganizationSerializerTest`: test_update_with_duplicate_organization_name_case_insensitive
   - `ProjectSerializerTest`: test_duplicate_project_name_case_insensitive
   - `ProjectSerializerTest`: test_update_with_duplicate_project_name_case_insensitive

3. PEP8 auto formatting might have added some extra lines and spaces here and there.

### When should this PR be merged

- As soon as it's approved

### Risks

- Low

### Follow-up actions

- None


### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
