### PR TITLE
Fix #1863 -- Remove option to switch between phone and email identifiers

### DIFF
--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -140,16 +140,12 @@ class ProfileForm(SanitizeFieldsForm, forms.ModelForm):
         self.request = kwargs.pop('request', None)
         super().__init__(*args, **kwargs)
         self.current_email = self.instance.email
+        if self.current_email:
+            self.fields['email'].required = True
+
         self.current_phone = self.instance.phone
-
-    def clean(self):
-        super(ProfileForm, self).clean()
-        email = self.data.get('email')
-        phone = self.data.get('phone')
-
-        if not phone and not email:
-            raise forms.ValidationError(
-                _("You cannot leave both phone and email empty."))
+        if self.current_phone:
+            self.fields['phone'].required = True
 
     def clean_username(self):
         username = self.data.get('username')
@@ -183,12 +179,6 @@ class ProfileForm(SanitizeFieldsForm, forms.ModelForm):
         else:
             phone = None
 
-            if (self.current_phone and
-                    not self.current_email and self.data.get('email')):
-                raise forms.ValidationError(
-                    _('It is not possible to change from phone to email for '
-                      'your account identifier.'))
-
         return phone
 
     def clean_email(self):
@@ -201,12 +191,6 @@ class ProfileForm(SanitizeFieldsForm, forms.ModelForm):
                     _("User with this Email address already exists."))
         else:
             email = None
-
-            if (self.current_email and
-                    not self.current_phone and self.data.get('phone')):
-                raise forms.ValidationError(
-                    _('It is not possible to change from email to phone for '
-                      'your account identifier.'))
 
         return email
 

--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -212,24 +212,16 @@ class ProfileForm(SanitizeFieldsForm, forms.ModelForm):
 
     def save(self, *args, **kwargs):
         user = super().save(commit=False, *args, **kwargs)
-        email_update_message = None
+        # email_update_message = None
 
         if self.current_email != user.email:
             current_email_set = self.instance.emailaddress_set.all()
             if current_email_set.exists():
                 current_email_set.delete()
 
-            if user.email:
-                send_email_confirmation(self.request, user)
-                email_update_message = messages.email_change
-
-                if self.current_email:
-                    utils.send_email_update_notification(self.current_email)
-                    user.email = self.current_email
-            else:
-                user.email_verified = False
-                email_update_message = messages.email_delete
-                utils.send_email_deleted_notification(self.current_email)
+            send_email_confirmation(self.request, user)
+            utils.send_email_update_notification(self.current_email)
+            user.email = self.current_email
 
         if self.current_phone != user.phone:
             current_phone_set = VerificationDevice.objects.filter(
@@ -237,23 +229,12 @@ class ProfileForm(SanitizeFieldsForm, forms.ModelForm):
             if current_phone_set.exists():
                 current_phone_set.delete()
 
-            if user.phone:
-                device = VerificationDevice.objects.create(
-                    user=self.instance, unverified_phone=user.phone)
-                device.generate_challenge()
-                if self.current_phone:
-                    utils.send_sms(self.current_phone, messages.phone_change)
-                    user.phone = self.current_phone
-                if user.email:
-                    utils.send_phone_update_notification(user.email)
-            else:
-                user.phone_verified = False
-                utils.send_sms(self.current_phone, messages.phone_delete)
-                if user.email:
-                    utils.send_phone_deleted_notification(user.email)
+            device = VerificationDevice.objects.create(
+                user=self.instance, unverified_phone=user.phone)
+            device.generate_challenge()
+            utils.send_sms(self.current_phone, messages.phone_change)
+            user.phone = self.current_phone
 
-        if user.phone and email_update_message:
-            utils.send_sms(user.phone, email_update_message)
         user.save()
         return user
 

--- a/cadasta/accounts/forms.py
+++ b/cadasta/accounts/forms.py
@@ -182,6 +182,13 @@ class ProfileForm(SanitizeFieldsForm, forms.ModelForm):
 
         else:
             phone = None
+
+            if (self.current_phone and
+                    not self.current_email and self.data.get('email')):
+                raise forms.ValidationError(
+                    _('It is not possible to change from phone to email for '
+                      'your account identifier.'))
+
         return phone
 
     def clean_email(self):
@@ -194,6 +201,12 @@ class ProfileForm(SanitizeFieldsForm, forms.ModelForm):
                     _("User with this Email address already exists."))
         else:
             email = None
+
+            if (self.current_email and
+                    not self.current_phone and self.data.get('phone')):
+                raise forms.ValidationError(
+                    _('It is not possible to change from email to phone for '
+                      'your account identifier.'))
 
         return email
 

--- a/cadasta/accounts/messages.py
+++ b/cadasta/accounts/messages.py
@@ -16,19 +16,6 @@ unverified_identifier = _(
     "You have not verified your phone or email. We request you to verify"
     " your registered phone or email in order to access your account.")
 
-# send an sms to the user's phone(if any) notifying the removal of email
-email_delete = _(
-    "You are receiving this message because a user at Cadasta Platform removed"
-    " the email address from the account linked to this phone number."
-    " If it wasn't you, please contact us immediately at security@cadasta.org")
-
-# send an sms to the user's phone(if any) notifying the change in email
-email_change = _(
-    "You are receiving this message because a user at Cadasta Platform updated"
-    " the email address for the account linked to this phone"
-    " number."
-    " If it wasn't you, please contact us immediately at security@cadasta.org")
-
 # send an sms to the user's old phone(if any) notifying the removal of phone
 phone_delete = _(
     "You are receiving this message because a user at Cadasta Platform removed"

--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -63,6 +63,12 @@ class RegistrationSerializer(SanitizeFieldSerializer,
 
         email = self.initial_data.get('email')
         phone = self.initial_data.get('phone')
+
+        if phone and email:
+            raise serializers.ValidationError(
+                _("You can either use your phone number or email to sign up "
+                  "but not both."))
+
         if (not phone) and (not email):
             raise serializers.ValidationError(
                 _("You cannot leave both phone and email empty."

--- a/cadasta/accounts/serializers.py
+++ b/cadasta/accounts/serializers.py
@@ -78,6 +78,7 @@ class RegistrationSerializer(SanitizeFieldSerializer,
                     _("User with this Email address already exists."))
         else:
             email = None
+
         return email
 
     def validate_phone(self, phone):
@@ -93,6 +94,7 @@ class RegistrationSerializer(SanitizeFieldSerializer,
                     _("Please enter a valid country code."))
         else:
             phone = None
+
         return phone
 
     def validate_username(self, username):
@@ -221,6 +223,12 @@ class UserSerializer(SanitizeFieldSerializer,
                     _("User with this Email address already exists."))
         else:
             email = None
+
+            if (instance and instance.email and
+                    not instance.phone and self.initial_data.get('phone')):
+                raise serializers.ValidationError(
+                    _('It is not possible to change from email to phone for '
+                      'your account identifier.'))
         return email
 
     def validate_phone(self, phone):
@@ -246,6 +254,12 @@ class UserSerializer(SanitizeFieldSerializer,
                     _("Please enter a valid country code."))
         else:
             phone = None
+
+            if (instance and instance.phone and
+                    not instance.email and self.initial_data.get('email')):
+                raise serializers.ValidationError(
+                    _('It is not possible to change from phone to email for '
+                      'your account identifier.'))
         return phone
 
     def validate_username(self, username):

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -446,12 +446,11 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
                                   password='sgt-pepper',
                                   language='en',
                                   measurement='metric',
-                                  phone='+919327768250',
+                                  phone=None,
                                   phone_verified=True)
         data = {
             'username': 'imagine71',
             'email': 'john2@beatles.uk',
-            'phone': '+12345678990',
             'full_name': 'John Lennon',
             'password': 'sgt-pepper',
             'language': 'en',
@@ -475,12 +474,10 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         assert user.language == 'en'
         assert user.measurement == 'imperial'
         assert user.email_verified is True
-        assert user.phone == '+919327768250'
         assert user.phone_verified is True
-        assert len(mail.outbox) == 3
+        assert len(mail.outbox) == 2
         assert 'john2@beatles.uk' in mail.outbox[0].to
         assert 'john@beatles.uk' in mail.outbox[1].to
-        assert 'john@beatles.uk' in mail.outbox[2].to
 
     def test_display_name(self):
         user = UserFactory.create(username='imagine71',
@@ -568,12 +565,11 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         UserFactory.create(email='existing@example.com')
         user = UserFactory.create(username='imagine71',
                                   email='john@beatles.uk',
-                                  phone='+919327768250',
+                                  phone=None,
                                   password='sgt-pepper')
         data = {
             'username': 'imagine71',
             'email': 'existing@example.com',
-            'phone': '+919327768250',
             'full_name': 'John Lennon',
             'password': 'sgt-pepper',
             'language': 'en'
@@ -599,7 +595,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_signup_with_released_email(self):
         user = UserFactory.create(username='user1',
                                   email='user1@example.com',
-                                  phone='+919327768250',
+                                  phone=None,
                                   email_verified=True,
                                   password='sgt-pepper',
                                   measurement='metric')
@@ -611,7 +607,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
             'email': 'user1_email_change@example.com',
             'language': 'en',
             'measurement': 'metric',
-            'phone': '+919327768250',
             'password': 'sgt-pepper'
         }
 
@@ -633,12 +628,11 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_update_email_with_incorrect_password(self):
         user = UserFactory.create(email='john@beatles.uk',
-                                  phone='+919327768250',
+                                  phone=None,
                                   password='imagine71')
         data = {
             'username': 'imagine71',
             'email': 'john2@beatles.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'full_name': 'John Lennon',
@@ -652,12 +646,11 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_sanitize(self):
         user = UserFactory.create(email='john@beatles.uk',
-                                  phone='+919327768250',
+                                  phone=None,
                                   password='imagine71')
         data = {
             'username': '😛😛😛😛',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'password': 'Iloveyoko68!',
             'full_name': 'John Lennon'
         }
@@ -666,9 +659,9 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         assert form.is_valid() is False
         assert SANITIZE_ERROR in form.errors.get('username')
 
-    def test_update_phone_only(self):
+    def test_update_phone(self):
         user = UserFactory.create(username='sherlock',
-                                  email='sherlock.holmes@bbc.uk',
+                                  email=None,
                                   phone='+919327768250',
                                   email_verified=True,
                                   phone_verified=True,
@@ -678,7 +671,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
                                           unverified_phone=user.phone)
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+12345678990',
             'language': 'en',
             'measurement': 'metric',
@@ -694,13 +686,11 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         assert user.phone_verified is True
         assert VerificationDevice.objects.filter(
             unverified_phone='+919327768250').exists() is False
-        assert len(mail.outbox) == 1
-        assert 'sherlock.holmes@bbc.uk' in mail.outbox[0].to
 
-    def test_update_email_only(self):
+    def test_update_email(self):
         user = UserFactory.create(username='sherlock',
                                   email='sherlock.holmes@bbc.uk',
-                                  phone='+919327768250',
+                                  phone=None,
                                   email_verified=True,
                                   phone_verified=True,
                                   password='221B@bakerstreet',
@@ -710,7 +700,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         data = {
             'username': 'sherlock',
             'email': 'john.watson@bbc.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': '221B@bakerstreet',
@@ -740,7 +729,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_update_with_duplicate_phone(self):
         UserFactory.create(phone='+12345678990')
         user = UserFactory.create(username='sherlock',
-                                  email='sherlock.holmes@bbc.uk',
+                                  email=None,
                                   email_verified=True,
                                   phone_verified=True,
                                   phone='+919327768250',
@@ -749,7 +738,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+12345678990',
             'language': 'en',
             'measurement': 'metric',
@@ -761,70 +749,9 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         assert (_("User with this Phone number already exists.")
                 in form.errors.get('phone'))
 
-    def test_update_add_phone(self):
-        user = UserFactory.create(username='sherlock',
-                                  email='sherlock.holmes@bbc.uk',
-                                  phone=None,
-                                  email_verified=True,
-                                  password='221B@bakerstreet',
-                                  full_name='Sherlock Holmes')
-
-        data = {
-            'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
-            'phone': '+919327768250',
-            'language': 'en',
-            'measurement': 'metric',
-            'password': '221B@bakerstreet',
-            'full_name': 'Sherlock Holmes'
-        }
-        form = forms.ProfileForm(data=data, instance=user)
-        assert form.is_valid() is True
-        form.save()
-
-        user.refresh_from_db()
-        assert user.phone == '+919327768250'
-        assert user.phone_verified is False
-        assert VerificationDevice.objects.count() == 1
-        assert len(mail.outbox) == 1
-        assert 'sherlock.holmes@bbc.uk' in mail.outbox[0].to
-
-    def test_update_add_email(self):
-        user = UserFactory.create(username='sherlock',
-                                  phone='+919327768250',
-                                  email=None,
-                                  phone_verified=True,
-                                  password='221B@bakerstreet',
-                                  full_name='Sherlock Holmes')
-
-        data = {
-            'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
-            'phone': '+919327768250',
-            'language': 'en',
-            'measurement': 'metric',
-            'password': '221B@bakerstreet',
-            'full_name': 'Sherlock Holmes'
-        }
-        request = HttpRequest()
-        setattr(request, 'session', 'session')
-        self.messages = FallbackStorage(request)
-        setattr(request, '_messages', self.messages)
-        request.META['SERVER_NAME'] = 'testserver'
-        request.META['SERVER_PORT'] = '80'
-
-        form = forms.ProfileForm(data, request=request, instance=user)
-        assert form.is_valid() is True
-        form.save()
-
-        user.refresh_from_db()
-        assert user.email == 'sherlock.holmes@bbc.uk'
-        assert user.email_verified is False
-        assert len(mail.outbox) == 1
-
     def test_udpate_with_invalid_phone(self):
         user = UserFactory.create(username='sherlock',
-                                  email='sherlock.holmes@bbc.uk',
+                                  email=None,
                                   phone='+919327768250',
                                   email_verified=True,
                                   phone_verified=True,
@@ -832,7 +759,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
                                   full_name='Sherlock Holmes')
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': 'Test Number',
             'password': '221B@bakerstreet',
             'language': 'en',
@@ -845,7 +771,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '9327768250',
             'password': '221B@bakerstreet',
             'full_name': 'Sherlock Holmes'
@@ -905,31 +830,9 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         assert (_("Please enter a valid country code.")
                 in form.errors.get('phone'))
 
-    def test_update_remove_both_phone_and_email(self):
-        user = UserFactory.create(username='sherlock',
-                                  email='sherlock.holmes@bbc.uk',
-                                  phone='+919327768250',
-                                  email_verified=True,
-                                  phone_verified=True,
-                                  password='221B@bakerstreet',
-                                  full_name='Sherlock Holmes')
-        data = {
-            'username': 'sherlock',
-            'email': '',
-            'phone': '',
-            'language': 'en',
-            'measurement': 'metric',
-            'password': '221B@bakerstreet',
-            'full_name': 'Sherlock Holmes'
-        }
-        form = forms.ProfileForm(data=data, instance=user)
-        assert form.is_valid() is False
-        assert (_("You cannot leave both phone and email empty.")
-                in form.errors.get('__all__'))
-
     def test_update_remove_phone(self):
         user = UserFactory.create(username='sherlock',
-                                  email='sherlock.holmes@bbc.uk',
+                                  email=None,
                                   phone='+919327768250',
                                   email_verified=True,
                                   phone_verified=True,
@@ -939,7 +842,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
                                           unverified_phone=user.phone)
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '',
             'language': 'en',
             'measurement': 'metric',
@@ -947,20 +849,12 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
             'full_name': 'Sherlock Holmes'
         }
         form = forms.ProfileForm(data=data, instance=user)
-        assert form.is_valid() is True
-        form.save()
-
-        user.refresh_from_db()
-        assert not user.phone
-        assert user.phone_verified is False
-        assert VerificationDevice.objects.count() == 0
-        assert len(mail.outbox) == 1
-        assert 'sherlock.holmes@bbc.uk' in mail.outbox[0].to
+        assert form.is_valid() is False
 
     def test_update_remove_email(self):
         user = UserFactory.create(username='sherlock',
                                   email='sherlock.holmes@bbc.uk',
-                                  phone='+919327768250',
+                                  phone=None,
                                   email_verified=True,
                                   phone_verified=True,
                                   password='221B@bakerstreet',
@@ -970,37 +864,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         data = {
             'username': 'sherlock',
             'email': '',
-            'phone': '+919327768250',
-            'language': 'en',
-            'measurement': 'metric',
-            'password': '221B@bakerstreet',
-            'full_name': 'Sherlock Holmes'
-        }
-        form = forms.ProfileForm(data=data, instance=user)
-        assert form.is_valid() is True
-        form.save()
-
-        user.refresh_from_db()
-        assert not user.email
-        assert user.email_verified is False
-        assert EmailAddress.objects.count() == 0
-        assert len(mail.outbox) == 1
-        assert 'sherlock.holmes@bbc.uk' in mail.outbox[0].to
-
-    def test_update_add_phone_and_remove_email(self):
-        user = UserFactory.create(username='sherlock',
-                                  email='sherlock.holmes@bbc.uk',
-                                  phone=None,
-                                  email_verified=True,
-                                  password='221B@bakerstreet',
-                                  full_name='Sherlock Holmes')
-
-        EmailAddress.objects.create(user=user, email=user.email)
-
-        data = {
-            'username': 'sherlock',
-            'email': '',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': '221B@bakerstreet',
@@ -1008,125 +871,13 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         }
         form = forms.ProfileForm(data=data, instance=user)
         assert form.is_valid() is False
-        assert ('It is not possible to change from email to phone for '
-                'your account identifier.' in form.errors['email'])
-
-    def test_update_add_email_and_remove_phone(self):
-        user = UserFactory.create(username='sherlock',
-                                  email=None,
-                                  phone='+919327768250',
-                                  phone_verified=True,
-                                  password='221B@bakerstreet',
-                                  full_name='Sherlock Holmes')
-
-        VerificationDevice.objects.create(user=user,
-                                          unverified_phone=user.phone)
-
-        data = {
-            'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
-            'phone': '',
-            'language': 'en',
-            'measurement': 'metric',
-            'password': '221B@bakerstreet',
-            'full_name': 'Sherlock Holmes'
-        }
-
-        form = forms.ProfileForm(data, instance=user)
-        assert form.is_valid() is False
-        assert ('It is not possible to change from phone to email for '
-                'your account identifier.' in form.errors['phone'])
-
-    def test_update_phone_and_remove_email(self):
-        user = UserFactory.create(username='sherlock',
-                                  email='sherlock.holmes@bbc.uk',
-                                  phone='+12345678990',
-                                  phone_verified=True,
-                                  email_verified=True,
-                                  password='221B@bakerstreet',
-                                  full_name='Sherlock Holmes')
-
-        EmailAddress.objects.create(user=user, email=user.email)
-        VerificationDevice.objects.create(user=user,
-                                          unverified_phone=user.phone)
-
-        data = {
-            'username': 'sherlock',
-            'email': '',
-            'phone': '+919327768250',
-            'language': 'en',
-            'measurement': 'metric',
-            'password': '221B@bakerstreet',
-            'full_name': 'Sherlock Holmes'
-        }
-        form = forms.ProfileForm(data=data, instance=user)
-        assert form.is_valid() is True
-        form.save()
-
-        user.refresh_from_db()
-        assert user.phone == '+12345678990'
-        assert user.phone_verified is True
-        assert user.email is None
-        assert user.email_verified is False
-        assert EmailAddress.objects.count() == 0
-        assert VerificationDevice.objects.filter(
-            unverified_phone='+12345678990').exists() is False
-        assert len(mail.outbox) == 1
-        assert 'sherlock.holmes@bbc.uk' in mail.outbox[0].to
-        # send sms to user's phone '+12345678990' about email removal
-        # send sms to user's phone '+12345678990' about phone change
-
-    def test_update_email_and_remove_phone(self):
-        user = UserFactory.create(username='sherlock',
-                                  email='john.watson@bbc.uk',
-                                  phone='+919327768250',
-                                  phone_verified=True,
-                                  email_verified=True,
-                                  password='221B@bakerstreet',
-                                  full_name='Sherlock Holmes')
-        EmailAddress.objects.create(user=user, email=user.email)
-        VerificationDevice.objects.create(user=user,
-                                          unverified_phone=user.phone)
-
-        data = {
-            'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
-            'phone': '',
-            'language': 'en',
-            'measurement': 'metric',
-            'password': '221B@bakerstreet',
-            'full_name': 'Sherlock Holmes'
-        }
-        request = HttpRequest()
-        setattr(request, 'session', 'session')
-        self.messages = FallbackStorage(request)
-        setattr(request, '_messages', self.messages)
-        request.META['SERVER_NAME'] = 'testserver'
-        request.META['SERVER_PORT'] = '80'
-
-        form = forms.ProfileForm(data, request=request, instance=user)
-        assert form.is_valid() is True
-        form.save()
-
-        user.refresh_from_db()
-        assert user.phone is None
-        assert user.phone_verified is False
-        assert user.email == 'john.watson@bbc.uk'
-        assert user.email_verified is True
-        assert EmailAddress.objects.filter(
-            email='john.watson@bbc.uk').exists() is False
-        assert VerificationDevice.objects.count() == 0
-        assert len(mail.outbox) == 3
-        assert 'sherlock.holmes@bbc.uk' in mail.outbox[0].to
-        assert 'john.watson@bbc.uk' in mail.outbox[1].to
-        assert 'john.watson@bbc.uk' in mail.outbox[2].to
 
     def test_update_with_existing_email_in_EmailAddress(self):
         user = UserFactory.create()
         EmailAddress.objects.create(email='sherlock.holmes@bbc.uk', user=user)
         user1 = UserFactory.create(username='sherlock',
                                    email='john.watson@bbc.uk',
-                                   phone='+919327768250',
+                                   phone=None,
                                    phone_verified=True,
                                    email_verified=True,
                                    password='221B@bakerstreet',
@@ -1134,7 +885,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         data = {
             'username': 'sherlock',
             'email': 'sherlock.holmes@bbc.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': '221B@bakerstreet',
@@ -1150,7 +900,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         VerificationDevice.objects.create(unverified_phone='+919327768250',
                                           user=user)
         user1 = UserFactory.create(username='sherlock',
-                                   email='john.watson@bbc.uk',
+                                   email=None,
                                    phone='+12345678990',
                                    phone_verified=True,
                                    email_verified=True,
@@ -1159,7 +909,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -440,14 +440,14 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         user = UserFactory.build(email='john@beatles.uk',
                                  email_verified=True,
                                  phone=None,
-                                 phone_verified=True)
+                                 phone_verified=False)
         form = forms.ProfileForm({}, request=Mock(), instance=user)
         assert form.fields['email'].required is True
         assert form.fields['phone'].required is False
 
     def test_init_with_phone(self):
         user = UserFactory.build(email=None,
-                                 email_verified=True,
+                                 email_verified=False,
                                  phone='+4915712111111111',
                                  phone_verified=True)
         form = forms.ProfileForm({}, request=Mock(), instance=user)
@@ -466,7 +466,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
                                   language='en',
                                   measurement='metric',
                                   phone=None,
-                                  phone_verified=True)
+                                  phone_verified=False)
         data = {
             'username': 'imagine71',
             'email': 'john2@beatles.uk',
@@ -493,7 +493,6 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         assert user.language == 'en'
         assert user.measurement == 'imperial'
         assert user.email_verified is True
-        assert user.phone_verified is True
         assert len(mail.outbox) == 2
         assert 'john2@beatles.uk' in mail.outbox[0].to
         assert 'john@beatles.uk' in mail.outbox[1].to
@@ -682,7 +681,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         user = UserFactory.create(username='sherlock',
                                   email=None,
                                   phone='+919327768250',
-                                  email_verified=True,
+                                  email_verified=False,
                                   phone_verified=True,
                                   password='221B@bakerstreet',
                                   full_name='Sherlock Holmes')
@@ -711,7 +710,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
                                   email='sherlock.holmes@bbc.uk',
                                   phone=None,
                                   email_verified=True,
-                                  phone_verified=True,
+                                  phone_verified=False,
                                   password='221B@bakerstreet',
                                   full_name='Sherlock Holmes')
         EmailAddress.objects.create(user=user, email=user.email, verified=True)
@@ -749,7 +748,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         UserFactory.create(phone='+12345678990')
         user = UserFactory.create(username='sherlock',
                                   email=None,
-                                  email_verified=True,
+                                  email_verified=False,
                                   phone_verified=True,
                                   phone='+919327768250',
                                   password='221B@bakerstreet',
@@ -772,7 +771,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         user = UserFactory.create(username='sherlock',
                                   email=None,
                                   phone='+919327768250',
-                                  email_verified=True,
+                                  email_verified=False,
                                   phone_verified=True,
                                   password='221B@bakerstreet',
                                   full_name='Sherlock Holmes')
@@ -853,7 +852,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         user = UserFactory.create(username='sherlock',
                                   email=None,
                                   phone='+919327768250',
-                                  email_verified=True,
+                                  email_verified=False,
                                   phone_verified=True,
                                   password='221B@bakerstreet',
                                   full_name='Sherlock Holmes')
@@ -875,7 +874,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
                                   email='sherlock.holmes@bbc.uk',
                                   phone=None,
                                   email_verified=True,
-                                  phone_verified=True,
+                                  phone_verified=False,
                                   password='221B@bakerstreet',
                                   full_name='Sherlock Holmes')
         EmailAddress.objects.create(user=user,
@@ -945,7 +944,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
         user1 = UserFactory.create(username='sherlock',
                                    email='john.watson@bbc.uk',
                                    phone=None,
-                                   phone_verified=True,
+                                   phone_verified=False,
                                    email_verified=True,
                                    password='221B@bakerstreet',
                                    full_name='Sherlock Holmes')
@@ -970,7 +969,7 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
                                    email=None,
                                    phone='+12345678990',
                                    phone_verified=True,
-                                   email_verified=True,
+                                   email_verified=False,
                                    password='221B@bakerstreet',
                                    full_name='Sherlock Holmes')
 

--- a/cadasta/accounts/tests/test_forms.py
+++ b/cadasta/accounts/tests/test_forms.py
@@ -1007,18 +1007,9 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
             'full_name': 'Sherlock Holmes'
         }
         form = forms.ProfileForm(data=data, instance=user)
-        assert form.is_valid() is True
-        form.save()
-
-        user.refresh_from_db()
-        assert user.phone == '+919327768250'
-        assert user.phone_verified is False
-        assert user.email is None
-        assert user.email_verified is False
-        assert EmailAddress.objects.count() == 0
-        assert VerificationDevice.objects.count() == 1
-        assert len(mail.outbox) == 1
-        assert 'sherlock.holmes@bbc.uk' in mail.outbox[0].to
+        assert form.is_valid() is False
+        assert ('It is not possible to change from email to phone for '
+                'your account identifier.' in form.errors['email'])
 
     def test_update_add_email_and_remove_phone(self):
         user = UserFactory.create(username='sherlock',
@@ -1040,27 +1031,11 @@ class ProfileFormTest(UserTestCase, FileStorageTestCase, TestCase):
             'password': '221B@bakerstreet',
             'full_name': 'Sherlock Holmes'
         }
-        request = HttpRequest()
-        setattr(request, 'session', 'session')
-        self.messages = FallbackStorage(request)
-        setattr(request, '_messages', self.messages)
-        request.META['SERVER_NAME'] = 'testserver'
-        request.META['SERVER_PORT'] = '80'
 
-        form = forms.ProfileForm(data, request=request, instance=user)
-        assert form.is_valid() is True
-        form.save()
-
-        user.refresh_from_db()
-        assert user.phone is None
-        assert user.phone_verified is False
-        assert user.email == 'sherlock.holmes@bbc.uk'
-        assert user.email_verified is False
-        assert EmailAddress.objects.count() == 1
-        assert VerificationDevice.objects.count() == 0
-        assert len(mail.outbox) == 2
-        assert 'sherlock.holmes@bbc.uk' in mail.outbox[0].to
-        assert 'sherlock.holmes@bbc.uk' in mail.outbox[0].to
+        form = forms.ProfileForm(data, instance=user)
+        assert form.is_valid() is False
+        assert ('It is not possible to change from phone to email for '
+                'your account identifier.' in form.errors['phone'])
 
     def test_update_phone_and_remove_email(self):
         user = UserFactory.create(username='sherlock',

--- a/cadasta/accounts/tests/test_serializers.py
+++ b/cadasta/accounts/tests/test_serializers.py
@@ -216,19 +216,20 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         assert (_("Passwords cannot contain your email.") in
                 serializer._errors['password'])
 
-    # def test_password_contains_blank_email(self):
-    #     data = {
-    #         'username': 'imagine71',
-    #         'email': '',
-    #         'language': 'en',
-    #         'measurement': 'metric',
-    #         'password': 'johnisjustheBest!!',
-    #         'password_repeat': 'johnisjustheBest!!',
-    #         'full_name': 'John Lennon',
-    #     }
-    #     serializer = serializers.RegistrationSerializer(data=data)
-    #     assert serializer.is_valid()
-    #     assert ('password' not in serializer._errors)
+    def test_password_contains_blank_email(self):
+        data = {
+            'username': 'imagine71',
+            'email': '',
+            'phone': '+4911111111',
+            'language': 'en',
+            'measurement': 'metric',
+            'password': 'johnisjustheBest!!',
+            'password_repeat': 'johnisjustheBest!!',
+            'full_name': 'John Lennon',
+        }
+        serializer = serializers.RegistrationSerializer(data=data)
+        assert serializer.is_valid()
+        assert ('password' not in serializer._errors)
 
     def test_password_contains_less_than_min_characters(self):
         data = {
@@ -279,19 +280,20 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         assert (_("Passwords cannot contain your phone.")
                 in serializer._errors['password'])
 
-    # def test_password_contains_blank_phone(self):
-    #     data = {
-    #         'username': 'sherlock',
-    #         'phone': '',
-    #         'language': 'en',
-    #         'measurement': 'metric',
-    #         'password': '221B@bakerstreet',
-    #         'password_repeat': '221B@bakerstreet',
-    #         'full_name': 'Sherlock Holmes'
-    #     }
-    #     serializer = serializers.RegistrationSerializer(data=data)
-    #     assert serializer.is_valid() is True
-    #     assert ('password' not in serializer._errors)
+    def test_password_contains_blank_phone(self):
+        data = {
+            'username': 'sherlock',
+            'email': 'sherlock@example.com',
+            'phone': '',
+            'language': 'en',
+            'measurement': 'metric',
+            'password': '221B@bakerstreet',
+            'password_repeat': '221B@bakerstreet',
+            'full_name': 'Sherlock Holmes'
+        }
+        serializer = serializers.RegistrationSerializer(data=data)
+        assert serializer.is_valid() is True
+        assert ('password' not in serializer._errors)
 
     def test_signup_with_phone_only(self):
         data = {

--- a/cadasta/accounts/tests/test_serializers.py
+++ b/cadasta/accounts/tests/test_serializers.py
@@ -216,19 +216,19 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         assert (_("Passwords cannot contain your email.") in
                 serializer._errors['password'])
 
-    def test_password_contains_blank_email(self):
-        data = {
-            'username': 'imagine71',
-            'phone': '+919327768250',
-            'language': 'en',
-            'measurement': 'metric',
-            'password': 'johnisjustheBest!!',
-            'password_repeat': 'johnisjustheBest!!',
-            'full_name': 'John Lennon',
-        }
-        serializer = serializers.RegistrationSerializer(data=data)
-        assert serializer.is_valid()
-        assert ('password' not in serializer._errors)
+    # def test_password_contains_blank_email(self):
+    #     data = {
+    #         'username': 'imagine71',
+    #         'email': '',
+    #         'language': 'en',
+    #         'measurement': 'metric',
+    #         'password': 'johnisjustheBest!!',
+    #         'password_repeat': 'johnisjustheBest!!',
+    #         'full_name': 'John Lennon',
+    #     }
+    #     serializer = serializers.RegistrationSerializer(data=data)
+    #     assert serializer.is_valid()
+    #     assert ('password' not in serializer._errors)
 
     def test_password_contains_less_than_min_characters(self):
         data = {
@@ -279,20 +279,19 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         assert (_("Passwords cannot contain your phone.")
                 in serializer._errors['password'])
 
-    def test_password_contains_blank_phone(self):
-        data = {
-            'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
-            'phone': '',
-            'language': 'en',
-            'measurement': 'metric',
-            'password': '221B@bakerstreet',
-            'password_repeat': '221B@bakerstreet',
-            'full_name': 'Sherlock Holmes'
-        }
-        serializer = serializers.RegistrationSerializer(data=data)
-        assert serializer.is_valid() is True
-        assert ('password' not in serializer._errors)
+    # def test_password_contains_blank_phone(self):
+    #     data = {
+    #         'username': 'sherlock',
+    #         'phone': '',
+    #         'language': 'en',
+    #         'measurement': 'metric',
+    #         'password': '221B@bakerstreet',
+    #         'password_repeat': '221B@bakerstreet',
+    #         'full_name': 'Sherlock Holmes'
+    #     }
+    #     serializer = serializers.RegistrationSerializer(data=data)
+    #     assert serializer.is_valid() is True
+    #     assert ('password' not in serializer._errors)
 
     def test_signup_with_phone_only(self):
         data = {
@@ -558,7 +557,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'password': 'iloveyoko79',
             'full_name': 'John Lennon',
             'last_login': '2016-01-01 23:00:00',
@@ -576,6 +574,22 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         assert user_obj.is_active
         assert not user_obj.email_verified
         assert not user_obj.phone_verified
+
+    def test_create_with_phone_and_email(self):
+        data = {
+            'username': 'imagine71',
+            'phone': '+4978964545464',
+            'email': 'test@example.com',
+            'password': 'iloveyoko79',
+            'full_name': 'John Lennon',
+            'last_login': '2016-01-01 23:00:00',
+            'language': 'en',
+            'measurement': 'metric',
+        }
+        serializer = serializers.UserSerializer(data=data)
+        assert serializer.is_valid() is False
+        assert ('You can either use your phone number or email to sign up but '
+                'not both.' in serializer.errors['non_field_errors'])
 
     def test_update_username_fails(self):
         serializer = serializers.UserSerializer(data=BASIC_TEST_DATA)
@@ -631,7 +645,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         data = {
             'username': random.choice(invalid_usernames),
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'full_name': 'John Lennon',
         }
         request = APIRequestFactory().patch('/user/imagine71', data)
@@ -692,7 +705,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_update_with_blank_phone_and_email(self):
         user = UserFactory.create(username='sherlock',
                                   email='sherlock.holmes@bbc.uk',
-                                  phone='+919327768250',
                                   password='221B@bakerstreet',
                                   full_name='Sherlock Holmes')
         data = {
@@ -732,7 +744,10 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         assert (_("Cannot update email") in serializer2.errors['email'])
 
     def test_update_phone_fails(self):
-        serializer = serializers.UserSerializer(data=BASIC_TEST_DATA)
+        data = BASIC_TEST_DATA.copy()
+        del data['email']
+        data['phone'] = '+12345678990'
+        serializer = serializers.UserSerializer(data=data)
         assert serializer.is_valid() is True
 
         user = serializer.save()
@@ -750,13 +765,11 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
 
     def test_update_with_invalid_phone(self):
         user = UserFactory.create(username='sherlock',
-                                  email='sherlock.holmes@bbc.uk',
                                   phone='+919327768250',
                                   password='221B@bakerstreet',
                                   full_name='Sherlock Holmes')
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': 'Test Number',
             'language': 'en',
             'measurement': 'metric',
@@ -774,7 +787,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '9067439937',
             'language': 'en',
             'measurement': 'metric',
@@ -792,7 +804,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+91 9067439937',
             'language': 'en',
             'measurement': 'metric',
@@ -810,7 +821,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+919067439937906743',
             'language': 'en',
             'measurement': 'metric',
@@ -828,7 +838,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+9190',
             'language': 'en',
             'measurement': 'metric',
@@ -846,7 +855,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+8018225332',
             'language': 'en',
             'measurement': 'metric',
@@ -868,13 +876,12 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         VerificationDevice.objects.create(user=user,
                                           unverified_phone='+919327768250')
         user1 = UserFactory.create(username='sherlock',
-                                   email='sherlock.holmes@bbc.uk',
+                                   phone='+496878645454654',
                                    password='221B@bakerstreet',
                                    full_name='Sherlock Holmes')
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
@@ -896,14 +903,13 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         EmailAddress.objects.create(user=user,
                                     email='sherlock.holmes@bbc.uk')
         user1 = UserFactory.create(username='sherlock',
-                                   phone='+919327768250',
+                                   email='test@example.com',
                                    password='221B@bakerstreet',
                                    full_name='Sherlock Holmes')
 
         data = {
             'username': 'sherlock',
             'email': 'sherlock.holmes@bbc.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': '221B@bakerstreet',
@@ -928,7 +934,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         data = {
             'username': 'sherlock',
             'email': 'sherlock.holmes@bbc.uk',
-            'phone': '+919327768250',
             'password': '221B@bakerstreet',
             'full_name': 'John Lennon',
             'last_login': '2016-01-01 23:00:00',
@@ -947,7 +952,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
                                           unverified_phone='+919327768250')
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+919327768250',
             'password': '221B@bakerstreet',
             'full_name': 'Sherlock Holmes',
@@ -1007,12 +1011,11 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
     def test_update_insensitive_email_check(self):
         UserFactory.create(email='sherlock.holmes@bbc.uk')
         user = UserFactory.create(username='sherlock',
-                                  phone='+919327768250',
+                                  email='test@example.com',
                                   password='221B@bakerstreet')
         data = {
             'username': 'sherlock',
             'email': 'SHERLOCK.HOLMES@BBC.UK',
-            'phone': '+919327768250',
             'password': '221B@bakerstreet',
             'full_name': 'John Lennon',
             'last_login': '2016-01-01 23:00:00',

--- a/cadasta/accounts/tests/test_serializers.py
+++ b/cadasta/accounts/tests/test_serializers.py
@@ -1034,6 +1034,36 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         assert (_("User with this Email address already exists.")
                 in serializer.errors['email'])
 
+    def test_update_replace_phone_with_email(self):
+        user = UserFactory.create(phone='+919327768250', email=None)
+        data = {'email': 'email@example.com', 'phone': None}
+        request = APIRequestFactory().patch('/user/sherlock', data)
+        force_authenticate(request, user=user)
+
+        serializer = serializers.UserSerializer(
+            user,
+            data=data,
+            partial=True,
+            context={'request': Request(request)})
+        assert serializer.is_valid() is False
+        assert ('It is not possible to change from phone to email for '
+                'your account identifier.' in serializer.errors['phone'])
+
+    def test_update_replace_email_with_phone(self):
+        user = UserFactory.create(phone=None, email='email@example.com')
+        data = {'email': None, 'phone': '+919327768250'}
+        request = APIRequestFactory().patch('/user/sherlock', data)
+        force_authenticate(request, user=user)
+
+        serializer = serializers.UserSerializer(
+            user,
+            data=data,
+            partial=True,
+            context={'request': Request(request)})
+        assert serializer.is_valid() is False
+        assert ('It is not possible to change from email to phone for '
+                'your account identifier.' in serializer.errors['email'])
+
 
 class AccountLoginSerializerTest(UserTestCase, TestCase):
 

--- a/cadasta/accounts/tests/test_serializers.py
+++ b/cadasta/accounts/tests/test_serializers.py
@@ -22,7 +22,6 @@ from .factories import UserFactory
 BASIC_TEST_DATA = {
     'username': 'imagine71',
     'email': 'john@beatles.uk',
-    'phone': '+919327768250',
     'password': 'iloveyoko79!',
     'full_name': 'John Lennon',
     'language': 'en',
@@ -70,6 +69,25 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         serializer.save()
         assert User.objects.count() == 4
 
+    def test_create_with_email_and_phone(self):
+        """User can either seign up using a phone number or an email address
+           but not both"""
+        data = {
+            'username': 'imagine71',
+            'email': 'john@beatles.uk',
+            'phone': '+49150111111111',
+            'language': 'en',
+            'measurement': 'metric',
+            'password': 'iloveyoko79!',
+            'password_repeat': 'iloveyoko79!',
+            'full_name': 'John Lennon',
+        }
+
+        serializer = serializers.RegistrationSerializer(data=data)
+        assert serializer.is_valid() is False
+        assert ('You can either use your phone number or email to sign up but '
+                'not both.' in serializer.errors['non_field_errors'])
+
     def test_create_without_email(self):
         """Serialiser should be invalid when no email address is provided."""
 
@@ -90,7 +108,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': 'iloveyoko79!',
@@ -111,7 +128,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': 'iloveyoko79!',
@@ -129,7 +145,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': random.choice(invalid_usernames),
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': 'iloveyoko79!',
@@ -146,7 +161,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'yoko79',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': 'iloveyoko79!',
@@ -162,7 +176,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'yoko79',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': 'iloveYOKO79!',
@@ -178,7 +191,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': '',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': 'iloveyoko79!',
@@ -193,7 +205,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': 'johnisjustheBest!!',
@@ -208,7 +219,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
     def test_password_contains_blank_email(self):
         data = {
             'username': 'imagine71',
-            'email': '',
             'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
@@ -224,7 +234,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': 'yoko<3',
@@ -241,7 +250,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': 'iloveyoko',
@@ -259,7 +267,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
     def test_password_contains_phone(self):
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
@@ -330,7 +337,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         UserFactory.create(phone='+919327768250')
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
@@ -380,7 +386,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
     def test_signup_with_invalid_phone(self):
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': 'Test Number',
             'language': 'en',
             'measurement': 'metric',
@@ -394,7 +399,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+91-9067439937',
             'language': 'en',
             'measurement': 'metric',
@@ -408,7 +412,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '9067439937',
             'language': 'en',
             'measurement': 'metric',
@@ -422,7 +425,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '9067439937',
             'language': 'en',
             'measurement': 'metric',
@@ -436,7 +438,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+91 9067439937',
             'language': 'en',
             'measurement': 'metric',
@@ -450,7 +451,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+919067439937906743',
             'language': 'en',
             'measurement': 'metric',
@@ -464,7 +464,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+9190',
             'language': 'en',
             'measurement': 'metric',
@@ -478,7 +477,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
 
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+8018225332',
             'language': 'en',
             'measurement': 'metric',
@@ -496,7 +494,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'sherlock',
             'email': 'SHERLOCK.HOLMES@BBC.UK',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': '221B@bakerstreet',
@@ -513,7 +510,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'sherlock',
             'email': 'sherlock.holmes@bbc.uk',
-            'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
             'password': '221B@bakerstreet',
@@ -531,7 +527,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
                                           unverified_phone='+919327768250')
         data = {
             'username': 'sherlock',
-            'email': 'sherlock.holmes@bbc.uk',
             'phone': '+919327768250',
             'language': 'en',
             'measurement': 'metric',
@@ -623,7 +618,6 @@ class UserSerializerTest(UserTestCase, FileStorageTestCase, TestCase):
         user = serializer.save()
         update_data1 = {'username': 'imagine71',
                         'email': 'john@beatles.uk',
-                        'phone': '+919327768250',
                         'last_login': '2016-01-01 23:00:00'}
         serializer2 = serializers.UserSerializer(user, data=update_data1)
         assert serializer2.is_valid() is False

--- a/cadasta/accounts/tests/test_serializers.py
+++ b/cadasta/accounts/tests/test_serializers.py
@@ -220,7 +220,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': '',
-            'phone': '+4911111111',
             'language': 'en',
             'measurement': 'metric',
             'password': 'johnisjustheBest!!',
@@ -228,7 +227,7 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
             'full_name': 'John Lennon',
         }
         serializer = serializers.RegistrationSerializer(data=data)
-        assert serializer.is_valid()
+        assert serializer.is_valid() is False
         assert ('password' not in serializer._errors)
 
     def test_password_contains_less_than_min_characters(self):
@@ -283,7 +282,6 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
     def test_password_contains_blank_phone(self):
         data = {
             'username': 'sherlock',
-            'email': 'sherlock@example.com',
             'phone': '',
             'language': 'en',
             'measurement': 'metric',
@@ -292,7 +290,7 @@ class RegistrationSerializerTest(UserTestCase, TestCase):
             'full_name': 'Sherlock Holmes'
         }
         serializer = serializers.RegistrationSerializer(data=data)
-        assert serializer.is_valid() is True
+        assert serializer.is_valid() is False
         assert ('password' not in serializer._errors)
 
     def test_signup_with_phone_only(self):

--- a/cadasta/accounts/tests/test_views_api.py
+++ b/cadasta/accounts/tests/test_views_api.py
@@ -20,9 +20,9 @@ class AccountUserTest(APITestCase, UserTestCase, TestCase):
     def setup_models(self):
         self.user = UserFactory.create(username='imagine71',
                                        email='john@beatles.uk',
-                                       phone='+12345678990',
                                        email_verified=True,
-                                       phone_verified=True)
+                                       phone=None,
+                                       phone_verified=False)
 
     def test_update_profile(self):
         data = {'email': 'boss@beatles.uk',
@@ -37,7 +37,7 @@ class AccountUserTest(APITestCase, UserTestCase, TestCase):
 
         self.user.refresh_from_db()
         assert self.user.email_verified is True
-        assert self.user.phone_verified is True
+        assert self.user.phone_verified is False
         assert self.user.email == 'john@beatles.uk'
 
     def test_update_email_address(self):
@@ -98,6 +98,10 @@ class AccountUserTest(APITestCase, UserTestCase, TestCase):
         assert self.user.email_verified is True
 
     def test_update_phone_number(self):
+        self.user.email = None
+        self.user.phone = '+12345678990'
+        self.user.save()
+
         VerificationDevice.objects.create(
             user=self.user, unverified_phone=self.user.phone)
         data = {'phone': '+919327768250', 'username': 'imagine71'}
@@ -110,9 +114,14 @@ class AccountUserTest(APITestCase, UserTestCase, TestCase):
 
         self.user.refresh_from_db()
         assert self.user.phone == '+12345678990'
-        assert self.user.phone_verified is True
+        assert self.user.phone_verified is False
 
     def test_keep_phone_number(self):
+        self.user.email = None
+        self.user.phone = '+12345678990'
+        self.user.phone_verified = True
+        self.user.save()
+
         data = {'phone': self.user.phone, 'username': 'imagine71'}
         response = self.request(method='PUT', post_data=data, user=self.user)
         assert response.status_code == 200
@@ -124,6 +133,11 @@ class AccountUserTest(APITestCase, UserTestCase, TestCase):
             user=self.user, unverified_phone=self.user.phone).exists() is False
 
     def test_update_with_existing_phone(self):
+        self.user.email = None
+        self.user.phone = '+12345678990'
+        self.user.phone_verified = True
+        self.user.save()
+
         VerificationDevice.objects.create(
             user=self.user, unverified_phone=self.user.phone)
 

--- a/cadasta/accounts/tests/test_views_api.py
+++ b/cadasta/accounts/tests/test_views_api.py
@@ -98,11 +98,15 @@ class AccountUserTest(APITestCase, UserTestCase, TestCase):
         assert self.user.email_verified is True
 
     def test_update_phone_number(self):
+        VerificationDevice.objects.create(
+            user=self.user, unverified_phone=self.user.phone)
         data = {'phone': '+919327768250', 'username': 'imagine71'}
         response = self.request(method='PUT', post_data=data, user=self.user)
         assert response.status_code == 200
         assert VerificationDevice.objects.filter(
             unverified_phone='+919327768250').exists() is True
+        assert VerificationDevice.objects.filter(
+            unverified_phone='+12345678990').exists() is False
 
         self.user.refresh_from_db()
         assert self.user.phone == '+12345678990'

--- a/cadasta/accounts/tests/test_views_api.py
+++ b/cadasta/accounts/tests/test_views_api.py
@@ -140,7 +140,6 @@ class AccountSignupTest(APITestCase, UserTestCase, TestCase):
         data = {
             'username': 'imagine71',
             'email': 'john@beatles.uk',
-            'phone': '+919327768250',
             'password': 'iloveyoko79!',
             'full_name': 'John Lennon',
         }

--- a/cadasta/accounts/utils.py
+++ b/cadasta/accounts/utils.py
@@ -17,43 +17,6 @@ def send_email_update_notification(email):
     )
 
 
-def send_email_deleted_notification(email):
-    msg_body = render_to_string(
-        'allauth/account/messages/email_deleted.txt', {'email': email}
-    )
-    send_mail(
-        _("Deleted email at Cadasta Platform"),
-        msg_body,
-        settings.DEFAULT_FROM_EMAIL,
-        [email],
-        fail_silently=False,
-    )
-
-
-def send_phone_update_notification(email):
-    msg_body = render_to_string(
-        'accounts/email/phone_changed_notification.txt')
-    send_mail(
-        _("Change of phone at Cadasta Platform"),
-        msg_body,
-        settings.DEFAULT_FROM_EMAIL,
-        [email],
-        fail_silently=False,
-    )
-
-
-def send_phone_deleted_notification(email):
-    msg_body = render_to_string(
-        'accounts/email/phone_deleted_notification.txt')
-    send_mail(
-        _("Deleted phone at Cadasta Platform"),
-        msg_body,
-        settings.DEFAULT_FROM_EMAIL,
-        [email],
-        fail_silently=False,
-    )
-
-
 def send_sms(to, body):
     twilioobj = (import_string(settings.SMS_GATEWAY))()
     twilioobj.send_sms(to, body)

--- a/cadasta/accounts/views/api.py
+++ b/cadasta/accounts/views/api.py
@@ -25,7 +25,6 @@ class AccountUser(djoser_views.UserView):
         current_email, current_phone = instance.email, instance.phone
         new_email = serializer.validated_data.get('email', instance.email)
         new_phone = serializer.validated_data.get('phone', instance.phone)
-        email_update_message = None
         user = serializer.save()
 
         if current_email != new_email:
@@ -34,7 +33,6 @@ class AccountUser(djoser_views.UserView):
                 email_set.delete()
             if new_email:
                 send_email_confirmation(self.request._request, user)
-                email_update_message = messages.email_change
                 if current_email:
                     user.email = current_email
                     utils.send_email_update_notification(current_email)
@@ -51,16 +49,7 @@ class AccountUser(djoser_views.UserView):
                 if current_phone:
                     user.phone = current_phone
                     utils.send_sms(current_phone, messages.phone_change)
-                if user.email:
-                    utils.send_phone_update_notification(user.email)
-            else:
-                user.phone_verified = False
-                utils.send_sms(current_phone, messages.phone_delete)
-                if user.email:
-                    utils.send_phone_deleted_notification(user.email)
 
-        if user.phone and email_update_message:
-            utils.send_sms(to=user.phone, body=email_update_message)
         user.save()
 
 

--- a/cadasta/accounts/views/api.py
+++ b/cadasta/accounts/views/api.py
@@ -38,10 +38,6 @@ class AccountUser(djoser_views.UserView):
                 if current_email:
                     user.email = current_email
                     utils.send_email_update_notification(current_email)
-            else:
-                user.email_verified = False
-                utils.send_email_deleted_notification(current_email)
-                email_update_message = messages.email_delete
 
         if current_phone != new_phone:
             phone_set = VerificationDevice.objects.filter(user=instance)

--- a/cadasta/organization/tests/test_views_api_users.py
+++ b/cadasta/organization/tests/test_views_api_users.py
@@ -134,7 +134,7 @@ class UserDetailAPITest(APITestCase, TestCase):
             body=json.dumps(clauses))
         self.user = UserFactory.create()
         assign_user_policies(self.user, policy)
-        self.test_user = UserFactory.create(username='test-user')
+        self.test_user = UserFactory.create(username='test-user', phone=None)
 
     def setup_url_kwargs(self):
         return {'username': self.test_user.username}

--- a/cadasta/templates/accounts/profile.html
+++ b/cadasta/templates/accounts/profile.html
@@ -28,14 +28,19 @@
             <div class="error-block">{{ form.username.errors }}</div>
           </div>
           {% url 'account:resend_token' as resend_url %}
+
+          {% if form.instance.email %}
           <div class="form-group{% if form.email.errors %} has-error{% endif %}">
             <label class="control-label" for="{{ form.email.id_for_label }}">{% trans "Email" %}</label>
             {% render_field form.email class+="form-control input-lg" data-parsley-sanitize="1" %}
             {% if emails_to_verify %}
               <p class="help-block small">{% blocktrans %} The email for this account has been changed recently, but the new email address has not yet been verified. You should have received an email with a link to verify the new email address. To manually verify the new email address, click <a href="{{ resend_url }}">here.</a>{% endblocktrans %}</p>
             {% endif %}
-          <div class="error-block">{{ form.email.errors }}</div>
+            <div class="error-block">{{ form.email.errors }}</div>
           </div>
+          {% endif %}
+
+          {% if form.instance.phone %}
           <div class="form-group{% if form.phone.errors %} has-error{%endif%}">
             <label class="control-label" for="{{ form.phone.id_for_label }}">{% trans "Phone" %}</label>
             {% render_field form.phone class+='form-control input-lg'  %}
@@ -44,6 +49,8 @@
               {% endif %}
               <div class="error-block">{{ form.phone.errors }}</div>
           </div>
+          {% endif %}
+
           <div class="form-group{% if form.full_name.errors %} has-error{% endif %}">
             <label class="control-label" for="{{ form.full_name.id_for_label }}">{% trans "Full name" %}</label>
             {% render_field form.full_name class+="form-control input-lg" data-parsley-sanitize="1" %}


### PR DESCRIPTION
### Proposed changes in this pull request

- Changes the profile template so only the phone or email form field is displayed. 
- Removed unnecessary code and tests
- Changed all tests so the user object has either a phone number or an email address
- Made the phone or email field required in the profile form, depending on the identifier the user chose when signing up
- Added a check to the serializer, so user accounts can only be created via the API with either a phone number or email address but not both

### When should this PR be merged

ASAP for release 1.14.0

### Risks

None

### Follow-up actions

None

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
