### PR TITLE
Refactor test_func --> has_permission

### DIFF
--- a/cadasta/core/tests/test_auth.py
+++ b/cadasta/core/tests/test_auth.py
@@ -45,6 +45,12 @@ class LoginRequiredTest(ViewTestCase, TestCase):
 
 
 class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
+    def assign_user(self, view):
+        user = UserFactory.build()
+        request = Mock()
+        request.user = user
+        view.request = request
+
     def test_permission_required_not_defined(self):
         """
         If neither permission_required is defined or get_permission_required is
@@ -104,6 +110,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
                 return ('some.perm', )
 
         view = TestView()
+        self.assign_user(view)
         assert view.has_permission() is True
 
     def test_has_permission_with_tuple(self):
@@ -117,6 +124,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
                 return ('some.perm', 'other.perm')
 
         view = TestView()
+        self.assign_user(view)
         assert view.has_permission() is True
 
     def test_has_permission_with_list(self):
@@ -130,6 +138,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
                 return ('some.perm', 'other.perm')
 
         view = TestView()
+        self.assign_user(view)
         assert view.has_permission() is True
 
     def test_has_no_permission_with_permission_required_method(self):
@@ -146,6 +155,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
                 return 'other.perm'
 
         view = TestView()
+        self.assign_user(view)
         assert view.has_permission() is False
 
     def test_has_permission_with_permission_required_method(self):
@@ -162,6 +172,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
                 return 'other.perm'
 
         view = TestView()
+        self.assign_user(view)
         assert view.has_permission() is True
 
     def test_has_permission_permission_denied(self):
@@ -176,6 +187,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
                 return ('other.perm', )
 
         view = TestView()
+        self.assign_user(view)
         assert view.has_permission() is False
 
     def test_has_permission_permission_denied_with_list(self):
@@ -190,6 +202,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
                 return ('some.perm', 'another.perm')
 
         view = TestView()
+        self.assign_user(view)
         assert view.has_permission() is False
 
     def test_has_permission_permission_denied_only_one_perm(self):
@@ -204,6 +217,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
                 return ('some.perm', )
 
         view = TestView()
+        self.assign_user(view)
         assert view.has_permission() is False
 
     def test_has_permission_permission_granted_for_list(self):
@@ -218,6 +232,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
                 return ('some.perm', 'other.perm', 'third.perm')
 
         view = TestView()
+        self.assign_user(view)
         assert view.has_permission() is True
 
     def test_has_permission_permission_denied_for_list(self):
@@ -232,14 +247,15 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
                 return ('some.perm', 'third.perm')
 
         view = TestView()
+        self.assign_user(view)
         assert view.has_permission() is False
 
-    def test_test_with_superuser(self):
+    def test_has_permission_with_superuser(self):
         """
-        For superuser test_func should always return True even if permission
-        would be denied otherwise.
+        For superusers has_permission should always return True even if
+        permission would be denied otherwise.
         """
-        user = UserFactory.create(is_superuser=True)
+        user = UserFactory.build(is_superuser=True)
         request = Mock()
         request.user = user
 
@@ -251,26 +267,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
 
         view = TestView()
         view.request = request
-        assert view.test_func() is True
-
-    def test_test_with_standarduser(self):
-        """
-        For standard users test_func should always return False if permission
-        is denied.
-        """
-        user = UserFactory.create()
-        request = Mock()
-        request.user = user
-
-        class TestView(auth.PermissionRequiredMixin, View):
-            permission_required = ['some.perm']
-
-            def get_perms(self):
-                return ('other.perm', )
-
-        view = TestView()
-        view.request = request
-        assert view.test_func() is False
+        assert view.has_permission() is True
 
     def test_raise_permission_denied(self):
         """
@@ -286,7 +283,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
 
         self.view_class = TestView
 
-        user = UserFactory.create()
+        user = UserFactory.build()
         referer = '/organizations/abc/projects/123'
 
         with pytest.raises(PermissionDenied):
@@ -306,7 +303,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
 
         self.view_class = TestView
 
-        user = UserFactory.create()
+        user = UserFactory.build()
         referer = '/organizations/abc/projects/123'
 
         response = self.request(user=user,
@@ -332,7 +329,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
 
         self.view_class = TestView
 
-        user = UserFactory.create()
+        user = UserFactory.build()
         referer = '/account/login/'
         url_kwargs = {'organization': 'abc', 'project': '123'}
 
@@ -359,7 +356,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
 
             def get_perms(self):
                 return ('other.perm', )
-        user = UserFactory.create()
+        user = UserFactory.build()
 
         view = TestView.as_view()
 
@@ -402,7 +399,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
 
         self.view_class = TestView
 
-        user = UserFactory.create()
+        user = UserFactory.build()
         referer = '/account/login/'
         url_kwargs = {'slug': 'abc'}
 
@@ -430,7 +427,7 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
             def get_perms(self):
                 return ('other.perm', )
 
-        user = UserFactory.create()
+        user = UserFactory.build()
         view = TestView.as_view()
 
         request = HttpRequest()
@@ -459,39 +456,40 @@ class PermissionRequiredTest(UserTestCase, ViewTestCase, TestCase):
 class SuperUserRequiredTest(UserTestCase, ViewTestCase, TestCase):
     def test_with_superuser(self):
         """
-        For superusers, test_func should return True; the permission is granted
+        For superusers, has_permission should return True; the permission is
+        granted
         """
         class TestView(auth.SuperUserRequiredMixin, View):
             pass
 
-        user = UserFactory.create(is_superuser=True)
+        user = UserFactory.build(is_superuser=True)
         request = Mock()
         request.user = user
 
         view = TestView()
         view.request = request
-        assert view.test_func() is True
+        assert view.has_permission() is True
 
     def test_with_standard_user(self):
         """
-        For standard users, test_func should return False; the permission is
-        denied
+        For standard users, has_permission should return False; the permission
+        is denied
         """
         class TestView(auth.SuperUserRequiredMixin, View):
             pass
 
-        user = UserFactory.create(is_superuser=False)
+        user = UserFactory.build(is_superuser=False)
         request = Mock()
         request.user = user
 
         view = TestView()
         view.request = request
-        assert view.test_func() is False
+        assert view.has_permission() is False
 
     def test_with_anonymous_user(self):
         """
-        For anonymous users, test_func should return False; the permission is
-        denied
+        For anonymous users, has_permission should return False; the
+        permission is denied
         """
         class TestView(auth.SuperUserRequiredMixin, View):
             pass
@@ -502,4 +500,4 @@ class SuperUserRequiredTest(UserTestCase, ViewTestCase, TestCase):
 
         view = TestView()
         view.request = request
-        assert view.test_func() is False
+        assert view.has_permission() is False

--- a/cadasta/core/views/auth.py
+++ b/cadasta/core/views/auth.py
@@ -129,8 +129,7 @@ class PermissionRequiredMixin(auth_mixins.UserPassesTestMixin):
         everything in the platform); or if all required permissions are met
         by the user's permissions as returned by `get_perms`.
         """
-        user = self.request.user
-        if not user.is_anonymous and user.is_superuser:
+        if self.request.user.is_superuser:
             return True
 
         permissions_required = self.get_permission_required()

--- a/cadasta/core/views/auth.py
+++ b/cadasta/core/views/auth.py
@@ -125,9 +125,14 @@ class PermissionRequiredMixin(auth_mixins.UserPassesTestMixin):
 
     def has_permission(self):
         """
-        Returns True if all required permissions are met by the user's
-        permissions as returned by `get_perms`.
+        Returns True if the user is a superuser (superuser can do
+        everything in the platform); or if all required permissions are met
+        by the user's permissions as returned by `get_perms`.
         """
+        user = self.request.user
+        if not user.is_anonymous and user.is_superuser:
+            return True
+
         permissions_required = self.get_permission_required()
         if not isinstance(permissions_required, (list, tuple)):
             permissions_required = (permissions_required, )
@@ -138,16 +143,11 @@ class PermissionRequiredMixin(auth_mixins.UserPassesTestMixin):
     def test_func(self):
         """
         `test_func` is the entry point for UserPassesTestMixin to validate
-        user's permissions on a view.
-
-        It always returns `True` if the user is a superuser (superuser can do
-        everything in the platform); otherwise it returns the value of
-        `has_permission`.
+        user's permissions on a view. It simply returns the value of
+        `has_permission`. That way we can overwrite `has_permission` instead
+        of `test_func` in implementing views, which allows us to use a more
+        obvious method name.
         """
-        user = self.request.user
-        if not user.is_anonymous and user.is_superuser:
-            return True
-
         return self.has_permission()
 
 
@@ -155,7 +155,7 @@ class SuperUserRequiredMixin(LoginRequiredMixin, PermissionRequiredMixin):
     """
     This mixin should be added to views that grant access to superusers only.
     """
-    def test_func(self):
+    def has_permission(self):
         """
         Returns True if the user is a superuser, the permission is granted.
         """

--- a/cadasta/organization/views/default.py
+++ b/cadasta/organization/views/default.py
@@ -142,11 +142,11 @@ class OrganizationEdit(auth.LoginRequiredMixin,
     def get_success_url(self):
         return reverse('organization:dashboard', kwargs=self.kwargs)
 
-    def test_func(self):
+    def has_permission(self):
         if self.get_object().archived:
             return False
 
-        return super().test_func()
+        return super().has_permission()
 
 
 class OrgArchiveView(auth.LoginRequiredMixin,
@@ -312,11 +312,11 @@ class OrganizationMembersEdit(mixins.OrganizationMixin,
         form.save()
         return super().form_valid(form)
 
-    def test_func(self):
+    def has_permission(self):
         if self.get_organization().archived:
             return False
 
-        return super().test_func()
+        return super().has_permission()
 
 
 class OrganizationMembersRemove(mixins.OrganizationMixin,
@@ -358,11 +358,11 @@ class OrganizationMembersRemove(mixins.OrganizationMixin,
             return redirect('organization:members_edit', **self.kwargs)
         return super().delete(*args, **kwargs)
 
-    def test_func(self):
+    def has_permission(self):
         if self.get_organization().archived:
             return False
 
-        return super().test_func()
+        return super().has_permission()
 
 
 class UserList(auth.SuperUserRequiredMixin, generic.ListView):


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds changes following the [discussions in #1855](https://github.com/Cadasta/cadasta-platform/pull/1855#discussion_r148658858). 

It unifies the use of `test_func` vs. `has_permission`. `has_permission` will now be used to work out if the view's user has permission to the view.

`test_func` is still present in `PermissionRequiredMixin` because it's the default method to get permissions. It calls `has_permission`.

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]



### Risks

[List any risks that could arise from merging your pull request.]

-

### Follow-up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
