### PR TITLE
[NOT READY] Improve async locations endpoint response speed

### DIFF
--- a/cadasta/core/static/js/map_utils.js
+++ b/cadasta/core/static/js/map_utils.js
@@ -53,24 +53,41 @@ function renderFeatures(map, featuresUrl, options) {
     }
   }
 
+  function allFeaturesLoaded() {
+    $('#messages #loading').addClass('hidden');
+    if (options.fitBounds === 'locations') {
+      var bounds = markers.getBounds();
+      if (bounds.isValid()) {
+        map.fitBounds(bounds);
+      }
+    }
+    locationToFront();
+  }
+
   function loadFeatures(url) {
     $('#messages #loading').removeClass('hidden');
-    $.get(url, function(response) {
+    return $.get(url, function(response) {
       geoJson.addData(response);
 
-      if (response.next) {
-        loadFeatures(response.next, map, options.trans);
-      } else {
-        $('#messages #loading').addClass('hidden');
-        if (options.fitBounds === 'locations') {
-          var bounds = markers.getBounds();
-          if (bounds.isValid()) {
-            map.fitBounds(bounds);
-          }
-        }
-      }
+      // On first response, request all subsequent pages concurrently
+      if (response.next && !response.previous) {
+        items_per_page = response.features.length;
+        total_items = response.count;
+        total_pages = Math.ceil(total_items / items_per_page);
 
-      locationToFront();
+        // Start requests
+        var requests = [];
+        for (var i = 2; i <= total_pages; i++) {
+          requests.push(loadFeatures(url + '?page=' + i, map, options.trans));
+        }
+
+        // Take action when all requests complete
+        $.when.apply(this, requests).then(allFeaturesLoaded);
+
+      // Handle situations where there is only 1 page of data
+      } else if (!response.next && !response.previous) {
+        allFeaturesLoaded()
+      }
     });
   }
 

--- a/cadasta/spatial/serializers.py
+++ b/cadasta/spatial/serializers.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from rest_framework import serializers
@@ -43,11 +45,45 @@ class SpatialUnitSerializer(core_serializers.JSONAttrsSerializer,
 class SpatialUnitGeoJsonSerializer(geo_serializers.GeoFeatureModelSerializer):
     url = serializers.SerializerMethodField()
     type = serializers.SerializerMethodField()
+    fixed_precision_geometry = geo_serializers.GeometrySerializerMethodField()
 
     class Meta:
         model = SpatialUnit
-        geo_field = 'geometry'
+        geo_field = 'fixed_precision_geometry'
         fields = ('id', 'type', 'url')
+
+    def get_fixed_precision_geometry(self, location):
+        """ Field to return geometry rounded down to a specified precision """
+        # Notes on precision notes:
+        # https://gis.stackexchange.com/questions/8650/measuring-accuracy-of-latitude-and-longitude/8674#8674  # NOQA
+        # - The fourth decimal place is worth up to 11 m: it can identify a
+        #   parcel of land. It is comparable to the typical accuracy of an
+        #   uncorrected GPS unit with no interference.
+        # - The fifth decimal place is worth up to 1.1 m: it distinguish trees
+        #   from each other. Accuracy to this level with commercial GPS units
+        #   can only be achieved with differential correction.
+        # - The sixth decimal place is worth up to 0.11 m: you can use this for
+        #   laying out structures in detail, for designing landscapes, building
+        #   roads. It should be more than good enough for tracking movements of
+        #   glaciers and rivers. This can be achieved by taking painstaking
+        #   measures with GPS, such as differentially corrected GPS.
+        precision = 5
+
+        features = []
+        for feature in location.geometry.coords:
+            coords = []
+            for f_coords in feature:
+                # Decrease precision
+                r_coords = tuple(round(coord, precision) for coord in f_coords)
+
+                # Rm duplicates
+                if coords and coords[-1] == r_coords:
+                    continue
+                coords.append(r_coords)
+            features.append(coords)
+
+        Feature = namedtuple('Feature', 'geom_type,coords')
+        return Feature(location.geometry.geom_type, tuple(features))
 
     def get_url(self, location):
         project = location.project

--- a/cadasta/spatial/serializers.py
+++ b/cadasta/spatial/serializers.py
@@ -54,6 +54,8 @@ class SpatialUnitGeoJsonSerializer(geo_serializers.GeoFeatureModelSerializer):
 
     def get_fixed_precision_geometry(self, location):
         """ Field to return geometry rounded down to a specified precision """
+        if not location.geometry:
+            return None
         # Notes on precision notes:
         # https://gis.stackexchange.com/questions/8650/measuring-accuracy-of-latitude-and-longitude/8674#8674  # NOQA
         # - The fourth decimal place is worth up to 11 m: it can identify a

--- a/cadasta/spatial/tests/test_serializers.py
+++ b/cadasta/spatial/tests/test_serializers.py
@@ -1,6 +1,7 @@
 import pytest
 from django.test import TestCase
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.gis.geos import Polygon
 from rest_framework.serializers import ValidationError
 from jsonattrs.models import Attribute, AttributeType, Schema
 
@@ -236,3 +237,18 @@ class SpatialUnitGeoJsonSerializerTest(TestCase):
         location = SpatialUnitFactory.build(type='CB')
         serializer = serializers.SpatialUnitGeoJsonSerializer(location)
         assert serializer.get_type(location) == 'Community boundary'
+
+    def test_simplified_geometry(self):
+        poly = Polygon(((-72.32137149, 18.5310175),
+                       (-72.32137148, 18.53101767),
+                       (-72.32137273, 18.53101229),
+                       (-72.32137195, 18.53101184),
+                       (-72.32137149, 18.5310175),
+                       (-72.32137149, 18.5310175)))
+        location = SpatialUnitFactory.build(type='CB', geometry=poly)
+        serializer = serializers.SpatialUnitGeoJsonSerializer(location)
+        assert serializer.get_fixed_precision_geometry(location).coords == (
+            [(-72.32137, 18.53102),
+             (-72.32137, 18.53101),
+             (-72.32137, 18.53102)],
+         )

--- a/cadasta/spatial/views/async.py
+++ b/cadasta/spatial/views/async.py
@@ -9,14 +9,39 @@ from . import mixins
 from .. import serializers
 
 
-class Paginator(GeoJsonPagination):
+from django.core.paginator import Paginator
+
+
+class SpatialUnitDjangoPaginator(Paginator):
+
+    def page(self, number):
+        page = super().page(number)
+        # Here we are adding annotation after the page is selected. This helps
+        # us avoid the burden of the annotation's lookup clauses when we are
+        # doing the COUNT() operation needed to create the page.
+        annotation = {
+            # Prefetch the location type name
+            page.object_list.model._LOCATION_TYPE_KEY: Subquery(
+                QuestionOption.objects.filter(
+                    question__questionnaire_id=OuterRef(
+                        'project__current_questionnaire'),
+                    name=OuterRef('type')
+                ).values('label_xlat')
+            )
+        }
+        page.object_list = page.object_list.annotate(**annotation)
+        return page
+
+
+class SpatialUnitPaginator(GeoJsonPagination):
     page_size = 1000
+    django_paginator_class = SpatialUnitDjangoPaginator
 
 
 class SpatialUnitList(APIPermissionRequiredMixin,
                       mixins.SpatialQuerySetMixin,
                       generics.ListAPIView):
-    pagination_class = Paginator
+    pagination_class = SpatialUnitPaginator
     serializer_class = serializers.SpatialUnitGeoJsonSerializer
 
     def get_actions(self, request):
@@ -34,17 +59,7 @@ class SpatialUnitList(APIPermissionRequiredMixin,
     def get_queryset(self, *args, **kwargs):
         queryset = super().get_queryset(*args, **kwargs)
         queryset = queryset.exclude(id=self.request.GET.get('exclude'))
-        annotation = {
-            # Prefetch the location type name
-            queryset.model._LOCATION_TYPE_KEY: Subquery(
-                QuestionOption.objects.filter(
-                    question__questionnaire_id=OuterRef(
-                        'project__current_questionnaire'),
-                    name=OuterRef('type')
-                ).values('label_xlat')
-            )
-        }
-        return queryset.annotate(**annotation)
+        return queryset
 
     def get_perms_objects(self):
         return [self.get_project()]


### PR DESCRIPTION
### Proposed changes in this pull request

I noticed that the locations in the Project Dashboard were taking a very long time to load on large projects.  This is an important endpoint, as it serves the locations for the project view's map.  There are a number of ways in which I attempted to improve performance:


#### Database Lookups

Looking at the database usage, we have two queries that are both repeated 1000 times (there were 1000 locations in the response):

![screen shot 2017-12-19 at 5 31 48 pm](https://user-images.githubusercontent.com/897290/34214380-8bfa3156-e55f-11e7-8e65-821ab5f84052.png)

This was due to us serializing the `type` of the location, which is basically the location's `location_type_label` property:

```py
    @cached_property
    def location_type_label(self):
        if not self.project.current_questionnaire:
            return dict(TYPE_CHOICES)[self.type]

        question = Question.objects.get(
            questionnaire_id=self.project.current_questionnaire,
            name='location_type'
        )
        label = question.options.get(name=self.type).label_xlat
        if label is None or isinstance(label, str):
            return label
        else:
            return label.get(
                get_language(),
                label[question.questionnaire.default_language]
            )
```

This property does two lookups.  It is run for every location in the API view.

What I've done is use some QuerySet tricks to prefetch these values from the DB. This wasn't entirely straightforward being that it jumps a few relationships (`location` -> `project` -> `questionnaire` -> `question` -> `question option`) and the `project` doesn't actually have a FK relationship to the `questionnaire`, rather it uses a `CharField` to store the ID in the `current_questionnaire` field (I have no idea why we do it this way). The property to get the location type label now looks to see if there is a cached value on the object first, and if not then retrieves them from the DB manually (as it did before). The QuerySet uses `annotate` to cache the location type label on the object, meaning the manual DB retrieval won't be necessary.

The fix seems to have worked.  Unfortunately, the DB query is pretty expensive.  The DB query time is about the same as it was before the optimization.  However, because this is all done in the DB the amount of Python computation we are doing is drastically less. This results in a API response time that is about 5x as fast:

**Before**:
<img style="display:inline;" width="198" alt="screen shot 2017-12-19 at 10 25 25 pm" src="https://user-images.githubusercontent.com/897290/34214381-8c11057a-e55f-11e7-9fda-e103b09a2efc.png">

**After**:
<img width="196" alt="screen shot 2017-12-19 at 10 31 26 pm" src="https://user-images.githubusercontent.com/897290/34214383-8c38e0d6-e55f-11e7-896d-ce9297680d30.png">

After doing this, I realized that we are still being somewhat wasteful with DB queries: 
![screen shot 2017-12-20 at 11 53 14 am](https://user-images.githubusercontent.com/897290/34234568-3666d5ce-e5a9-11e7-9209-ea75d5e77356.png)

You can see that our two most expensive queries (the last two shown in the above image) are nearly identical, one is simple a `COUNT` while the other is a `SELECT`. This is because the paginator runs a count on the provided queryset to both determine how it should slice the queryset and to provide the total number of records in every response.  The `COUNT` was slow because of all the annotation logic, however the annotation logic does not affect the `COUNT`. This led me to the conclusion that we should annotate the queryset _after_ the `COUNT` took place, making the `COUNT` a fast query.  There was no easy way to do this, so my solution is admittedly pretty ugly (the paginator uses another paginator, so I had to subclass the paginator's subpaginator's `page` method.)  This brought our `COUNT` speed up quite a bit:

![screen shot 2017-12-20 at 11 49 27 am](https://user-images.githubusercontent.com/897290/34234695-d9873d0c-e5a9-11e7-838b-37af605e3f32.png)

#### Reduced Response Size

Our API is returning coordinates to the 14th decimal point.  This is way too accurate.  Based on [this StackOverflow answer](https://gis.stackexchange.com/questions/8650/measuring-accuracy-of-latitude-and-longitude/8674#8674), accuracy after the 5th decimal point can only be achieved through "differentially corrected GPS".  I put a bit of work into the `SpatialUnitGeoJsonSerializer` and replaced the default `geometry` field serializer with one that manually rounds all coordinates down to the fifth decimal point.

A quick example of the impact of dropping decimal points:

6 decimal points:
<img width="1059" alt="6" src="https://user-images.githubusercontent.com/897290/34241875-b0aa6914-e5d5-11e7-86c7-ec31c527e066.png">
5 decimal points:
<img width="1061" alt="5" src="https://user-images.githubusercontent.com/897290/34241877-b0d704c4-e5d5-11e7-81a3-1d23d0f3eb70.png">
4 decimal points: 
<img width="1061" alt="4" src="https://user-images.githubusercontent.com/897290/34241878-b0eba42e-e5d5-11e7-9e1b-ced03a12f825.png">
3 decimal points:
<img width="1060" alt="3" src="https://user-images.githubusercontent.com/897290/34241876-b0c0b890-e5d5-11e7-9278-871381b3c147.png">



#### Concurrent API Requests

The frontend javascript follows the pagination page by page, making each next request as a response comes in.  Being that the API includes a total count for all records that can be returned, we can do some simple math to determine all pages that will contain data.  I've updated the frontend to make a request for each page after the first page is returned.  Once all pages are in, we remove the "loading" message.

These concurrent requests kind of hammer my dev machine's webserver and don't show a huge performance increase, however I believe that they will on production as there are more worker threads for the webserver and a better provisioned database.  I'm sure this comment does not instil confidence, feel free to push back if this doesn't sound like a good idea.

### When should this PR be merged

I'd like to fit it in to the 1.15 milestone.

### Risks
There may be a better way to improve the database queries.  That annotation stuff was a bit crazy, I would love to hear that there's a simpler way to get the `location_type_label` for a location.

**To be honest, I don't really love any of this improvements, they all seem a bit hacky.  I'm all ears if anyone can suggest ways to improve or avoid any of this ideas. 👂 **

### Follow-up actions
None

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
