### PR TITLE
Amend #1770

### DIFF
--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -151,7 +151,7 @@ class OrganizationForm(SanitizeFieldsForm, forms.ModelForm):
             raise forms.ValidationError(
                 _("Organization name cannot be “Add” or “New”."))
 
-        not_unique = Organization.objects.filter(name__iexact=name)
+        not_unique = Organization.objects.filter(name__iexact=name).exists()
         if not_unique:
             raise forms.ValidationError(
                 self.fields['name'].error_messages['unique'])

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -331,14 +331,10 @@ class ProjectAddDetails(SanitizeFieldsForm, SuperUserCheck, forms.Form):
         # (Explicit validation because we are using a wizard and the
         # unique_together validation cannot occur in the proper page)
         if self.cleaned_data.get('organization'):
-            not_unique = Project.objects.filter(
-                organization__slug=self.cleaned_data['organization'],
-                name__iexact=name,
-            ).exists()
+            not_unique = Project.objects.filter(name__iexact=name).exists()
             if not_unique:
                 raise forms.ValidationError(
-                    _("Project with this name already exists "
-                      "in this organization."))
+                    _("Project with this name already exists"))
 
         return name
 
@@ -408,13 +404,10 @@ class ProjectEditDetails(SanitizeFieldsForm, forms.ModelForm):
         # (Explicit validation because we are using a wizard and the
         # unique_together validation cannot occur in the proper page)
         not_unique = Project.objects.filter(
-            organization__slug=self.instance.organization.slug,
-            name__iexact=name,
-        ).exclude(id=self.instance.id).exists()
+            name__iexact=name).exclude(id=self.instance.id).exists()
         if not_unique:
             raise forms.ValidationError(
-                _("Project with this name already exists "
-                  "in this organization."))
+                _("Project with this name already exists"))
 
         return name
 

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -33,7 +33,7 @@ class OrganizationSerializer(core_serializers.SanitizeFieldSerializer,
         if slugify(value, allow_unicode=True) in invalid_names:
             raise serializers.ValidationError(
                 _("Organization name cannot be “Add” or “New”."))
-        not_unique = Organization.objects.filter(name__iexact=value)
+        not_unique = Organization.objects.filter(name__iexact=value).exists()
         if not_unique:
             raise serializers.ValidationError(
                 _("Organization with this name already exists."))

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -76,25 +76,17 @@ class ProjectSerializer(core_serializers.SanitizeFieldSerializer,
             raise serializers.ValidationError(
                 _("Project name cannot be “Add” or “New”."))
 
-        # Check that name is unique org-wide
+        # Check that name is unique globally
         # (Explicit validation: see comment in the Meta class)
         is_create = not self.instance
-        if is_create:
-            org_slug = self.context['organization'].slug
-        else:
-            org_slug = self.instance.organization.slug
-        queryset = Project.objects.filter(
-            organization__slug=org_slug,
-            name__iexact=value,
-        )
+        queryset = Project.objects.filter(name__iexact=value)
         if is_create:
             not_unique = queryset.exists()
         else:
             not_unique = queryset.exclude(id=self.instance.id).exists()
         if not_unique:
             raise serializers.ValidationError(
-                _("Project with this name already exists "
-                  "in this organization."))
+                _("Project with this name already exists"))
 
         return value
 

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -547,8 +547,7 @@ class ProjectAddDetailsTest(UserTestCase, TestCase):
         data['name'] = existing_project.name
         form = forms.ProjectAddDetails(data=data, user=self.user)
         assert not form.is_valid()
-        assert ("Project with this name already exists in this organization."
-                in form.errors['name'])
+        assert ("Project with this name already exists" in form.errors['name'])
 
     def test_add_new_project_with_duplicate_name_in_another_org(self):
         another_org = OrganizationFactory.create()
@@ -556,7 +555,8 @@ class ProjectAddDetailsTest(UserTestCase, TestCase):
         data = self.data.copy()
         data['name'] = existing_project.name
         form = forms.ProjectAddDetails(data=data, user=self.user)
-        assert form.is_valid()
+        assert not form.is_valid()
+        assert ("Project with this name already exists" in form.errors['name'])
 
     def test_add_new_project_with_semivalid_url(self):
         data = self.data.copy()
@@ -627,8 +627,7 @@ class ProjectAddDetailsTest(UserTestCase, TestCase):
         data['name'] = existing_project.name.upper()
         form = forms.ProjectAddDetails(data=data, user=self.user)
         assert not form.is_valid()
-        assert ("Project with this name already exists in this organization."
-                in form.errors['name'])
+        assert ("Project with this name already exists" in form.errors['name'])
 
 
 @pytest.mark.usefixtures('make_dirs')
@@ -822,8 +821,7 @@ class ProjectEditDetailsTest(UserTestCase, FileStorageTestCase, TestCase):
         data['name'] = another_project.name
         form = forms.ProjectEditDetails(instance=self.project, data=data)
         assert not form.is_valid()
-        assert ("Project with this name already exists in this organization."
-                in form.errors['name'])
+        assert ("Project with this name already exists" in form.errors['name'])
 
     def test_update_project_with_semivalid_url(self):
         data = self.data.copy()
@@ -854,8 +852,7 @@ class ProjectEditDetailsTest(UserTestCase, FileStorageTestCase, TestCase):
         data['name'] = another_project.name.upper()
         form = forms.ProjectEditDetails(instance=self.project, data=data)
         assert not form.is_valid()
-        assert ("Project with this name already exists in this organization."
-                in form.errors['name'])
+        assert ("Project with this name already exists" in form.errors['name'])
 
 
 class UpdateProjectRolesTest(UserTestCase, TestCase):

--- a/cadasta/organization/tests/test_serializers.py
+++ b/cadasta/organization/tests/test_serializers.py
@@ -316,7 +316,7 @@ class ProjectSerializerTest(TestCase):
             serializer.is_valid(raise_exception=True)
         assert serializer.errors == {
             'name': [
-                "Project with this name already exists in this organization."]
+                "Project with this name already exists"]
         }
 
     def test_duplicate_project_name_in_another_org(self):
@@ -330,12 +330,12 @@ class ProjectSerializerTest(TestCase):
             data=data,
             context={'organization': another_org}
         )
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
-
-        project_instance = serializer.instance
-        assert project_instance.name == existing_project.name
-        assert Project.objects.count() == 2
+        with pytest.raises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+        assert serializer.errors == {
+            'name': [
+                "Project with this name already exists"]
+        }
 
     def test_update_with_duplicate_project_name(self):
         project_1 = ProjectFactory.create()
@@ -352,7 +352,7 @@ class ProjectSerializerTest(TestCase):
             serializer.is_valid(raise_exception=True)
         assert serializer.errors == {
             'name': [
-                "Project with this name already exists in this organization."]
+                "Project with this name already exists"]
         }
 
     def test_unicode_slug(self):
@@ -399,7 +399,7 @@ class ProjectSerializerTest(TestCase):
             serializer.is_valid(raise_exception=True)
         assert serializer.errors == {
             'name': [
-                "Project with this name already exists in this organization."]
+                "Project with this name already exists"]
         }
 
     def test_update_with_duplicate_project_name_case_insensitive(self):
@@ -417,7 +417,7 @@ class ProjectSerializerTest(TestCase):
             serializer.is_valid(raise_exception=True)
         assert serializer.errors == {
             'name': [
-                "Project with this name already exists in this organization."]
+                "Project with this name already exists"]
         }
 
 

--- a/cadasta/organization/tests/test_serializers.py
+++ b/cadasta/organization/tests/test_serializers.py
@@ -14,7 +14,7 @@ from core.tests.utils.cases import UserTestCase
 from core.messages import SANITIZE_ERROR
 from accounts.tests.factories import UserFactory
 from .. import serializers
-from ..models import OrganizationRole, ProjectRole, Project
+from ..models import OrganizationRole, ProjectRole
 from .factories import OrganizationFactory, ProjectFactory
 
 


### PR DESCRIPTION
### Proposed changes in this pull request

- This PR amends PR #1770. Something went wrong during the merge and changes committed after initial commit were not reflected in the merge. Those changes are now introduced in this PR.

### When should this PR be merged

-As soon as it's approved

### Risks

- Low

### Follow-up actions

- None


### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
