### PR TITLE
Improve handling of ValidationErrors for API

### DIFF
--- a/cadasta/core/serializers.py
+++ b/cadasta/core/serializers.py
@@ -1,3 +1,4 @@
+from django.utils.translation import ugettext as _
 from django.db.models.query import QuerySet
 from django.core.exceptions import ValidationError
 from django.contrib.contenttypes.models import ContentType
@@ -74,7 +75,7 @@ class JSONAttrsSerializer(SchemaSelectorMixin):
             try:
                 attr = attributes[key]
             except KeyError:
-                errors.append('Unknown key "{}"'.format(key))
+                errors.append(_('Unknown attribute "{}"'.format(key)))
             else:
                 try:
                     attr.validate(value)

--- a/cadasta/core/serializers.py
+++ b/cadasta/core/serializers.py
@@ -74,7 +74,7 @@ class JSONAttrsSerializer(SchemaSelectorMixin):
             try:
                 attr = attributes[key]
             except KeyError:
-                errors += 'Unknown key "{}"'.format(key)
+                errors.append('Unknown key "{}"'.format(key))
             else:
                 try:
                     attr.validate(value)

--- a/cadasta/core/serializers.py
+++ b/cadasta/core/serializers.py
@@ -70,15 +70,19 @@ class JSONAttrsSerializer(SchemaSelectorMixin):
         attributes = self.get_model_attributes(self.context['project'], label)
         attributes = attributes.get(attrs_selector, {})
 
-        for key, attr in attributes.items():
-            value = attrs.get(key)
+        for key, value in attrs.items():
             try:
-                attr.validate(value)
-            except ValidationError as e:
-                errors += e.messages
+                attr = attributes[key]
+            except KeyError:
+                errors += 'Unknown key "{}"'.format(key)
             else:
-                if hasattr(value, 'strip'):
-                    attrs[key] = value.strip()
+                try:
+                    attr.validate(value)
+                except ValidationError as e:
+                    errors += e.messages
+                else:
+                    if hasattr(value, 'strip'):
+                        attrs[key] = value.strip()
 
         if errors:
             raise serializers.ValidationError(errors)

--- a/cadasta/core/tests/test_views_api.py
+++ b/cadasta/core/tests/test_views_api.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 from django.http import Http404
+from django.core.exceptions import ValidationError as DjangoValidationError
 
 from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from ..views.api import set_exception, eval_json
 
@@ -10,23 +12,45 @@ class ExceptionHandleTest(TestCase):
     def test_set_exception_with_404(self):
         exception = Http404("No Organization matches the given query.")
 
-        e = set_exception(exception)
+        e = set_exception(exception, 'http://testserver.com')
         assert type(e) == NotFound
         assert str(e) == "Organization not found."
 
     def test_set_exception_with_404_and_different_error(self):
         exception = Http404("Error Message")
 
-        e = set_exception(exception)
+        e = set_exception(exception, 'http://testserver.com')
         assert type(e) == Http404
         assert str(e) == "Error Message"
 
     def test_set_exception_with_NotFound(self):
         exception = NotFound("Error Message")
 
-        e = set_exception(exception)
+        e = set_exception(exception, 'http://testserver.com')
         assert type(e) == NotFound
         assert str(e) == "Error Message"
+
+    def test_set_exception_with_validation_error(self):
+        # message case
+        exception = DjangoValidationError(message="Error Message")
+        e = set_exception(exception, 'http://testserver.com')
+        assert type(e) == DRFValidationError
+        assert "Error Message" in e.detail['detail']
+
+        # messages case
+        exception = DjangoValidationError(message=["Error 1", "Error 2"])
+        e = set_exception(exception, 'http://testserver.com')
+        assert type(e) == DRFValidationError
+        assert "Error 1" in e.detail['detail']
+        assert "Error 2" in e.detail['detail']
+
+        # message_dict case
+        exception = DjangoValidationError(
+            message={'error1': 'Error 1', 'error2': 'Error 2'})
+        e = set_exception(exception, 'http://testserver.com')
+        assert type(e) == DRFValidationError
+        assert "Error 1" in e.detail['error1']
+        assert "Error 2" in e.detail['error2']
 
     def test_evaluate_json(self):
         response_data = {
@@ -49,4 +73,10 @@ class ExceptionHandleTest(TestCase):
             'field': "Something went wrong"
         }
 
+        assert actual == expected
+
+        # test with list
+        response_data = ['Error 1', 'Error 2']
+        actual = eval_json(response_data)
+        expected = response_data
         assert actual == expected

--- a/cadasta/core/views/api.py
+++ b/cadasta/core/views/api.py
@@ -63,7 +63,7 @@ def eval_json(response_data):
 def exception_handler(exception, context):
     """
     Overwriting Django Rest Frameworks exception handler to provide more
-    meaniful exception messages for 404 errors.
+    meaningful exception messages for 404 and validation errors.
     """
     exception = set_exception(exception,
                               context['request'].build_absolute_uri())

--- a/cadasta/core/views/api.py
+++ b/cadasta/core/views/api.py
@@ -1,15 +1,20 @@
+import logging
 import json
 import re
 from django.http import Http404
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
+from django.core.exceptions import ValidationError as DjangoValidationError
 
 from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.views import exception_handler as drf_exception_handler
 
+logger = logging.getLogger('core')
 
-def set_exception(exception):
-    if (type(exception) is Http404):
+
+def set_exception(exception, url):
+    if isinstance(exception, Http404):
         exception_msg = str(exception)
         try:
             model = re.search(
@@ -17,14 +22,31 @@ def set_exception(exception):
             exception = NotFound(_("{name} not found.").format(name=model))
         except AttributeError:
             pass
+
+    elif isinstance(exception, DjangoValidationError):
+        if hasattr(exception, 'message_dict'):
+            detail = exception.message_dict
+        elif hasattr(exception, 'message'):
+            detail = {'detail': exception.message}
+        elif hasattr(exception, 'messages'):
+            detail = {'detail': exception.messages}
+
+        logger.exception(
+            "ValidationError raised at {}: {}".format(url, exception))
+
+        exception = DRFValidationError(detail=detail)
+
     return exception
 
 
 def eval_json(response_data):
     """
-    Evaluate stringified JSON objects, so we can return structure
+    Evaluate stringified JSON objects, so we can return structured
     error responses
     """
+    if not isinstance(response_data, dict):
+        return response_data
+
     for key in response_data:
         errors = []
         if not isinstance(response_data[key], six.string_types):
@@ -43,8 +65,8 @@ def exception_handler(exception, context):
     Overwriting Django Rest Frameworks exception handler to provide more
     meaniful exception messages for 404 errors.
     """
-    exception = set_exception(exception)
-
+    exception = set_exception(exception,
+                              context['request'].build_absolute_uri())
     response = drf_exception_handler(exception, context)
 
     if response:

--- a/cadasta/party/tests/test_serializers.py
+++ b/cadasta/party/tests/test_serializers.py
@@ -184,7 +184,7 @@ class PartySerializerTest(UserTestCase, TestCase):
 
         with pytest.raises(ValidationError) as e:
             serializer.validate_attributes(party_data['attributes'])
-        assert 'Unknown key "age"' in e.value.detail
+        assert 'Unknown attribute "age"' in e.value.detail
 
     def test_full_invalid(self):
         project = ProjectFactory.create(name='Test Project')
@@ -474,7 +474,7 @@ class TenureRelationshipSerializer(UserTestCase, TestCase):
             context={'project': project}
         )
         assert serializer.is_valid() is False
-        assert 'Unknown key "age"' in serializer.errors['attributes']
+        assert 'Unknown attribute "age"' in serializer.errors['attributes']
 
     def test_sanitise_string(self):
         project = ProjectFactory.create(name='Test Project')

--- a/cadasta/questionnaires/tests/test_attr_schemas.py
+++ b/cadasta/questionnaires/tests/test_attr_schemas.py
@@ -77,7 +77,7 @@ class CreateAttributeSchemaTest(UserTestCase, FileStorageTestCase, TestCase):
             content_type=content_type, errors=[],
             attr_type_ids=get_attr_type_ids())
         assert 1 == Schema.objects.all().count()
-        with pytest.raises(KeyError):
+        with pytest.raises(ValidationError):
             PartyFactory.create(
                 name='TestParty', project=project,
                 attributes={
@@ -138,7 +138,7 @@ class CreateAttributeSchemaTest(UserTestCase, FileStorageTestCase, TestCase):
             content_type=content_type, errors=[],
             attr_type_ids=get_attr_type_ids())
         assert 1 == Schema.objects.all().count()
-        with pytest.raises(KeyError):
+        with pytest.raises(ValidationError):
             SpatialUnitFactory.create(
                 project=project,
                 attributes={
@@ -176,7 +176,7 @@ class CreateAttributeSchemaTest(UserTestCase, FileStorageTestCase, TestCase):
             question_group_dict=party_relationship_xform_group,
             attr_type_ids=get_attr_type_ids())
         assert 1 == Schema.objects.all().count()
-        with pytest.raises(KeyError):
+        with pytest.raises(ValidationError):
             SpatialRelationshipFactory.create(
                 project=project,
                 attributes={
@@ -214,7 +214,7 @@ class CreateAttributeSchemaTest(UserTestCase, FileStorageTestCase, TestCase):
             question_group_dict=party_relationship_xform_group,
             attr_type_ids=get_attr_type_ids())
         assert 1 == Schema.objects.all().count()
-        with pytest.raises(KeyError):
+        with pytest.raises(ValidationError):
             PartyRelationshipFactory.create(
                 project=project,
                 attributes={
@@ -252,7 +252,7 @@ class CreateAttributeSchemaTest(UserTestCase, FileStorageTestCase, TestCase):
             question_group_dict=party_relationship_xform_group,
             attr_type_ids=get_attr_type_ids())
         assert 1 == Schema.objects.all().count()
-        with pytest.raises(KeyError):
+        with pytest.raises(ValidationError):
             TenureRelationshipFactory.create(
                 project=project,
                 attributes={
@@ -269,7 +269,7 @@ class CreateAttributeSchemaTest(UserTestCase, FileStorageTestCase, TestCase):
             project=project, question_group_dict=location_xform_group,
             content_type=content_type, errors=[],
             attr_type_ids=get_attr_type_ids())
-        with pytest.raises(KeyError):
+        with pytest.raises(ValidationError):
             SpatialUnitFactory.create(
                 project=project,
                 attributes={

--- a/cadasta/spatial/tests/test_serializers.py
+++ b/cadasta/spatial/tests/test_serializers.py
@@ -241,7 +241,7 @@ class SpatialUnitSerializerTest(UserTestCase, TestCase):
             context={'project': project}
         )
         assert serializer.is_valid() is False
-        assert 'Unknown key "age"' in serializer.errors['attributes']
+        assert 'Unknown attribute "age"' in serializer.errors['attributes']
 
 
 class SpatialUnitGeoJsonSerializerTest(TestCase):

--- a/cadasta/spatial/tests/test_serializers.py
+++ b/cadasta/spatial/tests/test_serializers.py
@@ -209,6 +209,40 @@ class SpatialUnitSerializerTest(UserTestCase, TestCase):
         assert serializer.is_valid() is False
         assert serializer.errors['attributes']
 
+    def test_unknown_attribute(self):
+        project = ProjectFactory.create(name='Test Project')
+
+        content_type = ContentType.objects.get(
+            app_label='spatial', model='spatialunit')
+        schema = Schema.objects.create(
+            content_type=content_type,
+            selectors=(project.organization.id, project.id, ))
+
+        Attribute.objects.create(
+            schema=schema,
+            name='notes',
+            long_name='Notes',
+            attr_type=AttributeType.objects.get(name='text'),
+            index=0
+        )
+        data = {
+            'properties': {
+                'type': 'AP',
+                'project': project,
+                'attributes': {
+                    'notes': 'Blah',
+                    'age': 'Ten'
+                }
+            }
+        }
+
+        serializer = serializers.SpatialUnitSerializer(
+            data=data,
+            context={'project': project}
+        )
+        assert serializer.is_valid() is False
+        assert 'Unknown key "age"' in serializer.errors['attributes']
+
 
 class SpatialUnitGeoJsonSerializerTest(TestCase):
     def test_serialize(self):

--- a/cadasta/xforms/mixins/model_helper.py
+++ b/cadasta/xforms/mixins/model_helper.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import ValidationError, PermissionDenied
+from django.core.exceptions import PermissionDenied
 from django.core.files.storage import get_storage_class
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.db import models as geo_models
@@ -395,7 +395,7 @@ class ModelHelper():
                 id_string=id_string, version=int(version)
             )
         except Questionnaire.DoesNotExist:
-            raise ValidationError(_('Questionnaire not found.'))
+            raise InvalidXMLSubmission(_('Questionnaire not found.'))
 
     def _get_attributes(self, data, model_type):
         attributes = {}

--- a/cadasta/xforms/tests/test_model_helper.py
+++ b/cadasta/xforms/tests/test_model_helper.py
@@ -3,7 +3,7 @@ import io
 import pytest
 from django.conf import settings
 from django.test import TestCase
-from django.core.exceptions import ValidationError, PermissionDenied
+from django.core.exceptions import PermissionDenied
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.contrib.contenttypes.models import ContentType
 from jsonattrs.models import Attribute, AttributeType, Schema
@@ -1421,7 +1421,7 @@ class XFormModelHelperTest(TestCase):
             self, 'a1', '0')
         assert questionnaire == self.questionnaire
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(InvalidXMLSubmission):
             mh._get_questionnaire(
                 self, 'bad_info', '0')
 

--- a/cadasta/xforms/tests/test_views_api.py
+++ b/cadasta/xforms/tests/test_views_api.py
@@ -439,13 +439,14 @@ class XFormSubmissionTest(APITestCase, UserTestCase, FileStorageTestCase,
                 in response.content)
 
     def test_questionnaire_not_found(self):
-        with pytest.raises(ValidationError):
-            data = self._submission(form='submission_bad_questionnaire')
-            response = self.request(method='POST',
-                                    post_data=data,
-                                    user=self.user,
-                                    content_type='multipart/form-data')
-            assert response.status_code == 400
+        data = self._submission(form='submission_bad_questionnaire')
+        response = self.request(method='POST',
+                                post_data=data,
+                                user=self.user,
+                                content_type='multipart/form-data')
+        assert response.status_code == 400
+        msg = self._getResponseMessage(response)
+        assert msg == 'Questionnaire not found.'
 
     def test_no_content_head(self):
         response = self.request(method='HEAD', user=self.user)

--- a/cadasta/xforms/tests/test_views_api.py
+++ b/cadasta/xforms/tests/test_views_api.py
@@ -6,7 +6,6 @@ from lxml import etree
 
 from django.test import TestCase
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from skivvy import APITestCase
 from tutelary.models import Policy

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,7 +25,7 @@ django-buckets==0.1.24.post1
 pyxform-cadasta==0.9.22
 python-magic==0.4.15
 Pillow==5.0.0
-git+https://github.com/cadasta/django-jsonattrs@bugfix/18
+django-jsonattrs==0.1.23
 openpyxl==2.5.0
 pytz==2018.3
 shapely==1.6.4.post1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,7 +25,7 @@ django-buckets==0.1.24.post1
 pyxform-cadasta==0.9.22
 python-magic==0.4.15
 Pillow==5.0.0
-django-jsonattrs==0.1.23
+git+https://github.com/cadasta/django-jsonattrs@bugfix/18
 openpyxl==2.5.0
 pytz==2018.3
 shapely==1.6.4.post1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,7 +25,7 @@ django-buckets==0.1.24.post1
 pyxform-cadasta==0.9.22
 python-magic==0.4.15
 Pillow==5.0.0
-git+https://github.com/cadasta/django-jsonattrs@bugfix/18
+django-jsonattrs==0.1.24.dev1
 openpyxl==2.5.0
 pytz==2018.3
 shapely==1.6.4.post1


### PR DESCRIPTION
### Proposed changes in this pull request

#### Why I made this change

Following the changes in https://github.com/Cadasta/django-jsonattrs/pull/39, we need to adapt the way we handle the `ValidationError` on the platform side. I decided to implement two solutions that were mentioned in the corresponding discussions:

- I updated `JSONAttrsSerializer`'s `validate_attributes` to catch unknown keys and return the appropriate error. I wanted to return an error that complies with DRF's practices; the error message should accessible via the `attributes` key in the response. The `ValidationError` is raised when the model is saved, so it would require a great deal of work to construct and return the correctly structured error. I further believe that the error should be caught during the data-validation stage and not when the model is saved. 
- As an additional layer of robustness, I also added the generic handling of `ValidationErrors` as proposed by @alukach in `core.views.api.exception_handler`. 

#### Description of the change

- Adapt `cadasta/questionnaires/tests/test_attr_schemas.py` so the `ValidationError` is caught instead of `KeyError`. 
- Change `core.serializer.JSONAttrsSerializer.validate_attributes` so that we loop through the data provided in the request payload and add the appropriate error to the errors list when no attribute is defined for the key. This will make the serializer raise a `ValidationError`.
- Add handling of `django.core.exceptions.ValidationError` into `core.views.api.set_exception`, which is used in a custom DRF `exception_handler` defined in the same module. This includes logging the exception, so we can further investigate their cause. `set_exception` now requires the parameter `url` so we can log the URL where the error occurred, which allows us to identify the object that cause the exception. 
- Following the changes discussed above I noticed an odd behaviour in `cadasta/xforms/mixins/model_helper.py` where a `ValidationError` is returned if no questionnaire is found for a submission from ODK. I changed that to `InvalidXMLSubmission` so the error is returned to the client in an ODK-compliant format. This fixes #1398.

#### How someone else can test the change

1. Create a project with a questionnaire.
2. Via the API, try to create a party. In the `attributes` dictionary add an entry using a key that is not defined as a field name in the questionnaire. 
3. You should receive a `HTTP 400` error, the response should indicate `Unknown key "your_key"`

### When should this PR be merged

After https://github.com/Cadasta/django-jsonattrs/pull/39 is merged, a new version of jsonattrs is released and the requirements are updated to point to that new version. 

### Risks

None.


### Follow-up actions

- [ ] Accept and merge https://github.com/Cadasta/django-jsonattrs/pull/39
- [ ] Create new jsonattrs release
- [ ] Update the requirements

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
