### PR TITLE
Fix issue 1842

### DIFF
--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -151,10 +151,16 @@ class OrganizationForm(SanitizeFieldsForm, forms.ModelForm):
             raise forms.ValidationError(
                 _("Organization name cannot be “Add” or “New”."))
 
-        not_unique = Organization.objects.filter(name__iexact=name).exists()
+        is_create = not self.instance.id
+        queryset = Organization.objects.filter(name__iexact=name)
+        if is_create:
+            not_unique = queryset.exists()
+        else:
+            not_unique = queryset.exclude(id=self.instance.id).exists()
         if not_unique:
             raise forms.ValidationError(
                 self.fields['name'].error_messages['unique'])
+
         return name
 
     def save(self, *args, **kwargs):

--- a/cadasta/organization/serializers.py
+++ b/cadasta/organization/serializers.py
@@ -33,10 +33,17 @@ class OrganizationSerializer(core_serializers.SanitizeFieldSerializer,
         if slugify(value, allow_unicode=True) in invalid_names:
             raise serializers.ValidationError(
                 _("Organization name cannot be “Add” or “New”."))
-        not_unique = Organization.objects.filter(name__iexact=value).exists()
+
+        is_create = not self.instance
+        queryset = Organization.objects.filter(name__iexact=value)
+        if is_create:
+            not_unique = queryset.exists()
+        else:
+            not_unique = queryset.exclude(id=self.instance.id).exists()
         if not_unique:
             raise serializers.ValidationError(
                 _("Organization with this name already exists."))
+
         return value
 
     def create(self, *args, **kwargs):

--- a/cadasta/organization/tests/test_forms.py
+++ b/cadasta/organization/tests/test_forms.py
@@ -216,6 +216,25 @@ class OrganizationTest(UserTestCase, TestCase):
                 in form.errors['name'])
         assert Organization.objects.count() == 1
 
+    def test_update_org_name_with_different_case(self):
+        self._save(self.data)
+        self.data['name'] = 'ORG'
+        org = Organization.objects.first()
+        form = forms.OrganizationForm(self.data, instance=org)
+        assert form.is_valid() is True
+        assert form.errors.get('name') is None
+        form.save()
+        org.refresh_from_db()
+        assert org.name == 'ORG'
+
+    def test_update_org_check_for_org_name_error(self):
+        self._save(self.data)
+        org = Organization.objects.first()
+        self.data['description'] = 'Checking for errors in name!'
+        form = forms.OrganizationForm(self.data, instance=org)
+        assert form.is_valid() is True
+        assert form.errors.get('name') is None
+
 
 class AddOrganizationMemberFormTest(UserTestCase, TestCase):
 

--- a/cadasta/organization/tests/test_serializers.py
+++ b/cadasta/organization/tests/test_serializers.py
@@ -201,6 +201,41 @@ class OrganizationSerializerTest(UserTestCase, TestCase):
             'name': ["Organization with this name already exists."]
         }
 
+    def test_update_org_name_with_different_case(self):
+        org_1 = OrganizationFactory.create()
+        request = APIRequestFactory().post('/')
+        user = UserFactory.create()
+        setattr(request, 'user', user)
+
+        data = {'name': org_1.name.upper()}
+        serializer = serializers.OrganizationSerializer(
+            org_1,
+            data=data,
+            partial=True,
+            context={'request': request}
+        )
+        assert serializer.is_valid() is True
+        assert serializer.errors.get('name') is None
+        serializer.save()
+        org_1.refresh_from_db()
+        assert org_1.name == org_1.name.upper()
+
+    def test_update_org_check_for_org_name_error(self):
+        org_1 = OrganizationFactory.create()
+        request = APIRequestFactory().post('/')
+        user = UserFactory.create()
+        setattr(request, 'user', user)
+
+        data = {'description': 'Checking for errors in name!'}
+        serializer = serializers.OrganizationSerializer(
+            org_1,
+            data=data,
+            partial=True,
+            context={'request': request}
+        )
+        assert serializer.is_valid() is True
+        assert serializer.errors.get('name') is None
+
 
 class ProjectSerializerTest(TestCase):
     def test_project_is_set(self):


### PR DESCRIPTION
### Proposed changes in this pull request
This PR fixes issue #1842 

- Change `clean_name` method of `OrganizationForm` to exclude the organization instance(if it exists) when checking for uniqueness of the org name.

- Make similar changes to `validate_name` method of `OrganizationSerializer`.

- Add 2 new tests to both `organization/tests/test_forms.py` and `organization/tests/test_serializers.py`.
    1. **test_update_org_name_with_different_case** : This test checks if a user is allowed to change  the 
          org  name to a different case. For example, if the org name is **cadasta_organization**, then the 
          user should be allowed to change the org name to **CADASTA_ORGANIZATION**
    2. **test_update_org_check_for_org_name_error** : This test checks the case mentioned in #1842.

### When should this PR be merged

- Once approved

### Risks

- Low

### Follow-up actions

- None

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [x] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [x] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [x] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [x] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [x] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [x] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [x] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [x] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [x] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [x] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [x] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [x] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [x] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [x] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [x] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [x] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [x] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [x] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [x] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [x] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [x] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [x] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [x] Review 2
