### PR TITLE
Async: Configure DB and Cadasta Platform dev VM to support async workers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Install:
     * Version 1.8.1
     * If you are behind a proxy, you may need to install and configure the `vagrant-proxyconf <https://rubygems.org/gems/vagrant-proxyconf/versions/1.5.2>`_ plugin
 * `Ansible <http://www.ansible.com/>`_
-    * Version 2.1.3.0
+    * Version 2.2+
     * For Linux and Mac, install Ansible 2 via pip
     * For Windows (unsupported), go through `Ansible Documentation <http://docs.ansible.com/ansible/intro_windows.html>`_ or this `blog <https://www.jeffgeerling.com/blog/running-ansible-within-windows>`_
 
@@ -29,9 +29,9 @@ Provision the VM::
 SSH into the VM (automatically activates the Python virtual environment)::
 
   vagrant ssh
-  
-Enter the cadasta directory and start the server:: 
- 
+
+Enter the cadasta directory and start the server::
+
   cd cadasta
   ./runserver
 
@@ -64,8 +64,8 @@ Do this::
   ...
 
   vagrant up --provider=aws ...
-  
-  
+
+
 .. |build-status-image| image:: https://secure.travis-ci.org/Cadasta/cadasta-platform.svg?branch=master
    :target: http://travis-ci.org/Cadasta/cadasta-platform?branch=master
 .. |req-status-image| image:: https://requires.io/github/Cadasta/cadasta-platform/requirements.svg?branch=master

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.box = "ubuntu/trusty64"
   config.vm.network "forwarded_port", guest: 8000, host: 8000
+  config.vm.network "forwarded_port", guest: 5432, host: 5433
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "2048"

--- a/cadasta/tasks/migrations/0001_initial.py
+++ b/cadasta/tasks/migrations/0001_initial.py
@@ -56,4 +56,9 @@ class Migration(migrations.Migration):
                 'db_table': 'celery_taskmeta',
             },
         ),
+        # Set sequence name to match sequence expected by Celery DB Result Backend
+        migrations.RunSQL(
+            [("ALTER SEQUENCE celery_taskmeta_id_seq RENAME TO task_id_sequence;")],
+            [("ALTER SEQUENCE task_id_sequence RENAME TO celery_taskmeta_id_seq;")]
+        ),
     ]

--- a/provision/roles/cadasta/application/tasks/main.yml
+++ b/provision/roles/cadasta/application/tasks/main.yml
@@ -95,6 +95,10 @@
                  virtualenv="{{ virtualenv_path }}"
                  settings="{{ django_settings }}"
 
+- name: Trigger "migrations called" signal
+  command: echo "Migrations have been called"
+  notify: migrations called
+
 - name: Install Bootstrap for SASS processing
   become: yes
   become_user: "{{ app_user }}"

--- a/provision/roles/db/development/files/pg_hba.conf
+++ b/provision/roles/db/development/files/pg_hba.conf
@@ -89,7 +89,8 @@ local   all             postgres                                peer
 # "local" is for Unix domain socket connections only
 local   all             all                                     md5
 # IPv4 local connections:
-host    all             all             127.0.0.1/32            md5
+host    all             all             0.0.0.0/0               md5
+host    all             all             ::/0                    md5
 # IPv6 local connections:
 host    all             all             ::1/128                 md5
 # Allow replication connections from localhost, by a user with the

--- a/provision/roles/db/development/files/postgresql.conf
+++ b/provision/roles/db/development/files/postgresql.conf
@@ -1,0 +1,609 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, or use "pg_ctl reload".  Some
+# parameters, which are marked below, require a server shutdown and restart to
+# take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  kB = kilobytes        Time units:  ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+data_directory = '/var/lib/postgresql/9.4/main'		# use data in another directory
+					# (change requires restart)
+hba_file = '/etc/postgresql/9.4/main/pg_hba.conf'	# host-based authentication file
+					# (change requires restart)
+ident_file = '/etc/postgresql/9.4/main/pg_ident.conf'	# ident configuration file
+					# (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+external_pid_file = '/var/run/postgresql/9.4-main.pid'			# write an extra PID file
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+#listen_addresses = 'localhost'		# what IP address(es) to listen on;
+listen_addresses = '*'
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
+port = 5432				# (change requires restart)
+max_connections = 100			# (change requires restart)
+#superuser_reserved_connections = 3	# (change requires restart)
+unix_socket_directories = '/var/run/postgresql'	# comma-separated list of directories
+					# (change requires restart)
+#unix_socket_group = ''			# (change requires restart)
+#unix_socket_permissions = 0777		# begin with 0 to use octal notation
+					# (change requires restart)
+#bonjour = off				# advertise server via Bonjour
+					# (change requires restart)
+#bonjour_name = ''			# defaults to the computer name
+					# (change requires restart)
+
+# - Security and Authentication -
+
+#authentication_timeout = 1min		# 1s-600s
+ssl = true				# (change requires restart)
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
+					# (change requires restart)
+#ssl_prefer_server_ciphers = on		# (change requires restart)
+#ssl_ecdh_curve = 'prime256v1'		# (change requires restart)
+#ssl_renegotiation_limit = 0		# amount of data between renegotiations
+ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'		# (change requires restart)
+ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'		# (change requires restart)
+#ssl_ca_file = ''			# (change requires restart)
+#ssl_crl_file = ''			# (change requires restart)
+#password_encryption = on
+#db_user_namespace = off
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = ''
+#krb_caseins_users = off
+
+# - TCP Keepalives -
+# see "man 7 tcp" for details
+
+#tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_count = 0		# TCP_KEEPCNT;
+					# 0 selects the system default
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = 128MB			# min 128kB
+					# (change requires restart)
+#huge_pages = try			# on, off, or try
+					# (change requires restart)
+#temp_buffers = 8MB			# min 800kB
+#max_prepared_transactions = 0		# zero disables the feature
+					# (change requires restart)
+# Caution: it is not advisable to set max_prepared_transactions nonzero unless
+# you actively intend to use prepared transactions.
+#work_mem = 4MB				# min 64kB
+#maintenance_work_mem = 64MB		# min 1MB
+#autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
+#max_stack_depth = 2MB			# min 100kB
+dynamic_shared_memory_type = posix	# the default is the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# use none to disable dynamic shared memory
+
+# - Disk -
+
+#temp_file_limit = -1			# limits per-session temp file space
+					# in kB, or -1 for no limit
+
+# - Kernel Resource Usage -
+
+#max_files_per_process = 1000		# min 25
+					# (change requires restart)
+#shared_preload_libraries = ''		# (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0			# 0-100 milliseconds
+#vacuum_cost_page_hit = 1		# 0-10000 credits
+#vacuum_cost_page_miss = 10		# 0-10000 credits
+#vacuum_cost_page_dirty = 20		# 0-10000 credits
+#vacuum_cost_limit = 200		# 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms			# 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100		# 0-1000 max buffers written/round
+#bgwriter_lru_multiplier = 2.0		# 0-10.0 multipler on buffers scanned/round
+
+# - Asynchronous Behavior -
+
+#effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
+#max_worker_processes = 8
+
+
+#------------------------------------------------------------------------------
+# WRITE AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+#wal_level = minimal			# minimal, archive, hot_standby, or logical
+					# (change requires restart)
+#fsync = on				# turns forced synchronization on or off
+#synchronous_commit = on		# synchronization level;
+					# off, local, remote_write, or on
+#wal_sync_method = fsync		# the default is the first option
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync (default on Linux)
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
+#full_page_writes = on			# recover from partial page writes
+#wal_log_hints = off			# also do full page writes of non-critical updates
+					# (change requires restart)
+#wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
+					# (change requires restart)
+#wal_writer_delay = 200ms		# 1-10000 milliseconds
+
+#commit_delay = 0			# range 0-100000, in microseconds
+#commit_siblings = 5			# range 1-1000
+
+# - Checkpoints -
+
+#checkpoint_segments = 3		# in logfile segments, min 1, 16MB each
+#checkpoint_timeout = 5min		# range 30s-1h
+#checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
+#checkpoint_warning = 30s		# 0 disables
+
+# - Archiving -
+
+#archive_mode = off		# allows archiving to be done
+				# (change requires restart)
+#archive_command = ''		# command to use to archive a logfile segment
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0		# force a logfile segment switch after this
+				# number of seconds; 0 disables
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Server(s) -
+
+# Set these on the master and on any standby that will send replication data.
+
+#max_wal_senders = 0		# max number of walsender processes
+				# (change requires restart)
+#wal_keep_segments = 0		# in logfile segments, 16MB each; 0 disables
+#wal_sender_timeout = 60s	# in milliseconds; 0 disables
+
+#max_replication_slots = 0	# max number of replication slots
+				# (change requires restart)
+
+# - Master Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = ''	# standby servers that provide sync rep
+				# comma-separated list of application_name
+				# from standby(s); '*' = all
+#vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
+
+# - Standby Servers -
+
+# These settings are ignored on a master server.
+
+#hot_standby = off			# "on" allows queries during recovery
+					# (change requires restart)
+#max_standby_archive_delay = 30s	# max delay before canceling queries
+					# when reading WAL from archive;
+					# -1 allows indefinite delay
+#max_standby_streaming_delay = 30s	# max delay before canceling queries
+					# when reading streaming WAL;
+					# -1 allows indefinite delay
+#wal_receiver_status_interval = 10s	# send replies at least this often
+					# 0 disables
+#hot_standby_feedback = off		# send info from standby to prevent
+					# query conflicts
+#wal_receiver_timeout = 60s		# time that receiver waits for
+					# communication from master
+					# in milliseconds; 0 disables
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_bitmapscan = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0			# measured on an arbitrary scale
+#random_page_cost = 4.0			# same scale as above
+#cpu_tuple_cost = 0.01			# same scale as above
+#cpu_index_tuple_cost = 0.005		# same scale as above
+#cpu_operator_cost = 0.0025		# same scale as above
+#effective_cache_size = 4GB
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5			# range 1-10
+#geqo_pool_size = 0			# selects default based on effort
+#geqo_generations = 0			# selects default based on effort
+#geqo_selection_bias = 2.0		# range 1.5-2.0
+#geqo_seed = 0.0			# range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100	# range 1-10000
+#constraint_exclusion = partition	# on, off, or partition
+#cursor_tuple_fraction = 0.1		# range 0.0-1.0
+#from_collapse_limit = 8
+#join_collapse_limit = 8		# 1 disables collapsing of explicit
+					# JOIN clauses
+
+
+#------------------------------------------------------------------------------
+# ERROR REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'		# Valid values are combinations of
+					# stderr, csvlog, syslog, and eventlog,
+					# depending on platform.  csvlog
+					# requires logging_collector to be on.
+
+# This is used when logging to stderr:
+#logging_collector = off		# Enable capturing of stderr and csvlog
+					# into log files. Required to be on for
+					# csvlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'pg_log'		# directory where log files are written,
+					# can be absolute or relative to PGDATA
+#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'	# log file name pattern,
+					# can include strftime() escapes
+#log_file_mode = 0600			# creation mode for log files,
+					# begin with 0 to use octal notation
+#log_truncate_on_rotation = off		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
+#log_rotation_age = 1d			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+#log_rotation_size = 10MB		# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+
+# This is only relevant when logging to eventlog (win32):
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#client_min_messages = notice		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
+
+#log_min_messages = warning		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
+
+#log_min_error_statement = error	# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+#log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
+
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default		# terse, default, or verbose messages
+#log_hostname = off
+log_line_prefix = '%m [%p] %q%u@%d '			# special values:
+					#   %a = application name
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %p = process ID
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %i = command tag
+					#   %e = SQL state
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
+#log_lock_waits = off			# log lock waits >= deadlock_timeout
+#log_statement = 'none'			# none, ddl, mod, all
+#log_temp_files = -1			# log temporary files equal or larger
+					# than the specified size in kilobytes;
+					# -1 disables, 0 logs all temp files
+log_timezone = 'UTC'
+
+
+#------------------------------------------------------------------------------
+# RUNTIME STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query/Index Statistics Collector -
+
+#track_activities = on
+#track_counts = on
+#track_io_timing = off
+#track_functions = none			# none, pl, all
+#track_activity_query_size = 1024	# (change requires restart)
+#update_process_title = on
+stats_temp_directory = '/var/run/postgresql/9.4-main.pg_stat_tmp'
+
+
+# - Statistics Monitoring -
+
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+#log_statement_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM PARAMETERS
+#------------------------------------------------------------------------------
+
+#autovacuum = on			# Enable autovacuum subprocess?  'on'
+					# requires track_counts to also be on.
+#log_autovacuum_min_duration = -1	# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least this number
+					# of milliseconds.
+#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+					# (change requires restart)
+#autovacuum_naptime = 1min		# time between autovacuum runs
+#autovacuum_vacuum_threshold = 50	# min number of row updates before
+					# vacuum
+#autovacuum_analyze_threshold = 50	# min number of row updates before
+					# analyze
+#autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
+#autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
+					# (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000	# maximum multixact age
+					# before forced vacuum
+					# (change requires restart)
+#autovacuum_vacuum_cost_delay = 20ms	# default vacuum cost delay for
+					# autovacuum, in milliseconds;
+					# -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#search_path = '"$user",public'		# schema names
+#default_tablespace = ''		# a tablespace name, '' uses the default
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
+					# only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0			# in milliseconds, 0 is disabled
+#lock_timeout = 0			# in milliseconds, 0 is disabled
+#vacuum_freeze_min_age = 50000000
+#vacuum_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_freeze_table_age = 150000000
+#bytea_output = 'hex'			# hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+#gin_fuzzy_search_limit = 0
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+timezone = 'UTC'
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia (historical usage)
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
+#extra_float_digits = 0			# min -15, max 3
+#client_encoding = sql_ascii		# actually, defaults to database
+					# encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'en_US.UTF-8'			# locale for system error message
+					# strings
+lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
+lc_numeric = 'en_US.UTF-8'			# locale for number formatting
+lc_time = 'en_US.UTF-8'				# locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64		# min 10
+					# (change requires restart)
+#max_pred_locks_per_transaction = 64	# min 10
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# VERSION/PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding	# on, off, or safe_encoding
+#default_with_oids = off
+#escape_string_warning = on
+#lo_compat_privileges = off
+#quote_all_identifiers = off
+#sql_inheritance = on
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off			# terminate session on any error?
+#restart_after_crash = on		# reinitialize after backend crash?
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.
+
+#include_dir = 'conf.d'			# include files ending in '.conf' from
+					# directory 'conf.d'
+#include_if_exists = 'exists.conf'	# include file only if it exists
+#include = 'special.conf'		# include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/provision/roles/db/development/handlers/main.yml
+++ b/provision/roles/db/development/handlers/main.yml
@@ -3,7 +3,7 @@
   become_user: postgres
   postgresql_privs: role="worker"
                     privs="SELECT,INSERT,UPDATE"
-                    objs="celery_taskmeta,celery_tasksetmeta"
+                    objs="celery_taskmeta"
                     db="cadasta"
   listen: migrations called
 

--- a/provision/roles/db/development/handlers/main.yml
+++ b/provision/roles/db/development/handlers/main.yml
@@ -1,0 +1,19 @@
+- name: Configure worker table priviliges
+  become: yes
+  become_user: postgres
+  postgresql_privs: role="worker"
+                    privs="SELECT,INSERT,UPDATE"
+                    objs="celery_taskmeta,celery_tasksetmeta"
+                    db="cadasta"
+  listen: migrations called
+
+- name: Configure worker sequence priviliges
+  become: yes
+  become_user: postgres
+  postgresql_privs: role="worker"
+                    priv="USAGE"
+                    objs="task_id_sequence,taskset_id_sequence"
+                    type="sequence"
+                    db="cadasta"
+  listen:
+    - migrations called

--- a/provision/roles/db/development/handlers/main.yml
+++ b/provision/roles/db/development/handlers/main.yml
@@ -1,4 +1,4 @@
-- name: Configure worker table priviliges
+- name: Configure worker table privileges
   become: yes
   become_user: postgres
   postgresql_privs: role="worker"
@@ -7,12 +7,12 @@
                     db="cadasta"
   listen: migrations called
 
-- name: Configure worker sequence priviliges
+- name: Configure worker sequence privileges
   become: yes
   become_user: postgres
   postgresql_privs: role="worker"
                     priv="USAGE"
-                    objs="task_id_sequence,taskset_id_sequence"
+                    objs="task_id_sequence"
                     type="sequence"
                     db="cadasta"
   listen:

--- a/provision/roles/db/development/tasks/main.yml
+++ b/provision/roles/db/development/tasks/main.yml
@@ -9,11 +9,17 @@
       - libpq-dev # Required for Ansible to interact with postgres
       - python-psycopg2 # Required for Ansible to interact with postgres
 
-- name: Allow password authentication for local socket users
+- name: Allow password authentication for local/remote socket users
   become: yes
   become_user: root
   register: pg_hba
   copy: src=pg_hba.conf dest=/etc/postgresql/9.4/main/pg_hba.conf force=yes
+
+- name: Listen for external connections
+  become: yes
+  become_user: root
+  register: postgresql_conf
+  copy: src=postgresql.conf dest=/etc/postgresql/9.4/main/postgresql.conf force=yes
 
 - name: Restart Postgres
   become: yes
@@ -24,7 +30,7 @@
 - name: Create database
   become: yes
   become_user: postgres
-  postgresql_db: login_user="postgres" name="cadasta"
+  postgresql_db: name="cadasta"
 
 # This test is needed because of a bad interaction between the way
 # that the Ansible postgresql_user modules works and the way that
@@ -41,19 +47,22 @@
 - name: Create database user
   become: yes
   become_user: postgres
-  postgresql_user: login_user="postgres"
-                   name="cadasta" password="cadasta"
+  postgresql_user: name="cadasta" password="cadasta"
                    state=present role_attr_flags=SUPERUSER,CREATEDB
   when: user_test.stdout.find('0') != -1
 
 - name: Provide user with DB permissions
   become: yes
   become_user: postgres
-  postgresql_user: login_user="postgres"
-                   user="cadasta" db="cadasta" priv=ALL
+  postgresql_user: user="cadasta" db="cadasta" priv=ALL
 
 - name: Install PostGIS on DB
   become: yes
   become_user: postgres
-  postgresql_ext: login_user="postgres"
-                  name=postgis db="cadasta"
+  postgresql_ext: name=postgis db="cadasta"
+
+- name: Create worker user
+  become: yes
+  become_user: postgres
+  postgresql_user: name="worker" password="cadasta"
+                   state=present

--- a/provision/roles/db/production/handlers/main.yml
+++ b/provision/roles/db/production/handlers/main.yml
@@ -1,0 +1,21 @@
+- name: Configure worker table priviliges
+  become: yes
+  postgresql_privs: login_host="{{ db_host }}"
+                    login_user="postgres" login_password="postgres"
+                    role="worker"
+                    privs="SELECT,INSERT,UPDATE"
+                    objs="celery_taskmeta,celery_tasksetmeta"
+                    db="cadasta"
+  listen: migrations called
+
+- name: Configure worker sequence priviliges
+  become: yes
+  postgresql_privs: login_host="{{ db_host }}"
+                    login_user="postgres" login_password="postgres"
+                    role="worker"
+                    priv="USAGE"
+                    objs="task_id_sequence,taskset_id_sequence"
+                    type="sequence"
+                    db="cadasta"
+  listen:
+    - migrations called

--- a/provision/roles/db/production/handlers/main.yml
+++ b/provision/roles/db/production/handlers/main.yml
@@ -4,7 +4,7 @@
                     login_user="postgres" login_password="postgres"
                     role="worker"
                     privs="SELECT,INSERT,UPDATE"
-                    objs="celery_taskmeta,celery_tasksetmeta"
+                    objs="celery_taskmeta"
                     db="cadasta"
   listen: migrations called
 

--- a/provision/roles/db/production/handlers/main.yml
+++ b/provision/roles/db/production/handlers/main.yml
@@ -1,4 +1,4 @@
-- name: Configure worker table priviliges
+- name: Configure worker table privileges
   become: yes
   postgresql_privs: login_host="{{ db_host }}"
                     login_user="postgres" login_password="postgres"
@@ -8,13 +8,13 @@
                     db="cadasta"
   listen: migrations called
 
-- name: Configure worker sequence priviliges
+- name: Configure worker sequence privileges
   become: yes
   postgresql_privs: login_host="{{ db_host }}"
                     login_user="postgres" login_password="postgres"
                     role="worker"
                     priv="USAGE"
-                    objs="task_id_sequence,taskset_id_sequence"
+                    objs="task_id_sequence"
                     type="sequence"
                     db="cadasta"
   listen:

--- a/provision/roles/db/production/tasks/main.yml
+++ b/provision/roles/db/production/tasks/main.yml
@@ -40,3 +40,10 @@
   postgresql_ext: login_host="{{ db_host }}"
                   login_user="postgres" login_password="postgres"
                   name=postgis db="cadasta"
+
+- name: Create worker user
+  postgresql_user: login_host="{{ db_host }}"
+                   login_user="postgres" login_password="postgres"
+                   name="worker" password="cadasta"
+                   state=present role_attr_flags=NOSUPERUSER
+  when: user_test.stdout.find('0') != -1

--- a/provision/roles/webserver/production/templates/uwsgi.ini
+++ b/provision/roles/webserver/production/templates/uwsgi.ini
@@ -37,3 +37,4 @@ env = OPBEAT_APPID={{ opbeat_appID }}
 env = OPBEAT_TOKEN={{ opbeat_token }}
 env = SLACK_HOOK={{ slack_hook }}
 env = QUEUE_PREFIX={{ identifier }}
+env = RESULT_DB_HOST={{ db_host }}


### PR DESCRIPTION
### Proposed changes in this pull request

_NOTE: This PR works towards the goals of #1400_

Our asynchronous task consumers need to be able to access the Cadasta DB in order to record task results. This PR includes changes that ensure that:

1. The dev VM exposes its DB to the host machine. This is done by altering the Vagrantfile to port-forward Postgres' port (`5432`) to host machine (`5433`). This is helpful when running a worker on the host machine.
1. The results tables of the database are set up in accordance to the expectations of the Celery database result backend. This required renaming the sequence generated by Django to match the sequence expected by Celery.
1. A DB user is created via Ansible in both dev and production environments. This DB worker should only have access to Create, Read, and Update task results and to increment the sequences responsible for generating IDs of new TaskResults. This command runs every time a machine is provisioned or a codebase is deployed. Given that Ansible aims to be idempotent, no harm will come if the users/permissions are already present in the database.
1. The `uwsgi` process serving our application in production has awareness of the [`RESULT_DB_*`](https://github.com/Cadasta/cadasta-workertoolbox#result_db_user) settings. Currently, I've only set the `RESULT_DB_HOST` value, although we probably should set the others as well. I'm not really sure how this should be done and am looking for input.


To test, you can checkout the [export-worker](https://github.com/Cadasta/cadasta-export-worker) and process the message. Assuming that you have SQS access, you'll need to:
1. Reprovision your Vagrant VM (`vagrant provision`)
1. Schedule a task (`python -c "from app.celery import app; from cadasta.workertoolbox.setup import setup_app; setup_app(app); app.send_task('export.project')"`) (note that this will fail as the proper arguments are not provided. the failure should still be logged in the DB)
1. Run the worker `RESULT_DB_PORT=5433 S3_BUCKET=my_bucket ./startworker -l INFO`
1. Either run `SQS=1 ./manage.py sync_tasks` in your VagrantVM or check the `celery_taskmeta` table for results. The later is probably easier, as it does not require you to have SQS access on the Vagrant VM.

If you don't have SQS access, you can install RabbitMQ and use that. This will require you to override the [`broker_transport`](https://github.com/Cadasta/cadasta-workertoolbox#broker_transport) to something like `'amqp://myuser:mypassword@localhost:5672/myvhost'` when running both scheduling the task and running the worker. (actually, after writing this, I realize that we don't currently support overriding the [`broker_transport` variable](https://github.com/Cadasta/cadasta-workertoolbox/blob/master/cadasta/workertoolbox/conf.py#L14). This could be a quick change if need be)

If you want the tasks to actually succeed, you will also need to:
* run the [zipstream service](https://github.com/ZipStream).
* ensure the `ZIPSTREAM_URL` and `PLATFORM_URL` env variables are set if [the default values](https://github.com/Cadasta/cadasta-export-worker/blob/master/app/settings.py#L4-L7) are not correct for your setup.
* set the `S3_BUCKET` env variable to a bucket that you have permissions to access. This will be the bucket that will receive generated export files.


### When should this PR be merged

This PR is a requirement for #1400.

### Risks

There is a change to `tasks/migrations/0001_initial.py`, however being that this PR is pointed at `feature/async`, I believe that this is acceptable.

Questions:

* Do we manage security groups via any configuration management tooling? Currently, no work has been done to ensure that RDS permits access to the workers via its security groups
* How should I approach setting the other `RESULT_DB_*` config variables on the `uwsgi` server? @amplifi mentioned that the DB passwords are overwritten at deployment. I'm not really quite sure how this works, we would need access to that new value. I would imagine it would take place around [here](https://github.com/Cadasta/cadasta-platform/blob/async%2Fconfigure-db-access/deployment/scripts/deploy#L227-L236) however I'm not seeing it...

### Follow-up actions

See #1400 for followup tasks.

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
