### PR TITLE
Permissions org views

### DIFF
--- a/cadasta/config/permissions/group-policies.json
+++ b/cadasta/config/permissions/group-policies.json
@@ -14,7 +14,7 @@
     }, {
         "group": "OrgMember",
         "permissions": [
-            "org.create", "org.view", "org.view.private",
+            "org.create", "org.view", "org.view.private",  "org.users.list",
             "org.list", "project.view", "project.view.private", "project.list"
         ]
     }, {

--- a/cadasta/core/mixins.py
+++ b/cadasta/core/mixins.py
@@ -37,14 +37,6 @@ class PermissionRequiredMixin(mixins.PermissionRequiredMixin):
                         kwargs={'slug': self.kwargs['organization']}
                     )
 
-            elif 'slug' in self.kwargs:
-                redirect_url = reverse(
-                    'organization:dashboard',
-                    kwargs={'slug': self.kwargs['slug']}
-                )
-                if redirect_url == self.request.get_full_path():
-                    redirect_url = reverse('core:dashboard')
-
         return redirect(redirect_url)
 
 
@@ -59,8 +51,6 @@ def update_permissions(permission, obj=None):
                 self.get_organization().archived):
             return False
         if (hasattr(self, 'get_project') and self.get_project().archived):
-            return False
-        if obj and self.get_object().archived:
             return False
         return permission
     return set_permissions

--- a/cadasta/core/tests/test_auth.py
+++ b/cadasta/core/tests/test_auth.py
@@ -1,0 +1,345 @@
+import pytest
+from django.http import HttpRequest
+from django.test import TestCase
+from django.views.generic import View
+from django.core.exceptions import PermissionDenied, ImproperlyConfigured
+from django.core.urlresolvers import reverse
+from django.contrib.messages.storage.fallback import FallbackStorage
+from skivvy import ViewTestCase
+
+from accounts.tests.factories import UserFactory
+from core.tests.utils.cases import UserTestCase
+from ..views.auth import LoginRequiredMixin, PermissionRequiredMixin
+
+
+class LoginRequiredTest(ViewTestCase, TestCase):
+    def test_raise_permission_denied(self):
+        """
+        View should raise PermissionDenied if user is not logged in and
+        raise_exception equals True.
+        """
+        class TestView(LoginRequiredMixin, View):
+            raise_exception = True
+
+        self.view_class = TestView
+
+        with pytest.raises(PermissionDenied):
+            self.request()
+
+    def test_redirect_to_login(self):
+        """
+        View should redirect to login page if user is not logged in and
+        raise_exception is not defined.
+        """
+        class TestView(LoginRequiredMixin, View):
+            pass
+
+        self.view_class = TestView
+
+        response = self.request()
+        assert response.status_code == 302
+        assert 'account/login' in response.location
+
+
+class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
+    def test_permission_required_not_defined(self):
+        """
+        If neither permission_required is defined or get_permission_required is
+        implemented ImproperlyConfigured must be raised
+        """
+        class TestView(PermissionRequiredMixin, View):
+            pass
+
+        view = TestView()
+        with pytest.raises(ImproperlyConfigured):
+            view.get_permission_required()
+
+    def test_permission_required_defined(self):
+        """
+        If permission_required is defined, its value should be returned when
+        calling get_permission_required
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = 'some.perm'
+
+        view = TestView()
+        assert view.get_permission_required() == 'some.perm'
+
+    def test_get_permission_required_defined(self):
+        """
+        If get_permission_required is implemented it has prefenence over
+        permission_required.
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = 'some.perm'
+
+            def get_permission_required(self):
+                return 'other.perm'
+
+        view = TestView()
+        assert view.get_permission_required() == 'other.perm'
+
+    def test_get_perms_not_defined(self):
+        """
+        Instances of PermissionRequiredMixin must implement get_perms
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = ['some.perm', 'other.perm']
+
+        view = TestView()
+        with pytest.raises(ImproperlyConfigured):
+            view.test_func()
+
+    def test_test_func_with_string(self):
+        """
+        permission_required can be defined as a string
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = 'some.perm'
+
+            def get_perms(self):
+                return ('some.perm', )
+
+        view = TestView()
+        assert view.test_func() is True
+
+    def test_test_func_with_tuple(self):
+        """
+        permission_required can be defined as a tuple
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = ('some.perm', 'other.perm')
+
+            def get_perms(self):
+                return ('some.perm', 'other.perm')
+
+        view = TestView()
+        assert view.test_func() is True
+
+    def test_test_func_with_list(self):
+        """
+        permission_required can be defined as a list
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = ['some.perm', 'other.perm']
+
+            def get_perms(self):
+                return ('some.perm', 'other.perm')
+
+        view = TestView()
+        assert view.test_func() is True
+
+    def test_test_func_permission_denied(self):
+        """
+        The permission returned from get_perms does not match the one defined
+        in permission_required.
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = 'some.perm'
+
+            def get_perms(self):
+                return ('other.perm', )
+
+        view = TestView()
+        assert view.test_func() is False
+
+    def test_test_func_permission_denied_with_list(self):
+        """
+        All permissions defined in permission_required must be present in the
+        return value of get_perms.
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = ['some.perm', 'other.perm']
+
+            def get_perms(self):
+                return ('some.perm', 'another.perm')
+
+        view = TestView()
+        assert view.test_func() is False
+
+    def test_test_func_permission_denied_only_one_perm(self):
+        """
+        All permissions defined in permission_required must be present in the
+        return value of get_perms.
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = ['some.perm', 'other.perm']
+
+            def get_perms(self):
+                return ('some.perm', )
+
+        view = TestView()
+        assert view.test_func() is False
+
+    def test_raise_permission_denied(self):
+        """
+        View should raise PermissionDenied if required permissions are not met
+        and raise_exception equals True.
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = 'some.perm'
+            raise_exception = True
+
+            def get_perms(self):
+                return ('other.perm', )
+
+        self.view_class = TestView
+
+        user = UserFactory.create()
+        referer = '/organizations/abc/projects/123'
+
+        with pytest.raises(PermissionDenied):
+            self.request(user=user, request_meta={'HTTP_REFERER': referer})
+
+    def test_login_redirect_to_original_referer(self):
+        """
+        If permissions were denied the view should redirect to the provided
+        referer if the user:
+        - was not refered from the login page
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = 'some.perm'
+
+            def get_perms(self):
+                return ('other.perm', )
+
+        self.view_class = TestView
+
+        user = UserFactory.create()
+        referer = '/organizations/abc/projects/123'
+
+        response = self.request(user=user,
+                                request_meta={'HTTP_REFERER': referer})
+        assert response.status_code == 302
+        assert response.location == referer
+
+    def test_login_redirect_to_project_dashboard(self):
+        """
+        If permissions were denied the view should redirect to the project
+        dashboard if the user:
+        - tries to access a project page other than the project dashboard
+          (incl. location, party and relationship views)
+        - was refered from the login page
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = 'some.perm'
+
+            def get_perms(self):
+                return ('other.perm', )
+
+        self.view_class = TestView
+
+        user = UserFactory.create()
+        referer = '/account/login/'
+        url_kwargs = {'organization': 'abc', 'project': '123'}
+
+        response = self.request(user=user,
+                                request_meta={'HTTP_REFERER': referer},
+                                url_kwargs=url_kwargs)
+
+        exp_redirect = reverse('organization:project-dashboard',
+                               kwargs=url_kwargs)
+        assert response.status_code == 302
+        assert response.location == exp_redirect
+
+    def test_login_redirect_from_project_dashboard_to_org_dashboard(self):
+        """
+        If permissions were denied the view should redirect to the organization
+        dashboard if the user:
+        - tries to access the project dashboard
+        - was refered from the login page
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = 'some.perm'
+
+            def get_perms(self):
+                return ('other.perm', )
+        user = UserFactory.create()
+
+        view = TestView.as_view()
+
+        request = HttpRequest()
+        request.META['HTTP_REFERER'] = '/account/login/'
+        setattr(request, 'user', user)
+        setattr(request, 'method', 'GET')
+
+        setattr(request, 'session', 'session')
+        self.messages = FallbackStorage(request)
+        setattr(request, '_messages', self.messages)
+
+        kwargs = {'organization': 'abc', 'project': '123'}
+
+        def get_full_path():
+            return '/organizations/abc/projects/123/'
+        setattr(request, 'get_full_path', get_full_path)
+
+        exp_redirect = reverse('organization:dashboard', kwargs={
+            'slug': 'abc'})
+        response = view(request, **kwargs)
+        assert response.status_code == 302
+        assert exp_redirect == response['location']
+
+    def test_login_redirect_to_organization_dashboard(self):
+        """
+        If permissions were denied the view should redirect to the organization
+        dashboard if the user:
+        - tries to access an organization page other than the organization
+          dashboard
+        - was refered from the login page
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = 'some.perm'
+
+            def get_perms(self):
+                return ('other.perm', )
+
+        self.view_class = TestView
+
+        user = UserFactory.create()
+        referer = '/account/login/'
+        url_kwargs = {'slug': 'abc'}
+
+        response = self.request(user=user,
+                                request_meta={'HTTP_REFERER': referer},
+                                url_kwargs=url_kwargs)
+
+        exp_redirect = reverse('organization:dashboard',
+                               kwargs=url_kwargs)
+        assert response.status_code == 302
+        assert response.location == exp_redirect
+
+    def test_login_redirect_from_org_dashboard_to_dashboard(self):
+        """
+        If permissions were denied the view should redirect to the platform
+        dashboard if the user:
+        - tries to access the organization dashboard
+        - was refered from the login page
+        """
+        class TestView(PermissionRequiredMixin, View):
+            permission_required = 'some.perm'
+
+            def get_perms(self):
+                return ('other.perm', )
+
+        user = UserFactory.create()
+        view = TestView.as_view()
+
+        request = HttpRequest()
+        request.META['HTTP_REFERER'] = '/account/login/'
+        setattr(request, 'user', user)
+        setattr(request, 'method', 'GET')
+
+        setattr(request, 'session', 'session')
+        self.messages = FallbackStorage(request)
+        setattr(request, '_messages', self.messages)
+
+        kwargs = {'slug': 'abc'}
+
+        def get_full_path():
+            return '/organizations/abc/'
+        setattr(request, 'get_full_path', get_full_path)
+
+        exp_redirect = reverse('core:dashboard')
+        response = view(request, **kwargs)
+        assert response.status_code == 302
+        assert exp_redirect == response['location']

--- a/cadasta/core/tests/test_mixins.py
+++ b/cadasta/core/tests/test_mixins.py
@@ -131,8 +131,7 @@ class PermissionRequiredMixinTest(UserTestCase, TestCase):
 
     def test_login_redirect_from_org_dashboard_to_dashboard(self):
         user = UserFactory.create()
-        assign_user_policies(user, *[])
-        org = OrganizationFactory.create()
+        org = OrganizationFactory.create(archived=True)
         view = org_views.OrganizationDashboard.as_view()
 
         request = HttpRequest()

--- a/cadasta/core/tests/utils/cases.py
+++ b/cadasta/core/tests/utils/cases.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from buckets.test.storage import FakeS3Storage
 from core.tests.factories import PolicyFactory
 from jsonattrs.models import create_attribute_types
+from accounts.management.commands import loadpermissions
 
 
 class UserTestCase:
@@ -10,6 +11,8 @@ class UserTestCase:
         super().setUp()
         PolicyFactory.load_policies()
         create_attribute_types()
+        loadpermissions.create_permissions()
+        loadpermissions.assign_permissions()
 
 
 class FileStorageTestCase:

--- a/cadasta/core/views/auth.py
+++ b/cadasta/core/views/auth.py
@@ -40,6 +40,7 @@ class PermissionRequiredMixin(auth_mixins.UserPassesTestMixin):
 
     Views that use the mixin must implement the method `get_perms`.
     """
+    permission_denied_message = _("You don't have permission for this action.")
 
     def handle_no_permission(self):
         """
@@ -155,7 +156,6 @@ class OrganizationPermissionMixin(PermissionRequiredMixin):
     Mixin that provides the user's permissions for within organization.
     """
     org_slug = 'slug'
-    permission_denied_message = _("You don't have permission for this action.")
 
     def get_perms(self):
         if self.request.user.is_anonymous():

--- a/cadasta/core/views/auth.py
+++ b/cadasta/core/views/auth.py
@@ -53,7 +53,7 @@ class PermissionRequiredMixin(auth_mixins.UserPassesTestMixin):
         - The platform dashboard if the user tried to access an organization
           dashboard
         - The organization dashboard if the user tried to access an
-          organization page or a project dashbaord.
+          organization page or a project dashboard.
         - The project dashboard if the user tried to access a project page.
         """
         if hasattr(self, 'raise_exception') and self.raise_exception:
@@ -116,8 +116,8 @@ class PermissionRequiredMixin(auth_mixins.UserPassesTestMixin):
         """
         An abstract method, which must be overwritten by the implementing view.
 
-        If implemented it should return a list of permission code names the
-        user has for the given view.
+        It should return a list of permission code names the user has for
+        the given view.
         """
         raise ImproperlyConfigured(
             'Instances of PermissionRequiredMixin must implement method '

--- a/cadasta/core/views/auth.py
+++ b/cadasta/core/views/auth.py
@@ -1,0 +1,160 @@
+from django.contrib.auth.models import Group
+from django.contrib.auth import mixins as auth_mixins
+from django.contrib.auth.views import redirect_to_login
+from django.core.exceptions import PermissionDenied, ImproperlyConfigured
+
+from django.core.urlresolvers import reverse
+from django.shortcuts import redirect
+from django.contrib import messages
+from django.utils.translation import gettext as _
+from organization.models import Organization, OrganizationRole
+
+
+class LoginRequiredMixin(auth_mixins.LoginRequiredMixin):
+    """
+    This mixin should be added to views that require a logged-in user.
+
+    We are overwriting Django's default LoginRequiredMixin because it handles
+    unauthenticated users in handle_no_permission, which we overwrite in
+    PermissionRequiredMixin to handle specific redirections based on the users
+    HTTP referer. Both LoginRequiredMixin and PermissionRequiredMixin are used
+    together in many views.
+    """
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated():
+            if hasattr(self, 'raise_exception') and self.raise_exception:
+                raise PermissionDenied(self.get_permission_denied_message())
+
+            return redirect_to_login(self.request.get_full_path(),
+                                     self.get_login_url(),
+                                     self.get_redirect_field_name())
+
+        return super().dispatch(request, *args, **kwargs)
+
+
+class PermissionRequiredMixin(auth_mixins.UserPassesTestMixin):
+    """
+    The mixin should be added to views where a set of permissions need to be
+    fulfilled to access the view. It extends Django's UserPassesTestMixin,
+    which allows us to implement a custom `test_func` to validate permissions.
+
+    Views that use the mixin must implement the method `get_perms`.
+    """
+
+    def handle_no_permission(self):
+        """
+        If permission to access a view was denied the user is redirected to:
+
+        - The previous page if the user did not arrive from the login page.
+
+        Otherwise:
+
+        - The platform dashboard if the user tried to access an organization
+          dashboard
+        - The organization dashboard if the user tried to access an
+          organization page or a project dashbaord.
+        - The project dashboard if the user tried to access a project page.
+        """
+        if hasattr(self, 'raise_exception') and self.raise_exception:
+            raise PermissionDenied(self.permission_denied_message)
+
+        messages.add_message(self.request,
+                             messages.WARNING,
+                             self.permission_denied_message)
+
+        referer = self.request.META.get('HTTP_REFERER')
+        redirect_url = self.request.META.get('HTTP_REFERER', '/')
+
+        if (referer and '/account/login/' in referer and
+                not self.request.user.is_anonymous):
+
+            if 'organization' in self.kwargs and 'project' in self.kwargs:
+                # The user arrived from a project page;
+                # redirect to the project dashboard
+                redirect_url = reverse(
+                    'organization:project-dashboard',
+                    kwargs={'organization': self.kwargs['organization'],
+                            'project': self.kwargs['project']}
+                )
+                if redirect_url == self.request.get_full_path():
+                    # The user arrived from the project dashboard;
+                    # redirect to the project's organization dashboard
+                    redirect_url = reverse(
+                        'organization:dashboard',
+                        kwargs={'slug': self.kwargs['organization']}
+                    )
+
+            elif 'slug' in self.kwargs:
+                # The user arrived from an organization page;
+                # redirect to the organization dashboard
+                redirect_url = reverse(
+                    'organization:dashboard',
+                    kwargs={'slug': self.kwargs['slug']}
+                )
+                if redirect_url == self.request.get_full_path():
+                    redirect_url = reverse('core:dashboard')
+
+        return redirect(redirect_url)
+
+    def get_permission_required(self):
+        """
+        Returns the permissions required for this view.
+
+        For complex permission requirements (i.e. if the required permissions
+        depend on a object's state) this method can be overwritten. Otherwise,
+        the attribute `permission_required` must be defined for the view.
+        """
+        if not hasattr(self, 'permission_required'):
+            raise ImproperlyConfigured(
+                'Instances of PermissionRequiredMixin require either a '
+                'definition of "permission_required" or an implementation of '
+                '"get_permission_required')
+        return self.permission_required
+
+    def get_perms(self):
+        """
+        An abstract method, which must be overwritten by the implementing view.
+
+        If implemented it should return a list of permission code names the
+        user has for the given view.
+        """
+        raise ImproperlyConfigured(
+            'Instances of PermissionRequiredMixin must implement method '
+            '"get_perms"')
+
+    def test_func(self):
+        """
+        Returns True if all required permissions are met by the user's
+        permissions as returned by `get_perms`.
+        """
+        permissions_required = self.get_permission_required()
+        if not isinstance(permissions_required, (list, tuple)):
+            permissions_required = (permissions_required, )
+
+        perms = self.get_perms()
+        return all(perm in perms for perm in permissions_required)
+
+
+class OrganizationPermissionMixin(PermissionRequiredMixin):
+    """
+    Mixin that provides the user's permissions for within organization.
+    """
+    org_slug = 'slug'
+    permission_denied_message = _("You don't have permission for this action.")
+
+    def get_perms(self):
+        if self.request.user.is_anonymous():
+            # The user is not authenticated.
+            group = Group.objects.get(name='AnonymousUser')
+            return group.permissions.values_list('codename', flat=True)
+
+        org = Organization.objects.get(slug=self.kwargs[self.org_slug])
+        try:
+            # The user is member of the organization.
+            role = OrganizationRole.objects.get(organization=org,
+                                                user=self.request.user)
+            return role.group.permissions.values_list('codename', flat=True)
+        except OrganizationRole.DoesNotExist:
+            # The user is authenticated but not member of the organization.
+            group = Group.objects.get(name='PublicUser')
+            return group.permissions.values_list('codename', flat=True)

--- a/cadasta/core/views/auth.py
+++ b/cadasta/core/views/auth.py
@@ -122,7 +122,7 @@ class PermissionRequiredMixin(auth_mixins.UserPassesTestMixin):
             'Instances of PermissionRequiredMixin must implement method '
             '"get_perms"')
 
-    def test_func(self):
+    def has_permission(self):
         """
         Returns True if all required permissions are met by the user's
         permissions as returned by `get_perms`.
@@ -133,6 +133,21 @@ class PermissionRequiredMixin(auth_mixins.UserPassesTestMixin):
 
         perms = self.get_perms()
         return all(perm in perms for perm in permissions_required)
+
+    def test_func(self):
+        """
+        `test_func` is the entry point for UserPassesTestMixin to validate
+        user's permissions on a view.
+
+        It always returns `True` if the user is a superuser (superuser can do
+        everything in the platform); otherwise it returns the value of
+        `has_permission`.
+        """
+        user = self.request.user
+        if not user.is_anonymous and user.is_superuser:
+            return True
+
+        return self.has_permission()
 
 
 class OrganizationPermissionMixin(PermissionRequiredMixin):

--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -3,7 +3,7 @@ import json
 from django.test import TestCase
 from django.contrib.auth.models import AnonymousUser
 
-from tutelary.models import Policy, Role, assign_user_policies
+from tutelary.models import Policy, assign_user_policies
 from skivvy import ViewTestCase
 
 from core.tests.utils.cases import UserTestCase

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -182,7 +182,8 @@ class OrganizationUnarchive(OrgArchiveView):
     do_archive = False
 
 
-class OrganizationMembers(LoginPermissionRequiredMixin,
+class OrganizationMembers(auth.LoginRequiredMixin,
+                          auth.OrganizationPermissionMixin,
                           mixins.OrgRoleCheckMixin,
                           mixins.ProjectCreateCheckMixin,
                           core_mixins.CacheObjectMixin,
@@ -194,12 +195,13 @@ class OrganizationMembers(LoginPermissionRequiredMixin,
 
 
 class OrganizationMembersAdd(mixins.OrganizationMixin,
-                             LoginPermissionRequiredMixin,
+                             auth.LoginRequiredMixin,
+                             auth.OrganizationPermissionMixin,
                              generic.CreateView):
     model = OrganizationRole
     form_class = forms.AddOrganizationMemberForm
     template_name = 'organization/organization_members_add.html'
-    permission_required = update_permissions('org.users.add')
+    permission_required = 'org.users.add'
     permission_denied_message = error_messages.ORG_USERS_ADD
 
     def get_context_data(self, *args, **kwargs):
@@ -224,7 +226,8 @@ class OrganizationMembersAdd(mixins.OrganizationMixin,
 
 
 class OrganizationMembersEdit(mixins.OrganizationMixin,
-                              LoginPermissionRequiredMixin,
+                              auth.LoginRequiredMixin,
+                              auth.OrganizationPermissionMixin,
                               mixins.OrgRoleCheckMixin,
                               mixins.ProjectCreateCheckMixin,
                               core_mixins.CacheObjectMixin,
@@ -236,7 +239,7 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
     template_name = 'organization/organization_members_edit.html'
     project_form_class = forms.EditOrganizationMemberProjectPermissionForm
     org_role_form_class = forms.EditOrganizationMemberForm
-    permission_required = update_permissions('org.users.edit')
+    permission_required = 'org.users.edit'
     permission_denied_message = error_messages.ORG_USERS_EDIT
 
     def get_success_url(self):
@@ -309,9 +312,16 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
         form.save()
         return super().form_valid(form)
 
+    def test_func(self):
+        if self.get_organization().archived:
+            return False
+
+        return super().test_func()
+
 
 class OrganizationMembersRemove(mixins.OrganizationMixin,
-                                LoginPermissionRequiredMixin,
+                                auth.LoginRequiredMixin,
+                                auth.OrganizationPermissionMixin,
                                 generic.DeleteView):
     permission_required = update_permissions('org.users.remove')
     permission_denied_message = error_messages.ORG_USERS_REMOVE
@@ -347,6 +357,12 @@ class OrganizationMembersRemove(mixins.OrganizationMixin,
                                  _("Administrators cannot remove themselves."))
             return redirect('organization:members_edit', **self.kwargs)
         return super().delete(*args, **kwargs)
+
+    def test_func(self):
+        if self.get_organization().archived:
+            return False
+
+        return super().test_func()
 
 
 class UserList(LoginPermissionRequiredMixin, generic.ListView):

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -323,7 +323,7 @@ class OrganizationMembersRemove(mixins.OrganizationMixin,
                                 auth.LoginRequiredMixin,
                                 auth.OrganizationPermissionMixin,
                                 generic.DeleteView):
-    permission_required = update_permissions('org.users.remove')
+    permission_required = 'org.users.remove'
     permission_denied_message = error_messages.ORG_USERS_REMOVE
 
     def admin_is_deleting_themselves(self):

--- a/cadasta/templates/organization/organization_list.html
+++ b/cadasta/templates/organization/organization_list.html
@@ -20,11 +20,13 @@
     <div class="row">
       <div class="col-md-12 page-title">
         <h1>{% trans "Organizations" %}</h1>
+        {% if not user.is_anonymous %}
         <div class="top-btn pull-right">
           <a href="{% url 'organization:add' %}" class="btn btn-primary add-org">
             <span class="glyphicon glyphicon-plus" aria-hidden="true"></span><span class="hidden-xs"> {% trans "Add" %}</span>
           </a>
         </div>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR mainly  introduces three new mixins in `core.views.auth`: `LoginRequiredMixin`, `PermissionRequiredMixin`, `OrganizationPermissionMixin`.

- `LoginRequiredMixin` simply replicates the functionality of tutelary's [`LoginPermissionRequiredMixin`](https://github.com/Cadasta/django-tutelary/blob/master/tutelary/mixins.py#L111). 
- `PermissionRequiredMixin` is the basic mixin to use throughout the platform when access to views is restricted. It extends Django's [`UserPassesTestMixin`](https://docs.djangoproject.com/en/1.11/topics/auth/default/#django.contrib.auth.mixins.UserPassesTestMixin), which allows us to hook custom permissions checks into `test_func`. I added docstrings so that I won't go into too much detail here, but I want to point out that:
    - `get_permission_required` should be overwritten in views if you need specific permissions based on an objects state; for example, when an organization is archived. This is meant as a replacement for `update_permissions` functions or `get_perms` methods we are using currently. 
    - `get_perms` must be implemented by the view. It's supposed to return the permissions a user has on a view. For organization views, it will return the permissions from the org membership, for example.
- `OrganizationPermissionMixin` is a more concrete implementation of `PermissionRequiredMixin`, which is used in organization view.

#### Other smaller changes

- Loads new permissions in `core.tests.utils.cases.UserTestCase`. 
- Adapt existing organization views to the new mixins. 
- Removes unnecessary lines from `cadasta/core/mixins.py`. This functionality was only used on organization views, and it's now replicated in the mixins introduced. 

---

I kept the functionality intentionally simple. For example, how we handle superusers in `PermissionRequiredMixin.test_func` or that there's no explicit check on permissions for `OrganizationList` and `OrganizationAdd`. I think we shouldn't be too clever about these things and accidentally build things that might get in the way at some point. 

I'm also aware that `get_perms` in `OrganizationPermissionMixin` needs to change when we introduce a similar mixin for projects in the next step. 

Aaaand finally, I replicated (as in copy & pasted) some existing code of the platform and will continue to do so. The reason is that I don't want to drag along any old baggage and that we run the old and new permission systems alongside for a bit. I'm keeping track of all the things that need to be removed when tutelary is gone. 

### When should this PR be merged

Whenever

### Risks

None

### Follow-up actions

None

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
