### PR TITLE
Test newest jsonattrs lib

### DIFF
--- a/cadasta/party/tests/test_models.py
+++ b/cadasta/party/tests/test_models.py
@@ -231,6 +231,15 @@ class TenureRelationshipTest(UserTestCase, TestCase):
         assert len(relationship.project.tenure_relationships.all()) == 1
 
     def test_set_attributes(self):
+        # add attribute schema
+        content_type = ContentType.objects.get(
+            app_label='party', model='tenurerelationship')
+        sch = Schema.objects.create(content_type=content_type, selectors=())
+        attr_type = AttributeType.objects.get(name="text")
+        Attribute.objects.create(
+            schema=sch, name='description', long_name='Description',
+            required=False, index=1, attr_type=attr_type
+        )
         tenure_relationship = TenureRelationshipFactory.create()
         attributes = {
             'description':

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,7 +25,7 @@ django-buckets==0.1.24.post1
 pyxform-cadasta==0.9.22
 python-magic==0.4.15
 Pillow==5.0.0
-django-jsonattrs==0.1.24.dev1
+django-jsonattrs==0.1.24
 openpyxl==2.5.0
 pytz==2018.3
 shapely==1.6.4.post1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,7 +25,7 @@ django-buckets==0.1.24.post1
 pyxform-cadasta==0.9.22
 python-magic==0.4.15
 Pillow==5.0.0
-django-jsonattrs==0.1.24
+django-jsonattrs==0.1.25
 openpyxl==2.5.0
 pytz==2018.3
 shapely==1.6.4.post1


### PR DESCRIPTION
### Proposed changes in this pull request

#### Why I made this change

Fixes #1656 

#### Description of the change

* Update `django-jsonattrs` to not attempt to validate the contents of a `jsonattrs` against that field's schema when reading from the field.  Instead, we will only scrutinize the data when insterting it into the field.
* Has the bonus effect of improving response times for API endpoints that include `jsonattrs` fields.

#### How someone else can test the change

##### Failure without fix

On `master` branch, in shell:

```
$ DJANGO_SETTINGS_MODULE=config.settings.dev_debug ./manage.py shell_plus`)
```

Use the `cpaste` command and paste:

```py
import json

from django.db import connection
from rest_framework.renderers import JSONRenderer

from organization.models import Project
from spatial.serializers import SpatialUnitSerializer

# Let's force insert some bad data into our DB
_id = "asd"
with connection.cursor() as c:
    sql = "INSERT INTO {table} ({columns}) VALUES ({values})"
    data = [
        ('id', repr("asdf")),
        ('project_id', repr(Project.objects.first().id)),
        ('type', "'PA'"),
        ('geometry', "null"),
        ('area', '0'), 
        ('attributes', repr(json.dumps({"foo": 'bar'}))), 
        ('created_date', "'2017-01-01T01:01:59'"),
        ('last_updated', "'2017-01-01T01:01:59'"),
    ]
    sql = sql.format(
        table=SpatialUnit._meta.db_table,
        columns=', '.join([d for d, _ in data]),
        values=', '.join([d for _, d in data]),
    )
    c.execute(sql)

# This is going to fail
l = SpatialUnit.objects.get(id="asdf")
data = SpatialUnitSerializer(l).data
JSONRenderer().render(data)
```

##### With fix

1. Checkout `update-django-jsonattrs` branch
1. `pip install -r requirements.txt`
1. In `shell_plus`:

```
# This won't fail
l = SpatialUnit.objects.get(id="asdf")
data = SpatialUnitSerializer(l).data
JSONRenderer().render(data)
```

### When should this PR be merged

Cadasta/django-jsonattrs#39 and Cadasta/django-jsonattrs#30 should both be merged and a new version released for `django-jsonattrs`. This PR should be closed and #1987 should be updated to use the new version of `django-jsonattrs`.


### Risks

~~I have faith in our unit and functional tests, so I feel that risks are low.~~

**Please review [this comment](https://github.com/Cadasta/cadasta-platform/pull/1984#issuecomment-366141625) and let me know if it seems sensible**


### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
