### PR TITLE
Handle cache errors gracefully

### DIFF
--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -122,20 +122,19 @@ LOGGING = {
         },
     },
     'loggers': {
-        'django': {
+        '': {
             'handlers': ['file', 'email_admins', 'opbeat'],
-            'level': 'DEBUG',
-            'propagate': True,
+            'level': 'INFO',
         },
         'core': {
             'handlers': ['file', 'email_admins', 'opbeat'],
             'level': 'DEBUG',
-            'propagate': True,
+            'propagate': False,
         },
         'xform.submissions': {
             'handlers': ['file', 'email_admins', 'opbeat'],
             'level': 'DEBUG',
-            'propagate': True,
+            'propagate': False,
         },
         # Log errors from the Opbeat module to the console
         'opbeat.errors': {

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,7 +15,7 @@ djangorestframework-gis==0.12
 jsonschema==2.6.0
 rfc3987==1.3.7
 drfdocs-cadasta==0.0.12
-django-tutelary==0.1.22
+git+https://github.com/Cadasta/django-tutelary.git@hotfix/handle-cache-failures
 django-audit-log==0.7.0
 django-simple-history==1.9.0
 simplejson==3.13.2
@@ -24,7 +24,7 @@ django-buckets==0.1.23
 pyxform-cadasta==0.9.22
 python-magic==0.4.15
 Pillow==4.3.0
-django-jsonattrs==0.1.23
+git+https://github.com/Cadasta/django-jsonattrs.git@hotfix/handle-cache-failures
 openpyxl==2.4.9
 pytz==2017.3
 shapely==1.6.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,49 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
+import sys
 from setuptools import setup
+
+
+def get_pkg_from_git_url(link):
+    """
+    Given a pip-compatible git-requirement, output a setup.py-compatible
+    install requirement.
+    'git+https://github.com/user/pkg.git@branch' ->
+        'pkg'
+    """
+    try:
+        link = link.split('#')[0].strip()
+        link, branch = link.split('@', 1)
+        pkg = link.split('/')[-1]
+        pkg = pkg.split('.git')[0]
+        return pkg
+    except:
+        sys.stderr.write("Failed on link {!r}\n".format(link))
+        raise
+
+
+def get_dependency_from_git_url(link):
+    """
+    Given a pip-compatible git-requirement, output a setup.py-compatible
+    dependency link.
+    'git+https://github.com/user/pkg.git@branch' ->
+        https://github.com/user/pkg/tarball/branch#egg=pkg'
+    """
+    try:
+        link = link.split('#')[0].strip()
+        link = link.replace('git+', '')
+        link, branch = link.split('@', 1)
+        link = link.replace('.git', '')
+        pkg = link.split('/')[-1]
+        link = '{}/tarball/{}'.format(link, branch)
+        if '#egg=' not in link:
+            link = "{}#egg={}".format(link, pkg)
+        return link
+    except:
+        sys.stderr.write("Failed on link {!r}\n".format(link))
+        raise
+
 
 BASE_DIR = os.path.dirname(__file__)
 
@@ -13,7 +55,15 @@ author = 'Cadasta development team'
 author_email = 'dev@cadasta.org'
 license = 'GNU Affero'
 req_file = os.path.join(BASE_DIR, 'requirements/common.txt')
-requirements = open(req_file).read().splitlines()
+raw_requirements = open(req_file).read().splitlines()
+requirements = [
+    (req if '://' not in req.split('#')[0] else get_pkg_from_git_url(req))
+    for req in raw_requirements
+]
+dependency_links = [
+    get_dependency_from_git_url(req)
+    for req in raw_requirements if '://' in req.split('#')[0]
+]
 
 readme_file = os.path.join(BASE_DIR, 'README.rst')
 with open(readme_file, 'r') as f:
@@ -64,6 +114,7 @@ setup(
     packages=get_packages(package),
     package_data=get_package_data(package),
     install_requires=requirements,
+    dependency_links=dependency_links,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',


### PR DESCRIPTION
### Proposed changes in this pull request

Use hotfix branches on `django-jsonattrs` and `django-tutelary` to handle cache errors.

#### Why I made this change

A bug regarding our cache usage is causing intermittent 500 errors for users.

#### Description of the change

The cache failures are raised by either `django-jsonattrs` or `django-tutelary` when they attempt to write-to/read-from the cache.  This PR changes our build to use hotfix branches from each library ([1](https://github.com/Cadasta/django-jsonattrs/tree/hotfix/handle-cache-failures), [2](https://github.com/Cadasta/django-tutelary/tree/hotfix/handle-cache-failures)).  These branches log the errors as exceptions and continue, rather than allowing them to raise and interrupt our generation of a response to a user's request.

To ensure that these logged exceptions remain visible to developers, a root level logger has been added to ensure that the modules' logs make their way to our `opbeat` handler.

**NOTE** We should only apply [`commit#e6bebdd6cdc9296a237231dc76b536896dc00de0`](https://github.com/Cadasta/cadasta-platform/pull/1948/commits/e6bebdd6cdc9296a237231dc76b536896dc00de0), the other commit is only to get tests passing.

#### How someone else can test the change

Copy this PR's log settings to your dev server's settings file.  Manually alter `/opt/cadasta/env/lib/python3.5/site-packages/tutelary/models.py` to throw an error when it attempts to read from the cache in the `tree()` method:

https://github.com/Cadasta/django-tutelary/blob/564419cdbc4fdc5514cf03a79e22d4f02d283989/tutelary/models.py#L276

Start up dev server, load some views, confirm that the errors regarding cache failures made their way to `/var/log/django/debug.log`

### When should this PR be merged

**NEVER**

This fix should be considered a temporary patch.  I don't think we should even ever merge it to `master`, rather we should deploy it to our production Platform server as a stop-gap while we understand the true cause of the cache errors.

### Risks
None foreseen, as this should be seen as a temporary stopgap.

### Follow-up actions

Find the actual cause of the cache errors and resolve that.

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
