### PR TITLE
Fixes #1121 -- Displays permissions correctly for superusers in orgs

### DIFF
--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -262,14 +262,16 @@ class EditOrganizationMemberProjectPermissionForm(forms.Form):
         project_roles = {r['project__id']: r['role'] for r in project_roles}
         active_projects = self.organization.projects.filter(archived=False)
 
+        admin = self.org_role_instance.admin or user.is_superuser
+
         for p in active_projects.values_list('id', 'name'):
             role = project_roles.get(p[0], 'Pb')
             self.fields[p[0]] = org_fields.ProjectRoleEditField(
                 choices=FORM_CHOICES,
                 label=p[1],
-                required=(not self.org_role_instance.admin),
+                required=(not admin),
                 initial=role,
-                admin=self.org_role_instance.admin,
+                admin=admin,
             )
 
     def save(self):

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -260,13 +260,13 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
         context['project_role_form'] = self.get_prj_role_form()
         context['org_role_form'] = self.get_form()
 
-        context['org_admin'] = OrganizationRole.objects.filter(
-            user=context['org_member'],
-            organization=context['organization'],
-            admin=True).exists()
-        context['current_user'] = (
-            context['org_member'] == self.request.user and
-            not self.is_superuser)
+        context['org_admin'] = context['org_member'].is_superuser
+        if not context['org_admin']:
+            context['org_admin'] = OrganizationRole.objects.filter(
+                user=context['org_member'],
+                organization=context['organization'],
+                admin=True).exists()
+        context['current_user'] = context['org_member'] == self.request.user
         return context
 
     def post(self, request, *args, **kwargs):

--- a/cadasta/templates/organization/organization_members_edit.html
+++ b/cadasta/templates/organization/organization_members_edit.html
@@ -25,7 +25,12 @@
                 <img src="/static/img/avatar.jpg" class="avatar-lg thumbnail">
               </div>
               <div class="member-detail">
-                <h4>{{ object.username }}</h4>
+                <h4>
+                  {{ object.username }}
+                  {% if object.is_superuser %}
+                    <span class="badge" data-toggle="tooltip" data-trigger="hover" data-placement="left" title="{% trans 'This user has superuser permissions' %}">SU</span>
+                  {% endif %}
+                </h4>
                 <p>{{ object.full_name }}<br>
                 {{ object.email }}<br>
                 <span class="small help-block">{% trans "Last login:" %} {{ object.last_login }}</span></p>
@@ -34,7 +39,7 @@
                 {% csrf_token %}
                 <div class="form-group member-role{% if org_role_form.org_role.errors %} has-error{% endif %}">
                   <label class="control-label" for="{{ org_role_form.org_role.id_for_label }}">{% trans "Role" %}</label>
-                  {% if current_user %}
+                  {% if current_user or object.is_superuser %}
                   <p><strong>{% trans "Administrator" %}</strong></p>
                   {% else %}
                   {% render_field org_role_form.org_role class+="form-control" data-parsley-required="true" %}
@@ -81,7 +86,7 @@
                   </tbody>
                 </table>
               </div>
-              {% if not org_admin %}
+              {% if not org_admin and not object.is_superuser %}
               <div class="panel-footer panel-buttons text-center">
                 <button type="submit" class="btn btn-primary" name="submit">{% trans "Save" %}</button>
                 <a href="{% url 'organization:members' organization.slug %}" class="btn btn-default">{% trans "Cancel" %}</a>

--- a/cadasta/templates/organization/organization_members_edit.html
+++ b/cadasta/templates/organization/organization_members_edit.html
@@ -141,7 +141,7 @@
 {% endblock %}
 
 {% block modals %}
-{% if not current_user  %}
+{% if not current_user or org_member.is_superuser  %}
 <div class="modal fade" id="remove_confirm" tabindex="-1" role="dialog">
   <div class="modal-dialog">
     <div class="modal-content">

--- a/cadasta/templates/organization/organization_members_edit.html
+++ b/cadasta/templates/organization/organization_members_edit.html
@@ -47,9 +47,9 @@
                   <div class="error-block">{{ org_role_form.org_role.errors }}</div>
                 </div>
                 <div class="btn-full">
-                  <button type="button" class="btn btn-danger" name="remove" data-toggle="modal" data-target="#remove_confirm"{% if org_admin and current_user %} disabled{% endif %}>
+                  <button type="button" class="btn btn-danger" name="remove" data-toggle="modal" data-target="#remove_confirm"{% if current_user and not org_member.is_superuser %} disabled{% endif %}>
                     <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> {% trans "Remove member" %}</button>
-                  {% if current_user %}
+                  {% if current_user and not org_member.is_superuser %}
                   <div class="alert alert-full" role="alert">
                     <div class="pull-left"><span class="glyphicon glyphicon-info-sign"></span></div>
                     <div>{% trans "An organization administrator cannot remove themself." %}</div>
@@ -86,7 +86,7 @@
                   </tbody>
                 </table>
               </div>
-              {% if not org_admin and not object.is_superuser %}
+              {% if not org_admin %}
               <div class="panel-footer panel-buttons text-center">
                 <button type="submit" class="btn btn-primary" name="submit">{% trans "Save" %}</button>
                 <a href="{% url 'organization:members' organization.slug %}" class="btn btn-default">{% trans "Cancel" %}</a>


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes #1121: Superusers are always displayed as Administrators on organization permissions page. - Added flags for superusers in templates
- Changed how `ProjectRoleEditField` is initialized in `EditOrganizationMemberProjectPermissionForm` so that superusers are always indicated as admins. 

### When should this PR be merged

After 1.13.0 is released. 

### Risks

None

### Follow-up actions

None

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
