### PR TITLE
Update Vagrant/Production code organization

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+VAGRANT_COMMAND = ARGV[0]
 
 Vagrant.configure(2) do |config|
   if Vagrant.has_plugin?("vagrant-proxyconf")
@@ -15,6 +16,13 @@ Vagrant.configure(2) do |config|
           config.proxy.no_proxy = ENV["no_proxy"]
       end
   end
+
+  if VAGRANT_COMMAND == "ssh"
+    config.ssh.username = "cadasta"
+  end
+
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/opt/cadasta/cadasta-platform", create: true
 
   config.vm.box = "ubuntu/trusty64"
   config.vm.network "forwarded_port", guest: 8000, host: 8000

--- a/cadasta/config/settings/default.py
+++ b/cadasta/config/settings/default.py
@@ -303,15 +303,15 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 SASS_PROCESSOR_INCLUDE_DIRS = (
-    os.path.join(os.path.dirname(BASE_DIR), 'core/node_modules'),
+    '/opt/cadasta/node_modules',
 )
 # Required for bootstrap-sass
 # https://github.com/jrief/django-sass-processor
 SASS_PRECISION = 8
 
-MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'core/media')
+MEDIA_ROOT = '/opt/cadasta/media'
 MEDIA_URL = '/media/'
-STATIC_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'core/static')
+STATIC_ROOT = '/opt/cadasta/static'
 STATIC_URL = '/static/'
 
 STATICFILES_FINDERS = (

--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -83,10 +83,10 @@ DEFAULT_FROM_EMAIL = 'Cadasta Platform <platform@cadasta.org>'
 ROOT_URLCONF = 'config.urls.production'
 
 STATIC_URL = '/static/'
-STATIC_ROOT = '/opt/cadasta/cadasta-platform/cadasta/static/'
+STATIC_ROOT = '/opt/cadasta/static'
 
 MEDIA_URL = '/media/'
-MEDIA_ROOT = '/opt/cadasta/cadasta-platform/cadasta/media/'
+MEDIA_ROOT = '/opt/cadasta/media'
 
 # Debug logging...
 LOGGING = {

--- a/provision/ROLES.md
+++ b/provision/ROLES.md
@@ -1,7 +1,6 @@
 | Name                  | Dev? | Prod? | Description |
 |-----------------------|------|-------|-------------|
-| system/aws            |      |   X   | Create `cadasta` Linux user |
-| system/common         |  X   |   X   | Set up `~/.pgpass` |
+| system/common         |  X   |   X   | Create `cadasta` Linux user; set up `~/.pgpass` |
 | db/common             |  X   |   X   | Configure Postgres APT |
 | db/development        |  X   |       | Install Postgres server and other packages; set up local authentication; create Cadasta database, database user; install PostGIS |
 | db/production         |      |   X   | Install Postgres client and other packages; create Cadasta database, database user; install PostGIS |

--- a/provision/aws-deploy.yml
+++ b/provision/aws-deploy.yml
@@ -3,19 +3,14 @@
   remote_user: ubuntu
   gather_facts: true
   vars:
-    base_path: /opt/cadasta/
-    application_path: /opt/cadasta/cadasta-platform/
-    virtualenv_path: /opt/cadasta/env/
     django_settings: config.settings.production
-    app_user: cadasta
-    uwsgi_socket: "{{ application_path }}uwsgi.sock"
   vars_files:
     - shared_vars.yml
   roles:
-    - system/aws
     - system/common
     - db/common
     - db/production
+    - cadasta/common
     - cadasta/install
     - cadasta/application
     - cadasta/production

--- a/provision/roles/cadasta/application/tasks/main.yml
+++ b/provision/roles/cadasta/application/tasks/main.yml
@@ -41,7 +41,7 @@
   become: yes
   become_user: root
   file: path="{{ virtualenv_path | dirname }}" state=directory
-        owner="{{ app_user }}" mode=0755
+        owner="{{ app_user }}" group="{{ app_user }}" mode=0755
 
 - name: Manually create the initial virtualenv
   become: yes
@@ -63,6 +63,18 @@
   pip: virtualenv="{{ virtualenv_path }}"
        requirements="{{ application_path }}requirements/common.txt"
        extra_args="--find-links https://s3.amazonaws.com:443/cadasta-wheelhouse/index.html"
+
+- name: Create directory for static files
+  become: yes
+  become_user: root
+  file: path="{{ base_path }}static" state=directory
+        owner="{{ app_user }}" group="{{ app_user }}" mode=0755
+
+- name: Create directory for media files
+  become: yes
+  become_user: root
+  file: path="{{ base_path }}media" state=directory
+        owner="{{ app_user }}" group="{{ app_user }}" mode=0755
 
 - name: Set up logging directory
   become: yes
@@ -98,7 +110,7 @@
 - name: Install Bootstrap for SASS processing
   become: yes
   become_user: "{{ app_user }}"
-  command: chdir="{{ application_path }}cadasta/core"
+  command: chdir="{{ base_path }}"
            npm install bootstrap-sass
 
 - name: Write platform identifier to core template file

--- a/provision/roles/cadasta/common/tasks/main.yaml
+++ b/provision/roles/cadasta/common/tasks/main.yaml
@@ -1,0 +1,5 @@
+- name: Create base directory for installation
+  become: yes
+  become_user: root
+  file: path="{{ base_path }}" state=directory
+        owner="{{ app_user }}" group="{{ app_user }}" mode=0755

--- a/provision/roles/cadasta/development/tasks/main.yml
+++ b/provision/roles/cadasta/development/tasks/main.yml
@@ -1,4 +1,11 @@
-- name: Install requirements
+- name: Own files synced by Vagrant
+  file: path="{{ application_path }}"
+       owner="{{ app_user }}" group="{{ app_user }}"
+       state=directory
+
+- name: Install dev requirements
+  become: yes
+  become_user: "{{ app_user }}"
   pip: virtualenv="{{ virtualenv_path }}"
        requirements="{{ application_path }}requirements/dev.txt"
        extra_args="--find-links https://s3.amazonaws.com:443/cadasta-wheelhouse/index.html"
@@ -6,20 +13,20 @@
 - name: Activate virtual environment on VM login
   become: yes
   become_user: "{{ app_user }}"
-  lineinfile: dest=/home/vagrant/.bashrc
-              line=". /opt/cadasta/env/bin/activate"
+  lineinfile: dest="/home/{{ app_user }}/.bashrc"
+              line=". {{ virtualenv_path }}bin/activate"
 
 - name: Set up development environment Django settings
   become: yes
   become_user: "{{ app_user }}"
-  lineinfile: dest=/home/vagrant/.bashrc
+  lineinfile: dest="/home/{{ app_user }}/.bashrc"
               line="export DJANGO_SETTINGS_MODULE=config.settings.dev"
 
 - name: Go to cadasta-platform root on VM login
   become: yes
   become_user: "{{ app_user }}"
-  lineinfile: dest=/home/vagrant/.bashrc
-              line="cd /vagrant"
+  lineinfile: dest="/home/{{ app_user }}/.bashrc"
+              line="cd {{ application_path }}"
 
 - name: Install gettext translation utilities
   become: yes
@@ -27,5 +34,7 @@
   apt: pkg=gettext state=installed update_cache=yes
 
 - name: Make Transifex credentials file link
+  become: yes
+  become_user: "{{ app_user }}"
   file: state=link force=yes
-        path=/home/vagrant/.transifexrc src=/vagrant/.transifexrc
+        path="/home/{{ app_user }}/.transifexrc" src={{ application_path }}.transifexrc

--- a/provision/roles/cadasta/install/tasks/main.yml
+++ b/provision/roles/cadasta/install/tasks/main.yml
@@ -1,9 +1,3 @@
-- name: Create base directory for installation
-  become: yes
-  become_user: root
-  file: path="{{ base_path }}" state=directory
-        owner="{{ app_user }}" mode=0755
-
 - name: Clone cadasta-platform repository
   become: yes
   become_user: "{{ app_user }}"

--- a/provision/roles/system/aws/tasks/main.yml
+++ b/provision/roles/system/aws/tasks/main.yml
@@ -1,4 +1,0 @@
-- name: Create Cadasta user
-  become: yes
-  become_user: root
-  user: name=cadasta

--- a/provision/roles/system/common/tasks/main.yml
+++ b/provision/roles/system/common/tasks/main.yml
@@ -1,3 +1,8 @@
+- name: Create system user
+  become: yes
+  become_user: root
+  user: name={{ app_user }} shell=/bin/bash
+
 - name: Create Postgres password file for Cadasta user
   become: yes
   become_user: root

--- a/provision/roles/system/development/tasks/main.yml
+++ b/provision/roles/system/development/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: Create ssh dir
+  become: yes
+  become_user: root
+  file: path="/home/{{ app_user }}/.ssh"
+        state="directory"
+        owner="{{ app_user }}"
+
+- name: Copy vagrant ssh keys
+  become: yes
+  become_user: root
+  copy: src=/home/vagrant/.ssh/authorized_keys dest="/home/{{ app_user }}/.ssh/authorized_keys"
+        owner="{{ app_user }}" mode=0700 remote_src=yes

--- a/provision/roles/testing/tasks/main.yml
+++ b/provision/roles/testing/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Add path to ChromeDriver
   become: yes
   become_user: "{{ app_user }}"
-  lineinfile: dest=/home/vagrant/.bashrc
+  lineinfile: dest=/home/{{ app_user }}/.bashrc
               line="export PATH=/usr/lib/chromium-browser:$PATH"
 
 - name: Download Firefox 46 install bundle
@@ -38,7 +38,7 @@
 - name: Add path to Firefox 46
   become: yes
   become_user: "{{ app_user }}"
-  lineinfile: dest=/home/vagrant/.bashrc
+  lineinfile: dest=/home/{{ app_user }}/.bashrc
               line="export PATH=/opt/firefox:$PATH"
 
 - name: Install Python Selenium driver
@@ -57,11 +57,11 @@
 - name: Set up HTTP proxy
   become: yes
   become_user: "{{ app_user }}"
-  lineinfile: dest=/home/vagrant/.bashrc
+  lineinfile: dest=/home/{{ app_user }}/.bashrc
               line="export http_proxy=http://localhost:3128/"
 
 - name: Set up HTTPS proxy
   become: yes
   become_user: "{{ app_user }}"
-  lineinfile: dest=/home/vagrant/.bashrc
+  lineinfile: dest=/home/{{ app_user }}/.bashrc
               line="export https_proxy=https://localhost:3128/"

--- a/provision/roles/webserver/production/tasks/main.yml
+++ b/provision/roles/webserver/production/tasks/main.yml
@@ -116,7 +116,7 @@
   become_user: root
   cron: name="prune django media files" minute=5 hour=0
         user="root"
-        job="find {{ application_path }}cadasta/media -maxdepth 3 -type f -ctime +1 -exec rm {} \\; > /var/log/django/prune_media.log"
+        job="find {{ base_path }}media -maxdepth 3 -type f -ctime +1 -exec rm {} \\; > /var/log/django/prune_media.log"
 
 - name: Copy uwsgi_params to base directory
   become: yes

--- a/provision/roles/webserver/production/templates/nginx-production
+++ b/provision/roles/webserver/production/templates/nginx-production
@@ -41,11 +41,11 @@ server {
 
     # alias favicon.* to static
     location ~ ^/favicon.(\w*)$ {
-        alias   {{ application_path }}cadasta/static/img/favicon.png;
+        alias   {{ base_path }}static/img/favicon.png;
     }
 
     location /static/ {
-        alias   {{ application_path }}cadasta/static/;
+        alias   {{ base_path }}static/;
     }
 
     location / {
@@ -101,11 +101,11 @@ server {
 
     # alias favicon.* to static
     location ~ ^/favicon.(\w*)$ {
-        alias   {{ application_path }}cadasta/static/favicon.png;
+        alias   {{ base_path }}static/img/favicon.png;
     }
 
     location /static/ {
-        alias   {{ application_path }}cadasta/static/;
+        alias   {{ base_path }}static/;
     }
 
     location / {

--- a/provision/shared_vars.yml
+++ b/provision/shared_vars.yml
@@ -2,3 +2,8 @@ postgresql_version: "9.4"
 aws_postgresql_version: "9.4.5"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"
+base_path: /opt/cadasta/
+application_path: "{{ base_path }}cadasta-platform/"
+virtualenv_path: "{{ base_path }}env/"
+app_user: cadasta
+uwsgi_socket: "{{ application_path }}uwsgi.sock"

--- a/provision/vagrant.yml
+++ b/provision/vagrant.yml
@@ -1,18 +1,16 @@
 - hosts: all
   vars:
-    application_path: /vagrant/
-    virtualenv_path: /opt/cadasta/env/
     django_settings: config.settings.dev
-    app_user: vagrant
-    uwsgi_socket: /tmp/uwsgi.sock
     identifier: local
   vars_files:
     - shared_vars.yml
   roles:
     - system/common
+    - system/development
     - db/common
     - db/development
     - node
+    - cadasta/common
     - cadasta/application
     - cadasta/development
     - testing


### PR DESCRIPTION
### Proposed changes in this pull request

This PR address two small gripes I've had with our Vagrant box and code organization in general:

1. We had our static and media files located within the app code. This was problematic, as Django looks inside our application directory when running `collectstatic` to find static files and would then place the found files somewhere else within our application directory. This would cause failures when trying to run `collectstatic` subsequent times, as the `STATIC_ROOT` value would be found by the `django.contrib.staticfiles.finders.AppDirectoriesFinder`. In my experience, it's common to separate the media and static files from the application, as they should be served differently in production (uwsgi vs nginx).  This basically means:
    - Set `STATIC_ROOT` to `/opt/cadasta/static`
    - Set `MEDIA_ROOT` to `/opt/cadasta/media`
    - Ensure `node_modules` is created in `/opt/cadasta/node_modules`
1. The Vagrant machine's setup varied greatly from the production machine's setup. This is somewhat of a violation of the [Twelve-Factor App's suggestions about dev/production parity](https://12factor.net/dev-prod-parity). By keeping the two environments in sync, it will help developers reason about how a production machine will be configured and keep configuration tooling simpler as there will need to be less deviation between environments. This basically means:
    - Updating the production environment to implement the reorg listed in the point above
    - Update Vagrant to run as the user `cadasta`
    - Update Vagrant to sync the `cadasta-platform` in `/opt/cadasta` to match the location of the folder in production

### When should this PR be merged

Any time.

### Risks

It's possible that I missed some nuances around services that are running (this is especially true if there's an configuration not located within the `provision/` dir.  I've tested this with Vagrant however I have not yet tested this with a production deployment.

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
