### PR TITLE
Ensure all errors are sent to Opbeat and admins

### DIFF
--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -141,6 +141,11 @@ LOGGING = {
             'level': 'DEBUG',
             'propagate': True,
         },
+        'django.request': {
+            'handlers': ['debug_file', 'error_file'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
         'opbeat.errors': {
             'level': 'ERROR',
             'handlers': ['debug_file', 'error_file', 'email_admins'],

--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -106,7 +106,7 @@ LOGGING = {
         }
     },
     'handlers': {
-        'file': {
+        'debug_file': {
             'level': 'DEBUG',
             'class': 'logging.handlers.RotatingFileHandler',
             'filename': '/var/log/django/debug.log',
@@ -132,25 +132,18 @@ LOGGING = {
         },
     },
     'loggers': {
+        '': {
+            'handlers': ['error_file', 'email_admins', 'opbeat'],
+            'level': 'ERROR'
+        },
         'django': {
-            'handlers': ['file', 'error_file'],
+            'handlers': ['debug_file'],
             'level': 'DEBUG',
             'propagate': True,
         },
-        'core': {
-            'handlers': ['file', 'error_file', 'email_admins', 'opbeat'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-        'xform.submissions': {
-            'handlers': ['file', 'error_file', 'email_admins', 'opbeat'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-        # Log errors from the Opbeat module to the console
         'opbeat.errors': {
             'level': 'ERROR',
-            'handlers': ['file', 'error_file'],
+            'handlers': ['debug_file', 'error_file', 'email_admins'],
             'propagate': False,
         },
     },


### PR DESCRIPTION
### Proposed changes in this pull request

#### Why I made this change

I believe we made a mistake in #1959.  After the change, only errors logged to `'core'` and `xform.submissions'` will make their way to OpBeat.  Other errors, such as those that occur in our modules (e.g. [`spatial`](https://opbeat.com/cadasta/platform-staging/errors/331/)) or third party modules (e.g. [`rest_framework`](https://opbeat.com/cadasta/platform-prod/errors/122/)) will never make their way to OpBeat or be emailed to our admins.

Basically, I don't think the vast majority of our errors are making their way to OpBeat or our email!  For example, [this URL](https://demo.cadasta.org/api/v1/organizations/cadasta-demo-organization/projects/customary-rights-ghana/spatial/) consistently causes a failure but the logs are nowhere to be found.

#### Description of the change

Ensure that `django.request` errors (which I believe are where the "Internal Server Error" logs are coming from, however I may be wrong) will only be logged to on-disk files.  Any other logs will be sent to OpBeat and emailed to our admins (provided they meet the respective log handler's required level).

#### How someone else can test the change

Failing to come up with anything beyond testing on Staging.


### When should this PR be merged

ASAP, I would actually suggest that this be deployed as a hotfix.



### Risks

Only risk I could see is that this would allow too many errors to be logged to email or OpBeat, however I doubt that would occur as hopefully all modules respect the severity of the `ERROR` log level.

### Follow-up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]


### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
