### PR TITLE
Reduce number of ResourceWarning when running tests

### DIFF
--- a/cadasta/config/settings/dev.py
+++ b/cadasta/config/settings/dev.py
@@ -87,7 +87,8 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
             'filename': '/var/log/django/debug.log',
-            'formatter': 'simple'
+            'formatter': 'simple',
+            'delay': True
         },
     },
     'loggers': {

--- a/cadasta/core/tests/factories.py
+++ b/cadasta/core/tests/factories.py
@@ -25,8 +25,9 @@ class PolicyFactory(factory.django.DjangoModelFactory):
     @classmethod
     def _adjust_kwargs(cls, **kwargs):
         body_file = os.path.join(cls.directory, kwargs.pop('file', None))
-        kwargs['body'] = open(body_file).read()
-        return kwargs
+        with open(body_file) as body:
+            kwargs['body'] = body.read()
+            return kwargs
 
     def load_policies(force=True):
         load.run(force)

--- a/cadasta/organization/download/resources.py
+++ b/cadasta/organization/download/resources.py
@@ -69,7 +69,10 @@ class ResourceExporter():
                     r.original_file = zip_fname
 
                 res_data.append(self.pack_resource_data(r))
-                myzip.write(r.file.open().name, arcname=zip_fname)
+
+                resource_file = r.file.open()
+                myzip.write(resource_file.name, arcname=zip_fname)
+                resource_file.close()
             resources_xls = self.make_resource_worksheet(f_name, res_data)
             myzip.write(resources_xls, arcname='resources.xlsx')
             myzip.close()

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -664,12 +664,12 @@ class ProjectEditDetailsTest(UserTestCase, FileStorageTestCase, TestCase):
         form = forms.ProjectEditDetails(instance=project, data=data)
         form.save()
 
-        # project.refresh_from_db()
-        # assert project.name == data['name']
-        # questionnaire = project.questionnaires.get(
-        #     id=project.current_questionnaire)
-        # assert questionnaire.xls_form.url == data['questionnaire']
-        # assert questionnaire.original_file == data['original_file']
+        project.refresh_from_db()
+        assert project.name == data['name']
+        questionnaire = project.questionnaires.get(
+            id=project.current_questionnaire)
+        assert questionnaire.xls_form.url == data['questionnaire']
+        assert questionnaire.original_file == data['original_file']
 
     def test_add_invalid_questionnaire(self):
         project = ProjectFactory.create()

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -664,12 +664,12 @@ class ProjectEditDetailsTest(UserTestCase, FileStorageTestCase, TestCase):
         form = forms.ProjectEditDetails(instance=project, data=data)
         form.save()
 
-        project.refresh_from_db()
-        assert project.name == data['name']
-        questionnaire = project.questionnaires.get(
-            id=project.current_questionnaire)
-        assert questionnaire.xls_form.url == data['questionnaire']
-        assert questionnaire.original_file == data['original_file']
+        # project.refresh_from_db()
+        # assert project.name == data['name']
+        # questionnaire = project.questionnaires.get(
+        #     id=project.current_questionnaire)
+        # assert questionnaire.xls_form.url == data['questionnaire']
+        # assert questionnaire.original_file == data['original_file']
 
     def test_add_invalid_questionnaire(self):
         project = ProjectFactory.create()

--- a/cadasta/organization/tests/test_importers.py
+++ b/cadasta/organization/tests/test_importers.py
@@ -299,6 +299,7 @@ class CSVImportTest(UserTestCase, FileStorageTestCase, TestCase):
             '/organization/tests/files/uttaran_test.xlsx', 'rb')
         form = self.storage.save('xls-forms/uttaran_test.xlsx',
                                  xlscontent.read())
+        xlscontent.close()
         Questionnaire.objects.create_from_form(
             xls_form=form,
             project=self.project

--- a/cadasta/questionnaires/managers.py
+++ b/cadasta/questionnaires/managers.py
@@ -199,7 +199,9 @@ class QuestionnaireManager(models.Manager):
                     original_file=original_file,
                     project=project
                 )
-                json = parse_file_to_json(instance.xls_form.file.name)
+                xls_file = instance.xls_form.file
+                json = parse_file_to_json(xls_file.name)
+                xls_file.close()
 
                 id_string = json['id_string']
                 if re.search(r"\s", id_string):

--- a/cadasta/search/export/resource.py
+++ b/cadasta/search/export/resource.py
@@ -75,6 +75,7 @@ class ResourceExporter():
                 myzip.write(xls_path, arcname='resources.xlsx')
 
             myzip.close()
+            f.close()
 
         return zip_path, MIME_TYPE
 

--- a/cadasta/search/export/shape.py
+++ b/cadasta/search/export/shape.py
@@ -43,6 +43,7 @@ class ShapeExporter(Exporter):
                 break
             self.process_entity(
                 type_line, source_line, self.write_csv_row_and_shp)
+        f.close()
 
         # Clean up
         for metadatum in self.metadata.values():

--- a/cadasta/search/export/xls.py
+++ b/cadasta/search/export/xls.py
@@ -25,6 +25,7 @@ class XLSExporter(Exporter):
         # Finalize
         xls_path = os.path.splitext(es_dump_path)[0] + '.xlsx'
         self.workbook.save(filename=xls_path)
+        f.close()
         return xls_path, MIME_TYPE
 
     def write_xls_row(self, entity, metadatum):

--- a/cadasta/xforms/tests/test_model_helper.py
+++ b/cadasta/xforms/tests/test_model_helper.py
@@ -839,9 +839,9 @@ class XFormModelHelperTest(TestCase):
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~
         # test attaching resources
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        file = open(
-            path + '/xforms/tests/files/test_image_one.png', 'rb'
-        ).read()
+        with open(path +
+                  '/xforms/tests/files/test_image_one.png', 'rb') as src:
+            file = src.read()
 
         data = InMemoryUploadedFile(
             file=io.BytesIO(file),
@@ -872,9 +872,9 @@ class XFormModelHelperTest(TestCase):
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~
         # test without content object
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        file = open(
-            path + '/xforms/tests/files/test_image_two.png', 'rb'
-        ).read()
+        with open(path +
+                  '/xforms/tests/files/test_image_two.png', 'rb') as src:
+            file = src.read()
 
         data = InMemoryUploadedFile(
             file=io.BytesIO(file),
@@ -996,9 +996,11 @@ class XFormModelHelperTest(TestCase):
     def test_format_create_resource(self):
         party = PartyFactory.create(project=self.project)
         file_name = 'test_image_two.png'
-        file = open(
-            path + '/xforms/tests/files/test_image_two.png', 'rb'
-        ).read()
+
+        with open(path +
+                  '/xforms/tests/files/test_image_one.png', 'rb') as src:
+            file = src.read()
+
         file_data = InMemoryUploadedFile(
             file=io.BytesIO(file),
             field_name='test_image_two',

--- a/cadasta/xforms/tests/test_views_api.py
+++ b/cadasta/xforms/tests/test_views_api.py
@@ -359,6 +359,7 @@ class XFormSubmissionTest(APITestCase, UserTestCase, FileStorageTestCase,
         QuestionFactory.create(name='party_name',
                                questionnaire=questionnaire,
                                type='TX')
+
         # testing submitting with a missing xml_submission_file
         data = self._invalid_submission(form='This is not an xml form!')
         response = self.request(method='POST', user=self.user, post_data=data,

--- a/cadasta/xforms/tests/test_views_api.py
+++ b/cadasta/xforms/tests/test_views_api.py
@@ -186,7 +186,7 @@ class XFormSubmissionTest(APITestCase, UserTestCase, FileStorageTestCase,
                 file_name=image_name,
                 file_type='png')
             img_stream = img_file.read()
-            img = InMemoryUploadedFile(
+            img_uploaded = InMemoryUploadedFile(
                 file=io.BytesIO(img_stream),
                 field_name=image_name,
                 name='{}.png'.format(image_name),
@@ -195,14 +195,14 @@ class XFormSubmissionTest(APITestCase, UserTestCase, FileStorageTestCase,
                 charset='utf-8',
             )
             img_file.close()
-            data[img.name] = img
+            data[img_uploaded.name] = img_uploaded
 
         for audio_name in audio:
             audio_file = self._get_resource(
                 file_name=audio_name,
                 file_type='mp3')
             audio_stream = audio_file.read()
-            audio = InMemoryUploadedFile(
+            audio_uploaded = InMemoryUploadedFile(
                 file=io.BytesIO(audio_stream),
                 field_name=audio_name,
                 name='{}.mp3'.format(audio_name),
@@ -210,7 +210,7 @@ class XFormSubmissionTest(APITestCase, UserTestCase, FileStorageTestCase,
                 size=len(audio_stream),
                 charset='utf-8',
             )
-            data[audio.name] = audio
+            data[audio_uploaded.name] = audio_uploaded
             audio_file.close()
 
         if file:


### PR DESCRIPTION
### Proposed changes in this pull request

Changes in this PR reduce the number of `ResourceWarning` while running tests by:

- Adding `'delay': True` to the logging handler, so the log file is only open when it's needed. 
- Closing all files used in tests. 

You'll see that there are still a few `ResourceWarning` being thrown from `xforms/tests/test_views_api.py::XFormSubmissionTest`. I wasn't able to locate the origin of those. Something seems proper messed up in these tests; the number of warnings and the stack trace changes depending on what tests I run or if I comment out some of the tests. I'll look into that another time. 

### When should this PR be merged

Whenever; this is not urgent.

### Risks

None. 

### Follow-up actions

Address all other warnings. 

### Checklist (for reviewing)

#### General

- **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
  - [ ] Review 1
  - [ ] Review 2
- **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
  - [ ] Review 1
  - [ ] Review 2

#### Functionality

- **Are all requirements met?** Compare implemented functionality with the requirements specification.
  - [ ] Review 1
  - [ ] Review 2
- **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
  - [ ] Review 1
  - [ ] Review 2

#### Code

- **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
  - [ ] Review 1
  - [ ] Review 2
- **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
  - [ ] Review 1
  - [ ] Review 2
- **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
  - [ ] Review 1
  - [ ] Review 2
- **Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
  - [ ] Review 1
  - [ ] Review 2
- **Has the scalability of this change been evaluated?**
  - [ ] Review 1
  - [ ] Review 2
- **Is there a maintenance plan in place?**
  - [ ] Review 1
  - [ ] Review 2

#### Tests

- **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
  - [ ] Review 1
  - [ ] Review 2
- **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
  - [ ] Review 1
  - [ ] Review 2
- **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
  - [ ] Review 1
  - [ ] Review 2

#### Security

- **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
  - [ ] Review 1
  - [ ] Review 2
- **Are all UI and API inputs run through forms or serializers?** 
  - [ ] Review 1
  - [ ] Review 2
- **Are all external inputs validated and sanitized appropriately?**
  - [ ] Review 1
  - [ ] Review 2
- **Does all branching logic have a default case?**
  - [ ] Review 1
  - [ ] Review 2
- **Does this solution handle outliers and edge cases gracefully?**
  - [ ] Review 1
  - [ ] Review 2
- **Are all external communications secured and restricted to SSL?**
  - [ ] Review 1
  - [ ] Review 2

#### Documentation

- **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
  - [ ] Review 1
  - [ ] Review 2
- **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
  - [ ] Review 1
  - [ ] Review 2
