### PR TITLE
Async: Add link field to resources API

### DIFF
--- a/cadasta/resources/serializers.py
+++ b/cadasta/resources/serializers.py
@@ -7,13 +7,24 @@ from core.serializers import SanitizeFieldSerializer
 from .models import ContentObject, Resource, SpatialResource
 
 
+class ContentObjectSerializer(serializers.ModelSerializer):
+    id = serializers.CharField(source='object_id')
+    type = serializers.CharField(source='content_type.model')
+
+    class Meta:
+        model = ContentObject
+        fields = ('id', 'type')
+
+
 class ResourceSerializer(SanitizeFieldSerializer, serializers.ModelSerializer):
     file = S3Field()
+    links = ContentObjectSerializer(
+        many=True, required=False, source='content_objects')
 
     class Meta:
         model = Resource
         fields = ('id', 'name', 'description', 'file', 'original_file',
-                  'archived', 'mime_type', )
+                  'archived', 'mime_type', 'links')
         read_only_fields = ('id', )
         extra_kwargs = {'mime_type': {'required': False}}
 

--- a/cadasta/resources/views/api.py
+++ b/cadasta/resources/views/api.py
@@ -41,6 +41,10 @@ class ProjectResources(APIPermissionRequiredMixin,
     permission_filter_queryset = filter_archived_resources
     use_resource_library_queryset = True
 
+    def get_queryset(self):
+        return super().get_queryset().prefetch_related(
+            'content_objects__content_type')
+
 
 class ProjectResourcesDetail(APIPermissionRequiredMixin,
                              mixins.ResourceObjectMixin,


### PR DESCRIPTION
### Proposed changes in this pull request

_NOTE: This PR works towards the goals of #1400_

The export operation currently [records the relationships between Resources and system records](https://github.com/Cadasta/cadasta-platform/blob/a14f87e330653a9633326fc8f362f8384764e98b/cadasta/organization/download/resources.py#L32-L43). The API does not currently support listing links between Resources and other records, unless we tested every record individually (e.g. accessing the `/parties/<party>/resources/` endpoint).  This PR adds a `links` field to the `ProjectResources` API view.

### When should this PR be merged

This is independently deployable from #1400, so as soon as possible is fine. Being that this is a requirement of #1400, #1400 can't be completed without this feature.

### Risks

None foreseen, this only adds new functionality, does not alter existing functionality.

### Follow-up actions

- [ ] Update API documentation to describe new fields


### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
