### PR TITLE
Remove `core.form_mixins.SuperUserCheckMixin`

### DIFF
--- a/cadasta/core/form_mixins.py
+++ b/cadasta/core/form_mixins.py
@@ -4,7 +4,6 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import get_language
 from jsonattrs.mixins import template_xlang_labels
 from jsonattrs.forms import form_field_from_name
-from tutelary.models import Role
 
 from core.validators import sanitize_string
 from questionnaires.models import Questionnaire, Question, QuestionOption
@@ -43,20 +42,6 @@ def get_types(question_name, default, questionnaire_id=None,
         return types
     else:
         return [key for key, _ in types]
-
-
-class SuperUserCheck:
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._su_role = None
-
-    def is_superuser(self, user):
-        if not hasattr(self, 'su_role'):
-            self.su_role = Role.objects.get(name='superuser')
-
-        return any([isinstance(pol, Role) and pol == self.su_role
-                    for pol in user.assigned_policies()])
 
 
 class AttributeFormMixin(SchemaSelectorMixin):

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -7,7 +7,6 @@ from rest_framework import serializers
 from rest_framework_gis import serializers as geo_serializers
 from django_countries.serializer_fields import CountryField
 
-from core.form_mixins import SuperUserCheck
 from core import serializers as core_serializers
 from accounts.models import User
 from accounts.serializers import UserSerializer
@@ -137,7 +136,7 @@ class ProjectGeometrySerializer(geo_serializers.GeoFeatureModelSerializer):
                     'project': object.slug})
 
 
-class EntityUserSerializer(SuperUserCheck, serializers.Serializer):
+class EntityUserSerializer(serializers.Serializer):
     username = serializers.CharField()
 
     def to_representation(self, instance):
@@ -253,7 +252,7 @@ class ProjectUserSerializer(EntityUserSerializer):
     role = serializers.CharField()
 
     def validate(self, data):
-        if ((self.instance and self.is_superuser(self.instance)) or
+        if ((self.instance and self.instance.is_superuser) or
                 self.org_role.admin):
             raise serializers.ValidationError(
                 _("User {username} is an organization admin, the role cannot "
@@ -286,7 +285,7 @@ class ProjectUserSerializer(EntityUserSerializer):
             return 'A' if role.admin else 'Pb'
 
     def get_role_json(self, instance):
-        if self.is_superuser(instance):
+        if instance.is_superuser:
             return 'A'
 
         try:

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -925,12 +925,10 @@ class ProjectEditPermissionsTest(UserTestCase, TestCase):
         super().setUp()
         self.project = ProjectFactory.create()
 
-        self.super_user = UserFactory.create()
+        self.super_user = UserFactory.create(is_superuser=True)
         OrganizationRole.objects.create(user=self.super_user,
                                         organization=self.project.organization,
                                         admin=False)
-        su_role = Role.objects.get(name='superuser')
-        self.super_user.assign_policies(su_role)
 
         self.org_admin = UserFactory.create()
         OrganizationRole.objects.create(user=self.org_admin,

--- a/cadasta/organization/tests/test_serializers.py
+++ b/cadasta/organization/tests/test_serializers.py
@@ -610,9 +610,7 @@ class ProjectUserSerializerTest(UserTestCase, TestCase):
         org_admin = UserFactory.create()
         public_user = UserFactory.create()
 
-        superuser = UserFactory.create()
-        superuser_role = Role.objects.get(name='superuser')
-        superuser.assign_policies(superuser_role)
+        superuser = UserFactory.create(is_superuser=True)
 
         org = OrganizationFactory.create(
             add_users=[superuser, prj_admin, public_user])

--- a/cadasta/organization/tests/test_views_default_organizations.py
+++ b/cadasta/organization/tests/test_views_default_organizations.py
@@ -3,7 +3,7 @@ import json
 from django.test import TestCase
 from django.contrib.auth.models import AnonymousUser
 
-from tutelary.models import Policy, Role, assign_user_policies
+from tutelary.models import Policy, assign_user_policies
 from skivvy import ViewTestCase
 
 from core.tests.utils.cases import UserTestCase
@@ -754,9 +754,7 @@ class OrganizationMembersEditTest(ViewTestCase, UserTestCase, TestCase):
         assert role.admin is False
 
     def test_post_with_superuser(self):
-        superuser = UserFactory.create()
-        superuser_role = Role.objects.get(name='superuser')
-        superuser.assign_policies(superuser_role)
+        superuser = UserFactory.create(is_superuser=True)
         response = self.request(method='POST',
                                 post_data={'org_role': 'A'},
                                 user=superuser)

--- a/cadasta/organization/tests/test_views_default_projects.py
+++ b/cadasta/organization/tests/test_views_default_projects.py
@@ -30,7 +30,7 @@ from resources.utils.io import ensure_dirs
 from skivvy import ViewTestCase
 from spatial.models import SpatialUnit
 from spatial.tests.factories import SpatialUnitFactory
-from tutelary.models import Policy, Role, assign_user_policies
+from tutelary.models import Policy, assign_user_policies
 
 from .. import forms
 from ..views import default
@@ -480,8 +480,7 @@ class ProjectAddTest(UserTestCase, FileStorageTestCase, TestCase):
 
         self.user = UserFactory.create()
         self.unauth_user = UserFactory.create()
-        self.superuser = UserFactory.create()
-        self.superuser.assign_policies(Role.objects.get(name='superuser'))
+        self.superuser = UserFactory.create(is_superuser=True)
 
         setattr(self.request, 'user', self.user)
         assign_user_policies(self.user, self.policy)


### PR DESCRIPTION
### Proposed changes in this pull request

This PR removes `core.form_mixins.SuperUserCheckMixin` from the code base and refactors all forms that depended on it. 

Super users can not be identified using Tutelary's `Role` because we never actually assigned the superuser role to any users. Instead, super users can be identified using Django's `User.is_superuser` flag. 

### When should this PR be merged

The changes can be considered a step towards replacing Tutelary. It's not urgent but it should go into master before we have the first big chunk ready for the permissions rework. 

### Risks

None

### Follow-up actions

None

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [x] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [x] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [x] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [x] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [x] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [x] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [x] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [x] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [x] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [x] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [x] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [x] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [x] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [x] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [x] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [x] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [x] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [x] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [x] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [x] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [x] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [x] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [x] Review 2
