### PR TITLE
Ensure node present on servers

### DIFF
--- a/provision/aws-deploy.yml
+++ b/provision/aws-deploy.yml
@@ -13,6 +13,7 @@
     - system/common
     - db/common
     - db/production
+    - node
     - cadasta/common
     - cadasta/install
     - cadasta/application


### PR DESCRIPTION
### Proposed changes in this pull request

#### Why I made this change

When deploying `v1.16.0` to `demo` and `prod`, I got the following error:

```
TASK [cadasta/application : Transpile JSX] ***************************************************************************************************************************************************************************************************
task path: /Users/alukach/Projects/cadasta-platform/provision/roles/cadasta/application/tasks/main.yml:126
fatal: [platform-demo.local]: FAILED! => {"changed": true, "cmd": ["npm", "run-script", "build"], "delta": "0:00:00.209625", "end": "2018-02-22 22:22:36.439733", "failed": true, "rc": 1, "start": "2018-02-22 22:22:36.230108", "stderr": "sh: 1: node: not found\nnpm ERR! weird error 127\nnpm WARN This failure might be due to the use of legacy binary \"node\"\nnpm WARN For further explanations, please read\n/usr/share/doc/nodejs/README.Debian\n \nnpm ERR! not ok code 0", "stderr_lines": ["sh: 1: node: not found", "npm ERR! weird error 127", "npm WARN This failure might be due to the use of legacy binary \"node\"", "npm WARN For further explanations, please read", "/usr/share/doc/nodejs/README.Debian", " ", "npm ERR! not ok code 0"], "stdout": "\n> cadasta@1.0.0 build /opt/cadasta/cadasta-platform\n> node node_modules/babel-cli/bin/babel --plugins transform-react-jsx cadasta/core/static/jsx/ -d cadasta/core/static/dist", "stdout_lines": ["", "> cadasta@1.0.0 build /opt/cadasta/cadasta-platform", "> node node_modules/babel-cli/bin/babel --plugins transform-react-jsx cadasta/core/static/jsx/ -d cadasta/core/static/dist"]}
```

When trying to compile the JSX manually on the machine:

```sh
(env)cadasta@ip-10-0-0-92:/opt/cadasta/cadasta-platform$ npm run-script build

> cadasta@1.0.0 build /opt/cadasta/cadasta-platform
> node node_modules/babel-cli/bin/babel --plugins transform-react-jsx cadasta/core/static/jsx/ -d cadasta/core/static/dist

sh: 1: node: not found
npm ERR! weird error 127
npm WARN This failure might be due to the use of legacy binary "node"
npm WARN For further explanations, please read
/usr/share/doc/nodejs/README.Debian

npm ERR! not ok code 0
(env)cadasta@ip-10-0-0-92:/opt/cadasta/cadasta-platform$ node
WARNING:root:could not open file '/etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list'

WARNING:root:could not open file '/etc/apt/sources.list.d/ppa_nginx_stable_trusty.list'

WARNING:root:could not open file '/etc/apt/sources.list.d/ppa_fkrull_deadsnakes_trusty.list'

The program 'node' can be found in the following packages:
 * node
 * nodejs-legacy
Ask your administrator to install one of them
```

While the legacy `nodejs` binary was present on the machine, the `node` binary was not.

<details>
  <summary>Here are the details of <code>/usr/share/doc/nodejs/README.Debian</code>:</summary>

<pre>
nodejs for Debian
=================

packaged modules
----------------

The global search path for modules is
/usr/lib/nodejs

Future packages of node modules will use that directory,
so it should be used wisely.


user modules
------------

Node looks for modules in ./node_modules directory first;
please read node#modules documentation carefully for more information.

Node does not look for modules in /usr/local/lib/node_modules,
where npm put them.
Please read npm-link(1) of npm package, to understand how to properly
use npm-installed modules in a project.

Note that require.paths is not supported in future node versions.
See also node(1) for more information about NODE_PATH.


nodejs command
--------------

The upstream name for the Node.js interpreter command is "node".
In Debian the interpreter command has been changed to "nodejs".

This was done to prevent a namespace collision: other commands use
the same name in their upstreams, such as ax25-node from the "node"
package.

Scripts calling Node.js as a shell command must be changed to instead
use the "nodejs" command.
</pre>
</details>

tldr, basically it suggest we change our script to use `nodejs`:

> The upstream name for the Node.js interpreter command is "node".
In Debian the interpreter command has been changed to "nodejs".

> This was done to prevent a namespace collision: other commands use
the same name in their upstreams, such as ax25-node from the "node"
package.

> Scripts calling Node.js as a shell command must be changed to instead
use the "nodejs" command.

To get the build to succeed, I made the changes present in this PR locally and rand the ansible deployment.

Maybe this fix is the wrong fix? See "Risks" below.

#### Description of the change

Add the build `node` build step to ansible's production build steps.

#### How someone else can test the change

I'm unsure.

### When should this PR be merged

Anytime, being that I deployed the `demo` and `prod` builds with this step present on my local machine, it really does not make any difference unless we decide to build a server from scratch somewhere down the road.

### Risks

* I'm unsure how the `staging` server had the `node` binary
* The machines now have two separate version of nodejs, `nodejs` and `node`.  This feels like it could cause confusion down the road:
    ```sh
    ubuntu@ip-10-0-0-92:~$ node --version
    v5.5.0
    ubuntu@ip-10-0-0-92:~$ nodejs --version
    v0.10.25
    ```

Perhaps this was the wrong fix.  Instead, maybe I should have just added a symlink to point `node` to the `nodejs` binary.  Or perhaps I should change the `package.json` command to use `nodejs`?  Comments welcome.

### Follow-up actions

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
