### PR TITLE
Refactor user management views to new permission system

### DIFF
--- a/cadasta/core/views/auth.py
+++ b/cadasta/core/views/auth.py
@@ -151,6 +151,17 @@ class PermissionRequiredMixin(auth_mixins.UserPassesTestMixin):
         return self.has_permission()
 
 
+class SuperUserRequiredMixin(LoginRequiredMixin, PermissionRequiredMixin):
+    """
+    This mixin should be added to views that grant access to superusers only.
+    """
+    def test_func(self):
+        """
+        Returns True if the user is a superuser, the permission is granted.
+        """
+        return self.request.user.is_superuser
+
+
 class OrganizationPermissionMixin(PermissionRequiredMixin):
     """
     Mixin that provides the user's permissions for within organization.

--- a/cadasta/organization/tests/test_views_default_users.py
+++ b/cadasta/organization/tests/test_views_default_users.py
@@ -1,27 +1,13 @@
-import json
 import pytest
 
 from django.test import TestCase
 from django.http import Http404
 
-from tutelary.models import Policy, assign_user_policies
 from skivvy import ViewTestCase
 from core.tests.utils.cases import UserTestCase
 from accounts.tests.factories import UserFactory
 from organization.tests.factories import OrganizationFactory
 from ..views.default import UserList, UserActivation
-from .factories import clause
-
-
-def assign_policies(user):
-    USER_CLAUSES = {
-        'clause': [
-            clause('allow', ['user.list']),
-            clause('allow', ['user.update'], ['user/*'])
-        ]
-    }
-    policy = Policy.objects.create(name='allow', body=json.dumps(USER_CLAUSES))
-    assign_user_policies(user, policy)
 
 
 class UserListTest(ViewTestCase, UserTestCase, TestCase):
@@ -51,11 +37,12 @@ class UserListTest(ViewTestCase, UserTestCase, TestCase):
                 'is_superuser': False}
 
     def test_get_with_user(self):
-        assign_policies(self.user)
+        self.user.is_superuser = True
+        self.user.save()
         response = self.request(user=self.user)
 
         assert response.status_code == 200
-        assert response.content == self.expected_content
+        assert response.content == self.render_content(is_superuser=True)
 
     def test_get_with_unauthorized_user(self):
         response = self.request(user=self.user)
@@ -74,7 +61,8 @@ class UserActivationTest(ViewTestCase, UserTestCase, TestCase):
         self.user = UserFactory.create(is_active=True)
 
     def test_activate_valid(self):
-        assign_policies(self.user)
+        self.user.is_superuser = True
+        self.user.save()
         user = UserFactory.create(is_active=False)
         response = self.request(method='POST',
                                 user=self.user,
@@ -86,7 +74,8 @@ class UserActivationTest(ViewTestCase, UserTestCase, TestCase):
         assert user.is_active is True
 
     def test_deactivate_valid(self):
-        assign_policies(self.user)
+        self.user.is_superuser = True
+        self.user.save()
         user = UserFactory.create(is_active=True)
         response = self.request(method='POST',
                                 user=self.user,
@@ -98,7 +87,8 @@ class UserActivationTest(ViewTestCase, UserTestCase, TestCase):
         assert user.is_active is False
 
     def test_activate_nonexistent_user(self):
-        assign_policies(self.user)
+        self.user.is_superuser = True
+        self.user.save()
         with pytest.raises(Http404):
             self.request(method='POST',
                          user=self.user,
@@ -106,7 +96,8 @@ class UserActivationTest(ViewTestCase, UserTestCase, TestCase):
                          view_kwargs={'new_state': True})
 
     def test_deactivate_nonexistent_user(self):
-        assign_policies(self.user)
+        self.user.is_superuser = True
+        self.user.save()
         with pytest.raises(Http404):
             self.request(method='POST',
                          user=self.user,

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -365,10 +365,9 @@ class OrganizationMembersRemove(mixins.OrganizationMixin,
         return super().test_func()
 
 
-class UserList(LoginPermissionRequiredMixin, generic.ListView):
+class UserList(auth.SuperUserRequiredMixin, generic.ListView):
     model = User
     template_name = 'organization/user_list.html'
-    permission_required = 'user.list'
     permission_denied_message = error_messages.USERS_LIST
 
     def get_queryset(self):
@@ -389,13 +388,9 @@ class UserList(LoginPermissionRequiredMixin, generic.ListView):
         return context
 
 
-class UserActivation(LoginPermissionRequiredMixin, base_generic.View):
-    permission_required = 'user.update'
+class UserActivation(auth.SuperUserRequiredMixin, base_generic.View):
     permission_denied_message = error_messages.USERS_UPDATE
     new_state = None
-
-    def get_perms_objects(self):
-        return [get_object_or_404(User, username=self.kwargs['user'])]
 
     def post(self, request, user):
         userobj = get_object_or_404(User, username=user)


### PR DESCRIPTION
### Proposed changes in this pull request

- Adds `core.views.auth.SuperUserRequiredMixin`, which extends `LoginRequiredMixin` and  `PermissionRequiredMixin`. The mixin overwrites `test_func` so it returns `True` if the current user is a superuser. The mixin should be used for views that can only be accessed by superusers.
- Refactors `organization.views.default.UserList` and `organization.views.default. UserActivation` to use `SuperUserRequiredMixin`. 

### When should this PR be merged

Not going into master; can be merged whenever accepted.

### Risks

None

### Follow-up actions

None

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [x] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [x] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [x] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [x] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [x] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [x] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [x] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [x] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [x] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [x] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [x] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [x] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [x] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [x] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [x] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [x] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [x] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [x] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [x] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [x] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [x] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [x] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [x] Review 2
