### PR TITLE
Make test suite execute in less time

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,4 +10,4 @@ django-debug-toolbar==1.8
 django-extensions==1.9.1
 django-skivvy==0.1.9
 ipython==6.2.0
-git+https://github.com/Cadasta/cadasta-test.git@v0.2.3
+git+https://github.com/Cadasta/cadasta-test.git@v0.2.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,4 +10,4 @@ django-debug-toolbar==1.8
 django-extensions==1.9.1
 django-skivvy==0.1.9
 ipython==6.2.0
-git+https://github.com/Cadasta/cadasta-test.git@v0.2.4
+git+https://github.com/Cadasta/cadasta-test.git@faster-build

--- a/runtests-functional
+++ b/runtests-functional
@@ -1,39 +1,51 @@
 #!/bin/bash
 
-if [[ -z $TRAVIS || ($TRAVIS_EVENT_TYPE == pull_request && $TRAVIS_BRANCH == master) ]]
+# If this is not a Travis build, just execute runtests.py
+if [[ -z $TRAVIS ]]
 then
+  ./runtests.py --functional
+
+# We are on a Travis build
+else
 
   # Perform any final installations and setups before running tests on Travis
-  if [[ -n $TRAVIS ]]
+  cd cadasta/core
+  npm install bootstrap-sass
+  cd ..
+  ./manage.py migrate
+  ./manage.py loadstatic
+  ./manage.py loadfunctestfixtures
+  ./manage.py runserver 0.0.0.0:8000 &
+  sleep 5  # Wait for the Django server to start up
+  cd ..
+
+  # Run the test suite in the Travis VM for PRs
+  if [[ $TRAVIS_EVENT_TYPE == pull_request && $TRAVIS_BRANCH == master ]]
   then
-    cd cadasta/core
-    npm install bootstrap-sass
-    cd ..
-    ./manage.py migrate
-    ./manage.py loadstatic
-    ./manage.py loadfunctestfixtures
-    ./manage.py runserver 0.0.0.0:8000 &
-    cd ..
-    sleep 5  # Wait for the Django server to start up
+    export CADASTA_TEST_WEBDRIVER=Firefox
+    ./runtests.py --functional
+    ret=$?
   fi
 
-  # Run all the things
-  if [[ -n $TRAVIS ]]
+  # Run the test suite via BrowserStack (as much as possible) for commits to master
+  if [[ $TRAVIS_EVENT_TYPE == push && $TRAVIS_BRANCH == master ]]
   then
     # BrowserStack cannot handle local file uploads
     export CADASTA_TEST_WEBDRIVER=BrowserStack-Chrome
     ./runtests.py --functional -m 'not uploads'
+    ret=$?
 
-    # Run file upload tests using the local ChromeDriver
-    export CADASTA_TEST_WEBDRIVER=Firefox
-    ./runtests.py --functional -m uploads
-  else
-    ./runtests.py --functional
+    if [[ $ret == 0 ]]
+    then
+      # Run file upload tests using the local WebDriver
+      export CADASTA_TEST_WEBDRIVER=Firefox
+      ./runtests.py --functional -m uploads
+      ret=$?
+    fi
   fi
-  ret=$?
 
-  # Clean up on Travis
-  if [[ -n $TRAVIS ]]; then killall python; fi  # Kill the Django server
+  # Kill the Django server
+  killall python
 
   exit $ret
 fi

--- a/runtests-functional
+++ b/runtests-functional
@@ -16,7 +16,7 @@ else
   ./manage.py loadstatic
   ./manage.py loadfunctestfixtures
   ./manage.py runserver 0.0.0.0:8000 &
-  sleep 5  # Wait for the Django server to start up
+  until curl http://0:8000 -f; do sleep .1; done  # Wait for the Django server to start up
   cd ..
 
   # Run the test suite in the Travis VM for PRs


### PR DESCRIPTION
### Proposed changes in this pull request
This PR builds up on the changes in [PR #43](https://github.com/Cadasta/cadasta-test/pull/43) of the **cadasta-test** repo. The idea is that for PRs we run the functional test suite locally on Travis and only run the test suite using BrowserStack for commits to the `master` branch (when PRs are merged). (And as before, normal commits skip executing the test suite.)

### When should this PR be merged
After the **cadasta-test** PR mentioned above has been merged and tagged with `v0.2.4`.

### Risks
None foreseen.

### Follow-up actions
None.

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).
- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**
- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**
- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 
- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**
- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**
- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**
- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**
- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
- [ ] Review 1
- [ ] Review 2
