### PR TITLE
Adds languages: Odia, Aymara, Garifuna

### DIFF
--- a/cadasta/config/settings/languages.py
+++ b/cadasta/config/settings/languages.py
@@ -75,5 +75,8 @@ FORM_LANGS = {
     'uk': _("Ukrainian"),
     'ur': _("Urdu"),
     'vi': _("Vietnamese"),
-    'kar': _("S'gaw Karen")
+    'kar': _("S'gaw Karen"),
+    'aym': _("Aymara"),
+    'cab': _("Garifuna"),
+    'ori': _("Odia"),
 }

--- a/cadasta/config/settings/languages.py
+++ b/cadasta/config/settings/languages.py
@@ -76,7 +76,7 @@ FORM_LANGS = {
     'ur': _("Urdu"),
     'vi': _("Vietnamese"),
     'kar': _("S'gaw Karen"),
-    'aym': _("Aymara"),
+    'ay': _("Aymara"),
     'cab': _("Garifuna"),
-    'ori': _("Odia"),
+    'or': _("Odia"),
 }

--- a/cadasta/config/settings/languages.py
+++ b/cadasta/config/settings/languages.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 FORM_LANGS = {
     'af': _("Afrikaans"),
     'ar': _("Arabic"),
+    'ay': _("Aymara"),
     'az': _("Azerbaijani"),
     'be': _("Belarusian"),
     'bg': _("Bulgarian"),
@@ -11,6 +12,7 @@ FORM_LANGS = {
     'br': _("Breton"),
     'bs': _("Bosnian"),
     'ca': _("Catalan"),
+    'cab': _("Garifuna"),
     'cs': _("Czech"),
     'cy': _("Welsh"),
     'da': _("Danish"),
@@ -39,6 +41,7 @@ FORM_LANGS = {
     'it': _("Italian"),
     'ja': _("Japanese"),
     'ka': _("Georgian"),
+    'kar': _("S'gaw Karen"),
     'kk': _("Kazakh"),
     'km': _("Khmer"),
     'kn': _("Kannada"),
@@ -55,6 +58,7 @@ FORM_LANGS = {
     'ne': _("Nepali"),
     'nl': _("Dutch"),
     'nn': _("Norwegian (Nynorsk)"),
+    'or': _("Odia"),
     'os': _("Ossetian"),
     'pa': _("Eastern Punjabi"),
     'pl': _("Polish"),
@@ -74,9 +78,5 @@ FORM_LANGS = {
     'tt': _("Tatar"),
     'uk': _("Ukrainian"),
     'ur': _("Urdu"),
-    'vi': _("Vietnamese"),
-    'kar': _("S'gaw Karen"),
-    'ay': _("Aymara"),
-    'cab': _("Garifuna"),
-    'or': _("Odia"),
+    'vi': _("Vietnamese")
 }


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolves #1826: Forms containing Aymara and Garifona labels can now be submitted
- Resolves #1807: Forms containing Odia labels can now be submitted

### When should this PR be merged

For the next release

### Risks

None

### Follow-up actions

None

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
