### PR TITLE
Add close method to cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   - awscli (1.14.10)
   - pandas (0.21.1)
   - opbeat (3.6.0)
+- Run functional tests in two batches (#1938)
+
+### Fixed
+- Update deadsnakes repository for provisioning (#1950)
+- Prevent excessive cache connections (#1953)
 
 ## [v1.14.1](https://github.com/Cadasta/cadasta-platform/tree/v1.14.1) (2017-12-15)
 

--- a/cadasta/core/backends.py
+++ b/cadasta/core/backends.py
@@ -19,3 +19,19 @@ class MemorySafePyLibMCCache(PyLibMCCache, metaclass=HandledErrors):
         ('set', pylibmc.TooBig),
         ('set_many', pylibmc.TooBig),
     ]
+
+    def close(self):
+        # The close method for the PyLibMCCache cache was overridden to be a
+        # noop in Django 1.11+ (https://github.com/django/django/pull/7200) in
+        # effort to prevent a performance issue from memcached connections
+        # being closed after every connection. It is stated that libmemcached
+        # manages connections on its own, making a need for Django to manage
+        # connections obsolete. When we deployed the Django 1.11 upgrade
+        # (release v1.14.1), connections to our cache instances began to swell
+        # and eventually led to connection issues (the same issue that the
+        # close() method originally intended to resolve,
+        # https://code.djangoproject.com/ticket/5133). It is not known why our
+        # system does not seem to be closing connections, hunches have pointed
+        # to django-jsonattr and django-tutelary but nothing conclusive has
+        # been determined.
+        self._cache.disconnect_all()


### PR DESCRIPTION
### Proposed changes in this pull request

Add `close()` method to our used cache class.

#### Why I made this change

@oliverroick noticed that PR django/django#7200 introduced a change to Django 1.11 which keeps Django from closing memcached connections.  The reasoning behind this being that libmemcached should handle connections internally.  This change seems to be the cause for our cache connection errors that began occurring after deployment of [release v1.14.1](https://github.com/Cadasta/cadasta-platform/releases/tag/v1.14.1) in which we upgraded to Django 1.11.  While we are unsure why it appears that libmemcached is not in-fact closing our connections, it does seem to be our best candidate for a bugfix.  The `close()` method was originally added to fix the issue of unclosed connections (https://code.djangoproject.com/ticket/5133), however apparently "the cure" was considered to be "worse than the disease." The best candidates for points of blame between our system and the intended behaviour of Django with libmemcached seem to be:

* Our customized cache class which handles errors resulting from inserting exceedingly large objects into the cache:
https://github.com/Cadasta/cadasta-platform/blob/bad5537af3e4e99ddb769f2969afe68d13a09093/cadasta/core/backends.py#L13-L21
* Opbeat's wrapped cache class to log cache usage:
https://github.com/opbeat/opbeat_python/blob/198ea170f8e7075213e78a12e94a7b1af488b936/opbeat/instrumentation/packages/pylibmc.py#L5-L30
* Django Tutelary:
https://github.com/Cadasta/django-tutelary/tree/66bb05de7098777c0a383410c287bf48433cde87
* Django jsonattrs
https://github.com/Cadasta/django-jsonattrs/tree/4f06cdea8dbe131aa78e1ac1b67cd9837d9ad038

Current `libmemcached-dev` version: `1.0.8-1ubuntu2`

#### Description of the change

Re-add `self._cache. disconnect_all()` to `close()`

#### How someone else can test the change

While crude, it seems the best way to test this would be to deploy this onto staging and hit the server hard with a large import script (which seems to have been able to consistently raise the error).

### When should this PR be merged

After we can verify that the fix avoids cache connections from swelling.

### Risks

Feeling a bit uneasy about our inherit failure to understand why exactly we are having this connection problem when others using Django 1.11 do not; however I think this is acceptable.

### Follow-up actions

None.

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
