### PR TITLE
Async: Add list view to relationships API endpoints

### DIFF
--- a/cadasta/party/serializers.py
+++ b/cadasta/party/serializers.py
@@ -3,7 +3,7 @@
 from django.utils.translation import ugettext as _
 from rest_framework import serializers
 
-from .models import Party, PartyRelationship, TenureRelationship
+from . import models
 from core import serializers as core_serializers
 from .choices import TENURE_RELATIONSHIP_TYPES
 from spatial.serializers import SpatialUnitSerializer
@@ -17,35 +17,20 @@ class PartySerializer(core_serializers.JSONAttrsSerializer,
     attrs_selector = 'type'
 
     class Meta:
-        model = Party
+        model = models.Party
         fields = ('id', 'name', 'type', 'attributes', )
         read_only_fields = ('id', )
 
     def create(self, validated_data):
         project = self.context['project']
-        return Party.objects.create(
+        return models.Party.objects.create(
             project=project, **validated_data)
 
 
-class PartyRelationshipReadSerializer(serializers.ModelSerializer):
-
-    party1 = PartySerializer(fields=('id', 'name', 'type'))
-    party2 = PartySerializer(fields=('id', 'name', 'type'))
-    rel_class = serializers.SerializerMethodField()
+class PartyRelationshipSerializer(serializers.ModelSerializer):
 
     class Meta:
-        model = PartyRelationship
-        fields = ('rel_class', 'id', 'party1', 'party2', 'type', 'attributes')
-        read_only_fields = ('id',)
-
-    def get_rel_class(self, obj):
-        return 'party'
-
-
-class PartyRelationshipWriteSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = PartyRelationship
+        model = models.PartyRelationship
         fields = ('id', 'party1', 'party2', 'type', 'attributes')
         read_only_fields = ('id',)
 
@@ -69,34 +54,32 @@ class PartyRelationshipWriteSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         project = self.context['project']
-        return PartyRelationship.objects.create(
+        return models.PartyRelationship.objects.create(
             project=project, **validated_data)
 
 
-class TenureRelationshipReadSerializer(serializers.ModelSerializer):
+class PartyRelationshipDetailSerializer(serializers.ModelSerializer):
 
-    party = PartySerializer(fields=('id', 'name', 'type'))
-    spatial_unit = SpatialUnitSerializer(fields=(
-        'id', 'name', 'geometry', 'type'))
+    party1 = PartySerializer(fields=('id', 'name', 'type'))
+    party2 = PartySerializer(fields=('id', 'name', 'type'))
     rel_class = serializers.SerializerMethodField()
 
     class Meta:
-        model = TenureRelationship
-        fields = ('rel_class', 'id', 'party', 'spatial_unit', 'tenure_type',
-                  'attributes')
+        model = models.PartyRelationship
+        fields = ('rel_class', 'id', 'party1', 'party2', 'type', 'attributes')
         read_only_fields = ('id',)
 
     def get_rel_class(self, obj):
-        return 'tenure'
+        return 'party'
 
 
-class TenureRelationshipWriteSerializer(
+class TenureRelationshipSerializer(
         core_serializers.JSONAttrsSerializer,
         core_serializers.SanitizeFieldSerializer,
         serializers.ModelSerializer):
 
     class Meta:
-        model = TenureRelationship
+        model = models.TenureRelationship
         fields = ('id', 'party', 'spatial_unit', 'tenure_type', 'attributes')
         read_only_fields = ('id',)
 
@@ -131,5 +114,22 @@ class TenureRelationshipWriteSerializer(
 
     def create(self, validated_data):
         project = self.context['project']
-        return TenureRelationship.objects.create(
+        return models.TenureRelationship.objects.create(
             project=project, **validated_data)
+
+
+class TenureRelationshipDetailSerializer(serializers.ModelSerializer):
+
+    party = PartySerializer(fields=('id', 'name', 'type'))
+    spatial_unit = SpatialUnitSerializer(fields=(
+        'id', 'name', 'geometry', 'type'))
+    rel_class = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.TenureRelationship
+        fields = ('rel_class', 'id', 'party', 'spatial_unit', 'tenure_type',
+                  'attributes')
+        read_only_fields = ('id',)
+
+    def get_rel_class(self, obj):
+        return 'tenure'

--- a/cadasta/party/tests/test_serializers.py
+++ b/cadasta/party/tests/test_serializers.py
@@ -201,7 +201,7 @@ class PartySerializerTest(UserTestCase, TestCase):
         assert e.value.detail['attributes']
 
 
-class TenureRelationshipWriteSerializer(UserTestCase, TestCase):
+class TenureRelationshipSerializer(UserTestCase, TestCase):
     def test_valid_attributes(self):
         project = ProjectFactory.create(name='Test Project')
         su = SpatialUnitFactory.create(project=project)
@@ -237,7 +237,7 @@ class TenureRelationshipWriteSerializer(UserTestCase, TestCase):
                 'age': 2
             }
         }
-        serializer = serializers.TenureRelationshipWriteSerializer(
+        serializer = serializers.TenureRelationshipSerializer(
             data=data,
             context={'project': project}
         )
@@ -253,7 +253,7 @@ class TenureRelationshipWriteSerializer(UserTestCase, TestCase):
             'party': party.id
         }
 
-        serializer = serializers.TenureRelationshipWriteSerializer(
+        serializer = serializers.TenureRelationshipSerializer(
             data=data,
             context={'project': project})
         assert serializer.is_valid() is True
@@ -268,7 +268,7 @@ class TenureRelationshipWriteSerializer(UserTestCase, TestCase):
             'party': party.id
         }
 
-        serializer = serializers.TenureRelationshipWriteSerializer(
+        serializer = serializers.TenureRelationshipSerializer(
             data=data,
             context={'project': project})
         assert serializer.is_valid() is False
@@ -297,7 +297,7 @@ class TenureRelationshipWriteSerializer(UserTestCase, TestCase):
             'party': party.id
         }
 
-        serializer = serializers.TenureRelationshipWriteSerializer(
+        serializer = serializers.TenureRelationshipSerializer(
             data=data,
             context={'project': project})
         assert serializer.is_valid() is True
@@ -324,7 +324,7 @@ class TenureRelationshipWriteSerializer(UserTestCase, TestCase):
             'party': party.id
         }
 
-        serializer = serializers.TenureRelationshipWriteSerializer(
+        serializer = serializers.TenureRelationshipSerializer(
             data=data,
             context={'project': project})
         assert serializer.is_valid() is False
@@ -366,7 +366,7 @@ class TenureRelationshipWriteSerializer(UserTestCase, TestCase):
                 'age': 'Blah'
             }
         }
-        serializer = serializers.TenureRelationshipWriteSerializer(
+        serializer = serializers.TenureRelationshipSerializer(
             data=data,
             context={'project': project}
         )
@@ -408,7 +408,7 @@ class TenureRelationshipWriteSerializer(UserTestCase, TestCase):
                 'age': 2
             }
         }
-        serializer = serializers.TenureRelationshipWriteSerializer(
+        serializer = serializers.TenureRelationshipSerializer(
             data=data,
             context={'project': project}
         )

--- a/cadasta/party/tests/test_urls_api.py
+++ b/cadasta/party/tests/test_urls_api.py
@@ -121,9 +121,9 @@ class PartyUrlTest(TestCase):
 
 class RelationshipUrlTest(TestCase):
 
-    def generic_test_project_relationship_create(self, rel_class, view):
+    def generic_test_project_relationship_list(self, rel_class, view):
         actual = reverse(
-            version_ns('relationship:{}_rel_create'.format(rel_class)),
+            version_ns('relationship:{}_rel_list'.format(rel_class)),
             kwargs={
                 'organization': 'habitat',
                 'project': '123abc',
@@ -164,17 +164,17 @@ class RelationshipUrlTest(TestCase):
         assert resolved.kwargs['{}_rel_id'.format(rel_class)] == (
             '654321654321654321654321')
 
-    def test_project_spatial_relationship_create(self):
-        self.generic_test_project_relationship_create(
-            'spatial', api2.SpatialRelationshipCreate)
+    def test_project_spatial_relationship_list(self):
+        self.generic_test_project_relationship_list(
+            'spatial', api2.SpatialRelationshipList)
 
-    def test_project_party_relationship_create(self):
-        self.generic_test_project_relationship_create(
-            'party', api.PartyRelationshipCreate)
+    def test_project_party_relationship_list(self):
+        self.generic_test_project_relationship_list(
+            'party', api.PartyRelationshipList)
 
-    def test_project_tenure_relationship_create(self):
-        self.generic_test_project_relationship_create(
-            'tenure', api.TenureRelationshipCreate)
+    def test_project_tenure_relationship_list(self):
+        self.generic_test_project_relationship_list(
+            'tenure', api.TenureRelationshipList)
 
     def test_project_spatial_relationship_detail(self):
         self.generic_test_project_relationship_detail(

--- a/cadasta/party/tests/test_views_api_party_relationships.py
+++ b/cadasta/party/tests/test_views_api_party_relationships.py
@@ -44,8 +44,8 @@ def assign_policies(user):
     user.assign_policies(policy)
 
 
-class PartyRelationshipCreateAPITest(APITestCase, UserTestCase, TestCase):
-    view_class = api.PartyRelationshipCreate
+class PartyRelationshipListAPITest(APITestCase, UserTestCase, TestCase):
+    view_class = api.PartyRelationshipList
 
     def setup_models(self):
         self.user = UserFactory.create()
@@ -69,6 +69,32 @@ class PartyRelationshipCreateAPITest(APITestCase, UserTestCase, TestCase):
             'party2': self.party1.id,
             'type': 'C'
         }
+
+    def test_full_list(self):
+        PartyRelationshipFactory.create_batch(
+            2, project=self.prj, party1=self.party1, party2=self.party2)
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        assert len(response.content['results']) == 2
+
+    def test_full_list_with_unauthorized_user(self):
+        PartyRelationshipFactory.create(
+            project=self.prj, party1=self.party1, party2=self.party2)
+        response = self.request()
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+    def test_get_full_list_organization_does_not_exist(self):
+        response = self.request(user=self.user,
+                                url_kwargs={'organization': 'some-org'})
+        assert response.status_code == 404
+        assert response.content['detail'] == "Project not found."
+
+    def test_get_full_list_project_does_not_exist(self):
+        response = self.request(user=self.user,
+                                url_kwargs={'project': 'some-prj'})
+        assert response.status_code == 404
+        assert response.content['detail'] == "Project not found."
 
     def test_create_valid_record(self):
         response = self.request(user=self.user, method='POST')

--- a/cadasta/party/urls/api/relationships.py
+++ b/cadasta/party/urls/api/relationships.py
@@ -6,16 +6,16 @@ from party.views import api as party_api
 urlpatterns = [
     url(
         r'^spatial/$',
-        spatial_api.SpatialRelationshipCreate.as_view(),
-        name='spatial_rel_create'),
+        spatial_api.SpatialRelationshipList.as_view(),
+        name='spatial_rel_list'),
     url(
         r'^spatial/(?P<spatial_rel_id>[-\w]+)/$',
         spatial_api.SpatialRelationshipDetail.as_view(),
         name='spatial_rel_detail'),
     url(
         r'^party/$',
-        party_api.PartyRelationshipCreate.as_view(),
-        name='party_rel_create'),
+        party_api.PartyRelationshipList.as_view(),
+        name='party_rel_list'),
     url(
         r'^party/(?P<party_rel_id>[-\w]+)/$',
         party_api.PartyRelationshipDetail.as_view(),
@@ -26,8 +26,8 @@ urlpatterns = [
         name='tenure_rel_detail'),
     url(
         r'^tenure/$',
-        party_api.TenureRelationshipCreate.as_view(),
-        name='tenure_rel_create'),
+        party_api.TenureRelationshipList.as_view(),
+        name='tenure_rel_list'),
     url(
         (r'^tenure/(?P<tenure_rel_id>[-\w]+)/resources/'
          '(?P<resource>[-\w]+)/$'),

--- a/cadasta/party/views/api.py
+++ b/cadasta/party/views/api.py
@@ -13,7 +13,7 @@ from party.models import (PartyRelationship,
 from spatial.models import SpatialRelationship
 from party import serializers
 from resources.serializers import ResourceSerializer
-from spatial.serializers import SpatialRelationshipReadSerializer
+from spatial.serializers import SpatialRelationshipDetailSerializer
 from . import mixins
 from organization.views.mixins import ProjectMixin
 
@@ -144,21 +144,24 @@ class RelationshipList(APIPermissionRequiredMixin,
 
         return Response(paginate_results(
             request,
-            (spatial_rels, SpatialRelationshipReadSerializer),
-            (party_rels, serializers.PartyRelationshipReadSerializer),
-            (tenure_rels, serializers.TenureRelationshipReadSerializer),
+            (spatial_rels, SpatialRelationshipDetailSerializer),
+            (party_rels, serializers.PartyRelationshipDetailSerializer),
+            (tenure_rels, serializers.TenureRelationshipDetailSerializer),
         ))
 
     def get_perms_objects(self):
         return [self.get_project()]
 
 
-class PartyRelationshipCreate(APIPermissionRequiredMixin,
-                              mixins.PartyRelationshipQuerySetMixin,
-                              generics.CreateAPIView):
+class PartyRelationshipList(APIPermissionRequiredMixin,
+                            mixins.PartyRelationshipQuerySetMixin,
+                            generics.ListCreateAPIView):
 
-    permission_required = update_permissions('party_rel.create')
-    serializer_class = serializers.PartyRelationshipWriteSerializer
+    permission_required = {
+        'GET': 'party_rel.list',
+        'POST': update_permissions('party_rel.create')
+    }
+    serializer_class = serializers.PartyRelationshipSerializer
 
     def get_perms_objects(self):
         return [self.get_project()]
@@ -179,21 +182,24 @@ class PartyRelationshipDetail(APIPermissionRequiredMixin,
 
     def get_serializer_class(self):
         if self.request.method == 'PATCH':
-            return serializers.PartyRelationshipWriteSerializer
+            return serializers.PartyRelationshipSerializer
         else:
-            return serializers.PartyRelationshipReadSerializer
+            return serializers.PartyRelationshipDetailSerializer
 
     def destroy(self, request, *args, **kwargs):
         self.get_object().delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class TenureRelationshipCreate(APIPermissionRequiredMixin,
-                               mixins.TenureRelationshipQuerySetMixin,
-                               generics.CreateAPIView):
+class TenureRelationshipList(APIPermissionRequiredMixin,
+                             mixins.TenureRelationshipQuerySetMixin,
+                             generics.ListCreateAPIView):
 
-    permission_required = update_permissions('tenure_rel.create')
-    serializer_class = serializers.TenureRelationshipWriteSerializer
+    permission_required = {
+        'GET': 'tenure_rel.list',
+        'POST': update_permissions('tenure_rel.create')
+    }
+    serializer_class = serializers.TenureRelationshipSerializer
 
     def get_perms_objects(self):
         return [self.get_project()]
@@ -214,9 +220,9 @@ class TenureRelationshipDetail(APIPermissionRequiredMixin,
 
     def get_serializer_class(self):
         if self.request.method == 'PATCH':
-            return serializers.TenureRelationshipWriteSerializer
+            return serializers.TenureRelationshipSerializer
         else:
-            return serializers.TenureRelationshipReadSerializer
+            return serializers.TenureRelationshipDetailSerializer
 
     def destroy(self, request, *args, **kwargs):
         self.get_object().delete()

--- a/cadasta/spatial/serializers.py
+++ b/cadasta/spatial/serializers.py
@@ -19,7 +19,7 @@ class SpatialUnitSerializer(core_serializers.JSONAttrsSerializer,
         context_key = 'project'
         geo_field = 'geometry'
         id_field = False
-        fields = ('id', 'geometry', 'type', 'attributes', )
+        fields = ('id', 'geometry', 'type', 'attributes', 'area',)
         read_only_fields = ('id', )
 
     def validate_type(self, value):
@@ -61,22 +61,7 @@ class SpatialUnitGeoJsonSerializer(geo_serializers.GeoFeatureModelSerializer):
         return location.name
 
 
-class SpatialRelationshipReadSerializer(serializers.ModelSerializer):
-
-    su1 = SpatialUnitSerializer(fields=('id', 'geometry', 'type'))
-    su2 = SpatialUnitSerializer(fields=('id', 'geometry', 'type'))
-    rel_class = serializers.SerializerMethodField()
-
-    class Meta:
-        model = SpatialRelationship
-        fields = ('rel_class', 'id', 'su1', 'su2', 'type', 'attributes')
-        read_only_fields = ('id',)
-
-    def get_rel_class(self, obj):
-        return 'spatial'
-
-
-class SpatialRelationshipWriteSerializer(serializers.ModelSerializer):
+class SpatialRelationshipSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = SpatialRelationship
@@ -104,3 +89,18 @@ class SpatialRelationshipWriteSerializer(serializers.ModelSerializer):
         project = self.context['project']
         return SpatialRelationship.objects.create(
             project=project, **validated_data)
+
+
+class SpatialRelationshipDetailSerializer(serializers.ModelSerializer):
+
+    su1 = SpatialUnitSerializer(fields=('id', 'geometry', 'type'))
+    su2 = SpatialUnitSerializer(fields=('id', 'geometry', 'type'))
+    rel_class = serializers.SerializerMethodField()
+
+    class Meta:
+        model = SpatialRelationship
+        fields = ('rel_class', 'id', 'su1', 'su2', 'type', 'attributes')
+        read_only_fields = ('id',)
+
+    def get_rel_class(self, obj):
+        return 'spatial'

--- a/cadasta/spatial/tests/test_views_api_spatial_relationships.py
+++ b/cadasta/spatial/tests/test_views_api_spatial_relationships.py
@@ -40,8 +40,8 @@ def assign_policies(user):
     user.assign_policies(policy)
 
 
-class SpatialRelationshipCreateAPITest(APITestCase, UserTestCase, TestCase):
-    view_class = api.SpatialRelationshipCreate
+class SpatialRelationshipListAPITest(APITestCase, UserTestCase, TestCase):
+    view_class = api.SpatialRelationshipList
 
     def setup_models(self, access='public'):
         self.user = UserFactory.create()
@@ -63,6 +63,32 @@ class SpatialRelationshipCreateAPITest(APITestCase, UserTestCase, TestCase):
             'su2': self.su1.id,
             'type': 'C'
         }
+
+    def test_full_list(self):
+        SpatialRelationshipFactory.create_batch(
+            2, project=self.prj, su1=self.su1, su2=self.su2)
+        response = self.request(user=self.user)
+        assert response.status_code == 200
+        assert len(response.content['results']) == 2
+
+    def test_full_list_with_unauthorized_user(self):
+        SpatialRelationshipFactory.create(
+            project=self.prj, su1=self.su1, su2=self.su2)
+        response = self.request()
+        assert response.status_code == 403
+        assert response.content['detail'] == PermissionDenied.default_detail
+
+    def test_get_full_list_organization_does_not_exist(self):
+        response = self.request(user=self.user,
+                                url_kwargs={'organization': 'some-org'})
+        assert response.status_code == 404
+        assert response.content['detail'] == "Project not found."
+
+    def test_get_full_list_project_does_not_exist(self):
+        response = self.request(user=self.user,
+                                url_kwargs={'project': 'some-prj'})
+        assert response.status_code == 404
+        assert response.content['detail'] == "Project not found."
 
     def test_create_valid_record(self):
         response = self.request(user=self.user, method='POST')

--- a/cadasta/spatial/views/api.py
+++ b/cadasta/spatial/views/api.py
@@ -105,12 +105,15 @@ class SpatialUnitResourceDetail(APIPermissionRequiredMixin,
         return self.detach_resource(self.kwargs['location'])
 
 
-class SpatialRelationshipCreate(APIPermissionRequiredMixin,
-                                mixins.SpatialRelationshipQuerySetMixin,
-                                generics.CreateAPIView):
+class SpatialRelationshipList(APIPermissionRequiredMixin,
+                              mixins.SpatialRelationshipQuerySetMixin,
+                              generics.ListCreateAPIView):
 
-    permission_required = update_permissions('spatial_rel.create')
-    serializer_class = serializers.SpatialRelationshipWriteSerializer
+    permission_required = {
+        'GET': 'spatial_rel.list',
+        'POST': update_permissions('spatial_rel.create')
+    }
+    serializer_class = serializers.SpatialRelationshipSerializer
 
     def get_perms_objects(self):
         return [self.get_project()]
@@ -131,9 +134,9 @@ class SpatialRelationshipDetail(APIPermissionRequiredMixin,
 
     def get_serializer_class(self):
         if self.request.method == 'PATCH':
-            return serializers.SpatialRelationshipWriteSerializer
+            return serializers.SpatialRelationshipSerializer
         else:
-            return serializers.SpatialRelationshipReadSerializer
+            return serializers.SpatialRelationshipDetailSerializer
 
     def destroy(self, request, *args, **kwargs):
         self.get_object().delete()

--- a/cadasta/xforms/serializers.py
+++ b/cadasta/xforms/serializers.py
@@ -43,7 +43,7 @@ class XFormSubmissionSerializer(FieldSelectorSerializer,
 
     parties = party_serializer.PartySerializer(read_only=True, many=True)
     spatial_units = SpatialUnitSerializer(read_only=True, many=True)
-    tenure_relationships = party_serializer.TenureRelationshipReadSerializer(
+    tenure_relationships = party_serializer.TenureRelationshipDetailSerializer(
         read_only=True, many=True)
 
     def create(self, validated_data):


### PR DESCRIPTION
### Proposed changes in this pull request

_NOTE: This PR works towards the goals of #1400_

The export operation currently [writes Tenure Relationships to an XLS file](https://github.com/Cadasta/cadasta-platform/blob/a14f87e330653a9633326fc8f362f8384764e98b/cadasta/organization/download/xls.py#L55-L63). The API does not currently support listing Tenure Relationships. It does have a `/api/v1/organizations/:org/projects/:proj/relationships/tenure/` view, however [this view only supports `POST` requests](https://github.com/Cadasta/cadasta-platform/blob/a14f87e330653a9633326fc8f362f8384764e98b/cadasta/party/views/api.py#L191-L199) as it inherits from DRF's `generics.CreateAPIView` class. 

This PR updates the view to inherit from `generics.ListCreateAPIView` to allow for listing of the Tenure Relationships for the purpose of exporting the data as an XLS sheet.  While the needs of #1400 are accomplished by this change, there are also the `../relationships/spatial/` and `../relationships/party/` endpoints that are nearly identical to the `../relationships/tenure/` endpoint. For the sake of consistency, I also updated these endpoints.

This consisted of:
1. Refactoring views to inherit from `generics.CreateAPIView` to `generics.ListCreateAPIView` and renaming the views as follows:
    - `PartyRelationshipCreate` -> `PartyRelationshipList`
    - `SpatialRelationshipCreate` -> `SpatialRelationshipList`
    - `TenureRelationshipCreate` -> `TenureRelationshipList`
1. Each of these views used a `*WriteSerializer`, which no longer made sense. Serializers were renamed as follows:
    - `PartyRelationshipWriteSerializer` -> `PartyRelationshipSerializer`
    - `SpatialRelationshipWriteSerializer` -> `SpatialRelationshipSerializer`
    - `TenureRelationshipWriteSerializer` -> `TenureRelationshipSerializer`
1. All of the views also had a separate detail view (e.g. `/api/v1/organizations/<organization>/projects/<project>/relationships/spatial/<spatial_rel_id>/`). These views only supported `GET` requests and had a separate serializer, `*ReadSerializer`. After adding list views for each model type, this became a bit awkward since both the list and detail views supported read operations. To remedy list, these serializers were renamed as follows:
    - `PartyRelationshipReadSerializer` -> `PartyRelationshipDetailSerializer`
    - `SpatialRelationshipReadSerializer` -> `SpatialRelationshipDetailSerializer`
    - `TenureRelationshipReadSerializer` -> `TenureRelationshipDetailSerializer`

Before:

endpoint | view | name
--- | --- | ---
`/api/v1/organizations/<organization>/projects/<project>/relationships/party/` | `party.views.api.PartyRelationshipCreate` | `api:v1:relationship:party_rel_create`
`/api/v1/organizations/<organization>/projects/<project>/relationships/party/<party_rel_id>/` | `party.views.api.PartyRelationshipDetail` | `api:v1:relationship:party_rel_detail`
`/api/v1/organizations/<organization>/projects/<project>/relationships/spatial/` | `spatial.views.api.SpatialRelationshipCreate` | `api:v1:relationship:spatial_rel_create`
`/api/v1/organizations/<organization>/projects/<project>/relationships/spatial/<spatial_rel_id>/` | `spatial.views.api.SpatialRelationshipDetail` | `api:v1:relationship:spatial_rel_detail`
`/api/v1/organizations/<organization>/projects/<project>/relationships/tenure/` | `party.views.api.TenureRelationshipCreate` | `api:v1:relationship:tenure_rel_create`
`/api/v1/organizations/<organization>/projects/<project>/relationships/tenure/<tenure_rel_id>/` | `party.views.api.TenureRelationshipDetail` | `api:v1:relationship:tenure_rel_detail`

After:

endpoint | view | name
--- | --- | ---
`/api/v1/organizations/<organization>/projects/<project>/relationships/party/` | `party.views.api.PartyRelationshipList` | `api:v1:relationship:party_rel_list`
`/api/v1/organizations/<organization>/projects/<project>/relationships/party/<party_rel_id>/` | `party.views.api.PartyRelationshipDetail` | `api:v1:relationship:party_rel_detail`
`/api/v1/organizations/<organization>/projects/<project>/relationships/spatial/` | `spatial.views.api.SpatialRelationshipList` | `api:v1:relationship:spatial_rel_list`
`/api/v1/organizations/<organization>/projects/<project>/relationships/spatial/<spatial_rel_id>/` | `spatial.views.api.SpatialRelationshipDetail` | `api:v1:relationship:spatial_rel_detail`
`/api/v1/organizations/<organization>/projects/<project>/relationships/tenure/` | `party.views.api.TenureRelationshipList` | `api:v1:relationship:tenure_rel_list`
`/api/v1/organizations/<organization>/projects/<project>/relationships/tenure/<tenure_rel_id>/` | `party.views.api.TenureRelationshipDetail` | `api:v1:relationship:tenure_rel_detail`


### When should this PR be merged

This is independently deployable from #1400, so as soon as possible is fine. Being that this is a requirement of #1400, #1400 can't be completed without this feature.

### Risks

None foreseen, this only adds new functionality, does not alter existing functionality.

### Follow-up actions

-


### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
