### PR TITLE
New deployment configuration

### DIFF
--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -1,4 +1,5 @@
 import os
+import requests
 from .default import *  # NOQA
 
 INSTALLED_APPS += (  # NOQA
@@ -70,6 +71,13 @@ CSRF_COOKIE_SECURE = True
 
 # Adding localhost here for uWSGI debugging!
 ALLOWED_HOSTS = [os.environ['API_HOST'], os.environ['DOMAIN'], 'localhost']
+try:
+    # Append local ip to ALLOWED_HOSTS to allow successful responses from
+    # AWS ELB healthcheck
+    local_ip_url = 'http://169.254.169.254/latest/meta-data/local-ipv4'
+    ALLOWED_HOSTS.append(requests.get(local_ip_url, timeout=0.01).text)
+except requests.exceptions.RequestException:
+    pass
 
 ADMINS = [('Cadasta platform admins', 'platform-admin@cadasta.org'),
           ('Cadasta Platform Errors', os.environ['SLACK_HOOK'])]

--- a/provision/roles/webserver/production/files/nginx.conf
+++ b/provision/roles/webserver/production/files/nginx.conf
@@ -57,6 +57,14 @@ http {
   # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
   ##
+  # Default server
+  ##
+
+  server {
+      return 404;
+  }
+
+  ##
   # Virtual Host Configs
   ##
 
@@ -66,7 +74,7 @@ http {
   ##
   # Block the Bots
   ##
-  
+
   include /etc/nginx/lists/*.conf;
   include /etc/nginx/lists/search_bots;
 }
@@ -75,17 +83,17 @@ http {
 #mail {
 # # See sample authentication script at:
 # # http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
-# 
+#
 # # auth_http localhost/auth.php;
 # # pop3_capabilities "TOP" "USER";
 # # imap_capabilities "IMAP4rev1" "UIDPLUS";
-# 
+#
 # server {
 #   listen     localhost:110;
 #   protocol   pop3;
 #   proxy      on;
 # }
-# 
+#
 # server {
 #   listen     localhost:143;
 #   protocol   imap;

--- a/provision/roles/webserver/production/tasks/main.yml
+++ b/provision/roles/webserver/production/tasks/main.yml
@@ -87,6 +87,14 @@
   notify:
     - Restart nginx
 
+- name: Remove default nginx site from sites-enabled
+  become: yes
+  become_user: root
+  file: path="/etc/nginx/sites-enabled/default"
+        state=absent
+  notify:
+    - Restart nginx
+
 - name: Load static data
   become: yes
   become_user: "{{ app_user }}"

--- a/provision/roles/webserver/production/templates/nginx-production
+++ b/provision/roles/webserver/production/templates/nginx-production
@@ -12,6 +12,7 @@ map $sent_http_content_type $expires {
 
 server {
     listen      80;
+    server_name *.cadasta.org "~^10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$";
 
     set $should_redirect 0;
     # Redirect any HTTP requests to HTTPS

--- a/provision/roles/webserver/production/templates/nginx-production
+++ b/provision/roles/webserver/production/templates/nginx-production
@@ -13,6 +13,20 @@ map $sent_http_content_type $expires {
 server {
     listen      80;
 
+    set $should_redirect 0;
+    # Redirect any HTTP requests to HTTPS
+    if ($http_x_forwarded_proto != 'https') {
+        set $should_redirect 1;
+    }
+    # ... except for ELB Healthchecks, those come in at HTTP being that
+    # they occur behind the load balancer, where everything is HTTP
+    if ($http_user_agent ~* '^ELB-HealthChecker\/.*$') {
+        set $should_redirect 0;
+    }
+    if ($should_redirect) {
+        return 301 https://$host$request_uri;
+    }
+
     expires $expires;
     etag on;
     add_header Cache-Control "private, must-revalidate";

--- a/provision/roles/webserver/production/templates/nginx-production
+++ b/provision/roles/webserver/production/templates/nginx-production
@@ -11,76 +11,7 @@ map $sent_http_content_type $expires {
 }
 
 server {
-    listen      80; #force redirect to https for API URLs
-    server_name {{ api_url }};
-    return      301         https://{{ api_url }}$request_uri;
-}
-
-server {
-    listen      80; #force redirect to https for platform URLs
-    server_name {{ main_url }};
-    return      301         https://{{ main_url }}$request_uri;
-}
-
-server {
-    listen      443 ssl;
-    server_name {{ api_url }};
-
-    if ($http_host != "{{ api_url }}") {
-        return 403;
-    }
-
-    ssl_certificate     /etc/ssl/private/domain.crt;
-    ssl_certificate_key /etc/ssl/private/domain.key;
-
-    charset     utf-8;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Url-Scheme $scheme;
-
-    client_max_body_size 75M;
-
-    # alias favicon.* to static
-    location ~ ^/favicon.(\w*)$ {
-        alias   {{ application_path }}cadasta/static/img/favicon.png;
-    }
-
-    location /static/ {
-        alias   {{ application_path }}cadasta/static/;
-    }
-
-    location / {
-        if ($request_method = OPTIONS) {
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, PATCH, POST, DELETE, OPTIONS';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Headers' 'Authorization,Access-Control-Allow-Origin,Content-Type';
-            add_header Content-Length 0;
-            add_header Content-Type text/plain;
-            add_header Access-Control-Max-Age 1728000;
-            return 200;
-        }
-
-        uwsgi_pass  django;
-        include     {{ application_path }}uwsgi_params;
-        uwsgi_read_timeout 30;
-        add_header 'X-Robots-Tag' 'noindex, nofollow, nosnippet, noarchive, noodp, noimageindex';
-        add_header 'Access-Control-Allow-Methods' 'GET, PUT, PATCH, POST, DELETE, OPTIONS';
-        add_header 'Access-Control-Allow-Origin' '*' always;
-        add_header 'Access-Control-Allow-Headers' 'Authorization,Access-Control-Allow-Origin,Content-Type';
-        proxy_set_header X-Forwarded-Protocol $scheme;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-}
-
-server {
-    listen      443 ssl;
-    server_name {{ main_url }};
-
-    if ($http_host != "{{ main_url }}") {
-        return 403;
-    }
-
-    ssl_certificate     /etc/ssl/private/domain.crt;
-    ssl_certificate_key /etc/ssl/private/domain.key;
+    listen      80;
 
     expires $expires;
     etag on;

--- a/provision/roles/webserver/production/templates/nginx-production
+++ b/provision/roles/webserver/production/templates/nginx-production
@@ -28,6 +28,9 @@ server {
         return 301 https://$host$request_uri;
     }
 
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Url-Scheme $scheme;
+
     expires $expires;
     etag on;
     add_header Cache-Control "private, must-revalidate";
@@ -47,16 +50,30 @@ server {
 
     # alias favicon.* to static
     location ~ ^/favicon.(\w*)$ {
-        alias   {{ application_path }}cadasta/static/favicon.png;
+        alias   {{ application_path }}cadasta/static/img/favicon.png;
     }
 
     location /static/ {
         alias   {{ application_path }}cadasta/static/;
     }
 
+    location /api {
+        uwsgi_pass  django;
+        include {{ application_path }};
+        uwsgi_read_timeout 30;
+
+        add_header Cache-Control "private, must-revalidate";
+        add_header 'X-Robots-Tag' 'noindex, nofollow, nosnippet, noarchive, noodp, noimageindex';
+
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization,Access-Control-Allow-Origin,Content-Type';
+    }
+
     location / {
         uwsgi_pass  django;
         include {{ application_path }}uwsgi_params;
+
+        add_header Cache-Control "private, must-revalidate";
         add_header 'X-Robots-Tag' 'noindex, nofollow, nosnippet, noarchive, noodp, noimageindex';
     }
 }

--- a/provision/roles/webserver/production/templates/nginx-production
+++ b/provision/roles/webserver/production/templates/nginx-production
@@ -59,7 +59,7 @@ server {
 
     location /api {
         uwsgi_pass  django;
-        include {{ application_path }};
+        include {{ application_path }}uwsgi_params;
         uwsgi_read_timeout 30;
 
         add_header Cache-Control "private, must-revalidate";


### PR DESCRIPTION
### Proposed changes in this pull request

This PR contains a few changes to how we deploy the Cadasta-Platform.  This includes:

* Attempting to add the local IP of the AWS instance to Django's `ALLOWED_HOSTS` setting. This is important as the AWS Elastic Load Balancer will be doing healthchecks on the instance(s) attached to the load balancer. This occurs by sending a GET request to `/account/login` to test the service's health. Being that the healthcheck will be targeting a single machine, the HOST value of the request will be the machine's internal IP address (`10.*.*.*`)
* Add a default server that will simply return a 404 to the user. This is important as NGINX will try to serve _something_ to a user. If a user makes a request to NGINX with a HOST value not matching the NGINX server's `server_name` value, that server will still be served to the user if there is no fallback server.  This is the purpose of the default 404 server.
* Remove default nginx site from sites-enabled. This is basically the old default server. I removed it and then realized that it was needed after already adding the new default 404 server. I thought we may as well keep this change, as it was already written and will result in less traffic being sent to malicious requests.
* The NGINX server is now only configured to listen to port 80. All SSL tooling is handled by the Elastic Load Balancer. Anything behind the load balancer is decrypted communication that occurs within our VPC. This simplified the configuration substantially. The server is written to respond to any request with a HOST value ending in `cadasta.org` or with a HOST value equalling a local (`10.*.*.*`) IP address
* I have done away with the idea of a special API hostname. To my knowledge, nobody ever used `platform-staging-api.cadasta.org` or that endpoint for any other environment.

For more information on the overall design of the new deployment, see this following diagram:

![network diagram 2](https://user-images.githubusercontent.com/897290/32352676-d411573c-bfe7-11e7-95b9-638c84e99116.png)

I'm unsure how you could test this. One idea, on your Vagrant machine:

1. `sudo apt-get install nginx`
1. `sudo cp /vagrant/provision/roles/webserver/production/files/nginx.conf /etc/nginx`
1. `sudo rm /etc/nginx/sites-enabled/default`
1. `sudo cp /vagrant/provision/roles/webserver/production/templates/nginx-production /etc/nginx/sites-enabled/cadasta`
1. Manually edit `/vagrant/provision/roles/webserver/production/templates/nginx-production`, removing template variables and replacing them with their real values, replace the upstream server to:
    ```
    upstream django {
        server localhost:8000
    }
    ```
1. `sudo service nginx reload`


On your host machine:

1. add the following line to `/etc/hosts`:
    ```
    127.0.0.1 dev.cadasta.org
    ```
1. Edit `Vagrantfile` to forward the `guest` machine's port `80` to the host machine's port `8081`

Run `curl http://localhost:8081/account/login`, you should get a `404`
Run `curl http://dev.cadasta.org:8081/account/log`, you should get the login page

### When should this PR be merged

Before anything else is deployed to staging, as deploying something to staging without this configuration will break the AWS setup.

### Risks

None foreseen.

### Follow-up actions

When this is deployed to `demo` or `platform`, AWS routing configuration will need to first be changed to support this new deployment architecture.


### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [x] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [x] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [x] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [x] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [x] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [x] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [x] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [x] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [x] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [x] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [x] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [x] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [x] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [x] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [x] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [x] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [x] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [x] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [x] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [x] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [x] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [x] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [x] Review 2
