### PR TITLE
Avoid assigning policies on user save if user already has default policy

### DIFF
--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -131,7 +131,9 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
 
 
 @receiver(models.signals.post_save, sender=User)
-def assign_default_policy(sender, instance, **kwargs):
+def assign_default_policy(sender, instance, created, **kwargs):
+    if not created:
+        return
     perm_set = instance.permissionset.first()
     has_default = {'policy__name': 'default'}
     if perm_set and perm_set.policyinstance_set.filter(**has_default).exists():

--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -133,11 +133,12 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
 @receiver(models.signals.post_save, sender=User)
 def assign_default_policy(sender, instance, **kwargs):
     perm_set = instance.permissionset.first()
-    if perm_set.policyinstance_set.filter(policy__name='default').exists():
+    if not perm_set:
         return
-    instance.assign_policies(
-        Policy.objects.get(name='default'),
-        *instance.assigned_policies())
+    if not perm_set.policyinstance_set.filter(policy__name='default').exists():
+        instance.assign_policies(
+            Policy.objects.get(name='default'),
+            *instance.assigned_policies())
 
 
 @receiver(password_changed)

--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -132,11 +132,12 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
 
 @receiver(models.signals.post_save, sender=User)
 def assign_default_policy(sender, instance, **kwargs):
-    policy = Policy.objects.get(name='default')
-    assigned_policies = instance.assigned_policies()
-    if policy not in assigned_policies:
-        assigned_policies.insert(0, policy)
-    instance.assign_policies(*assigned_policies)
+    perm_set = instance.permissionset.first()
+    if perm_set.policyinstance_set.filter(policy__name='default').exists():
+        return
+    instance.assign_policies(
+        Policy.objects.get(name='default'),
+        *instance.assigned_policies())
 
 
 @receiver(password_changed)

--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -134,14 +134,7 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
 def assign_default_policy(sender, instance, created, **kwargs):
     if not created:
         return
-    perm_set = instance.permissionset.first()
-    has_default = {'policy__name': 'default'}
-    if perm_set and perm_set.policyinstance_set.filter(**has_default).exists():
-        # Default policy already assigned, no action necessary
-        return
-    instance.assign_policies(
-        Policy.objects.get(name='default'),
-        *instance.assigned_policies())
+    instance.assign_policies(Policy.objects.get(name='default'))
 
 
 @receiver(password_changed)

--- a/cadasta/accounts/models.py
+++ b/cadasta/accounts/models.py
@@ -133,12 +133,13 @@ class User(auth_base.AbstractBaseUser, auth.PermissionsMixin):
 @receiver(models.signals.post_save, sender=User)
 def assign_default_policy(sender, instance, **kwargs):
     perm_set = instance.permissionset.first()
-    if not perm_set:
+    has_default = {'policy__name': 'default'}
+    if perm_set and perm_set.policyinstance_set.filter(**has_default).exists():
+        # Default policy already assigned, no action necessary
         return
-    if not perm_set.policyinstance_set.filter(policy__name='default').exists():
-        instance.assign_policies(
-            Policy.objects.get(name='default'),
-            *instance.assigned_policies())
+    instance.assign_policies(
+        Policy.objects.get(name='default'),
+        *instance.assigned_policies())
 
 
 @receiver(password_changed)


### PR DESCRIPTION
### Proposed changes in this pull request

Currently, any time that a user is saved (such as when a user logs in or changes their password), we re-apply all Tutelary permissions to that user.  This is exceptionally slow (see Cadasta/django-tutelary#39). I'm unsure if this is actually needed, rather I believe that we should only re-assign permissions if the permissions changed (such as needing to add the 'default' permission for some reason).

### When should this PR be merged

Anytime.

### Risks

I'm uncertain if there was a good reason to re-apply permissions on every save. The [change that added the code](https://github.com/Cadasta/cadasta-platform/commit/7956a82ddfb5369081278c17c33480fba201f96f#diff-1ec82efacfd767281c32995e3d9b1547R53) doesn't seem to offer much insight. 

### Follow-up actions

-

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
