### PR TITLE
Only show Add Project link on Organization Dashboard if user has project.create perm

### DIFF
--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -316,15 +316,12 @@ class ProjectAddDetails(SanitizeFieldsForm, forms.Form):
             self.orgs = Organization.objects.filter(
                 archived=False).order_by('name')
         else:
-            non_admin_orgs = self.user.organizations.filter(
-                archived=False, organizationrole__admin=False).order_by('name')
-            non_admin_orgs = [
-                o for o in non_admin_orgs
+            qs = self.user.organizations.filter(
+                archived=False).order_by('name')
+            self.orgs = [
+                o for o in qs
                 if check_perms(self.user, ('project.create',), (o,))
             ]
-            admin_orgs = list(self.user.organizations.filter(
-                archived=False, organizationrole__admin=True))
-            self.orgs = set(non_admin_orgs + admin_orgs)
         choices = [(o.slug, o.name) for o in self.orgs]
         if not org_is_chosen and len(choices) > 1:
             choices = [('', _("Please select an organization"))] + choices

--- a/cadasta/organization/forms.py
+++ b/cadasta/organization/forms.py
@@ -316,12 +316,15 @@ class ProjectAddDetails(SanitizeFieldsForm, forms.Form):
             self.orgs = Organization.objects.filter(
                 archived=False).order_by('name')
         else:
-            qs = self.user.organizations.filter(
-                archived=False).order_by('name')
-            self.orgs = [
-                o for o in qs
+            non_admin_orgs = self.user.organizations.filter(
+                archived=False, organizationrole__admin=False).order_by('name')
+            non_admin_orgs = [
+                o for o in non_admin_orgs
                 if check_perms(self.user, ('project.create',), (o,))
             ]
+            admin_orgs = list(self.user.organizations.filter(
+                archived=False, organizationrole__admin=True))
+            self.orgs = set(non_admin_orgs + admin_orgs)
         choices = [(o.slug, o.name) for o in self.orgs]
         if not org_is_chosen and len(choices) > 1:
             choices = [('', _("Please select an organization"))] + choices

--- a/cadasta/templates/organization/organization_dashboard_member.html
+++ b/cadasta/templates/organization/organization_dashboard_member.html
@@ -9,7 +9,7 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h3 class="panel-title inline">{% trans "Projects" %}</h3>
-                {% if is_administrator %}
+                {% if add_allowed %}
                   <a href="{% url 'organization:project-add' organization.slug %}">
                     <i class="glyphicon glyphicon-plus" data-toggle="tooltip" data-trigger="hover" data-placement="left" title="{% trans 'Add project' %}"></i>
                   </a>
@@ -40,7 +40,7 @@
                             {% endif %}
                           </h4>
                           <p>{{ proj.description }}</p>
-                        </td>   
+                        </td>
                         <td class="hidden-xs">{{ proj.country }}</td>
                         <td data-sort="{{ proj.last_updated|date:'U' }}">{{ proj.last_updated }}</td>
                         <td class="hidden" data-filter="archived-{{ proj.archived }}"></td>
@@ -124,7 +124,7 @@
                       <dd class="clearfix">
                         {% if contact.email %}
                         <a href="mailto:{{ contact.email }}" class="break">
-                          <i class="glyphicon glyphicon-envelope"></i> 
+                          <i class="glyphicon glyphicon-envelope"></i>
                          {{ contact.email }}
                         </a>
                         {% endif %}


### PR DESCRIPTION
### Proposed changes in this pull request

When discussing the #1918 bug with @SteadyCadence, we ran into an issue where a user could not get past Step 2 of the Project Creation process.

Upon inspection, it became clear that while the user was an admin for the project (all that is needed to see the project creation button), it lacked the `project.create` permission.  Without this permission, the form failed to render the organization for which the project would be created in a hidden dropdown on the form.  Being that the dropdown was hidden, it was not possible for the user to see the error rendered on the input, making the bug's cause difficult to diagnose.

![](http://g.recordit.co/NIRB2XdghM.gif)

~~This PR adds all orgs that a user has admin status to the ProjectAdd form's organization choicefield.~~

**UPDATE:**

This PR updates the visibility of the Add Project button to only be displayed if the view has the `add_allowed` context set.  This context is set by our [`ProjectCreateCheckMixin`](https://github.com/Cadasta/cadasta-platform/blob/e2d5ead99f925efb9e2b39d4e0c9070a72d7cb07/cadasta/organization/views/mixins.py#L197-L231).

### When should this PR be merged

Anytime

### Risks

~~It's possible that I'm attacking this problem from the wrong end.  I've taken the stance that having admin status in an org overrides some requirements about permissions. It's equally as possible that the correct way to address this is to ensure that when someone is made admin to an org, all expected permissions (such as `project.create` are added to that user.  If so, this PR is s bandaid and likely unhelpful.  I'm going to go with assuming that my first assumption snd this fix is correct, as that is what would be expected based on the fact that the Add Project button is only shown to org admins rather than any user with the `project.create` permission.  Please correct me if I am wrong, our permissions structure is still something I'm wrapping my head around.~~

### Follow-up actions
N/A

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
