### PR TITLE
Handle questiongroups submitted as string by ODK

### DIFF
--- a/cadasta/xforms/mixins/model_helper.py
+++ b/cadasta/xforms/mixins/model_helper.py
@@ -429,7 +429,7 @@ class ModelHelper():
             resources['resources'].append(data['{}_photo'.format(model_type)])
 
         for key in data.keys():
-            if group_name in key:
+            if group_name in key and hasattr(data[key], 'keys'):
                 for group_key in data[key].keys():
                     if '{}_resource'.format(model_type) in group_key:
                         resources['resources'].append(data[key][group_key])

--- a/cadasta/xforms/tests/test_model_helper.py
+++ b/cadasta/xforms/tests/test_model_helper.py
@@ -750,6 +750,31 @@ class XFormModelHelperTest(TestCase):
                 mh(), data, self.project)
         assert SpatialUnit.objects.count() == 0
 
+    def test_create_tenure_relationship_empty_group(self):
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # test without repeats
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        party = PartyFactory.create(project=self.project)
+        location = SpatialUnitFactory.create(project=self.project)
+
+        data = {
+            'tenure_type': 'CO',
+            'tenure_relationship_attributes': '',
+            'tenure_resource_photo': 'resource.png'
+        }
+
+        tenure_relationships, tenure_resources = mh.create_tenure_relationship(
+            mh(), data, [party], [location], self.project)
+        tenure = TenureRelationship.objects.get(tenure_type='CO')
+        assert tenure_relationships == [tenure]
+        assert tenure.party == party
+        assert tenure.spatial_unit == location
+        assert tenure.attributes == {}
+        assert len(tenure_resources) == 1
+        assert tenure_resources[0]['id'] == tenure.id
+        assert 'resource.png' in tenure_resources[0]['resources']
+        assert TenureRelationship.objects.count() == 1
+
     def test_create_tenure_relationship(self):
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~
         # test without repeats

--- a/cadasta/xforms/views/api.py
+++ b/cadasta/xforms/views/api.py
@@ -49,7 +49,7 @@ class XFormSubmissionViewSet(OpenRosaHeadersMixin, viewsets.GenericViewSet):
         try:
             instance = ModelHelper().upload_submission_data(request)
         except InvalidXMLSubmission as e:
-            logger.debug(str(e))
+            logger.exception(str(e))
             return self._sendErrorResponse(request, e,
                                            status.HTTP_400_BAD_REQUEST)
         except PermissionDenied as e:


### PR DESCRIPTION
### Proposed changes in this pull request

#### Why I made this change

We were seeing issues where one partner wasn't able to submit questionnaires via ODK.  

The group `tenure_relationship_attributes` in the form in question contains two questions which both have a `relevant` condition. When you select any tenure type that is not `CO - Concessionary Rights` you never get to any of these questions in the form. In this case, ODK sends the response to question group `tenure_relationship_attributes` as an empty string. The platform expects a `dict` hence the exception. 

#### Description of the change

Check whether the object provided has the attribue `keys` before trying to drill down the question group. This will skip all string-like responses. 

#### How someone else can test the change

Need to deploy to staging and verify

### When should this PR be merged

ASAP. 


### Risks

None.

### Follow-up actions

None.

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
