### PR TITLE
Set sentry environment via env, use git to provide release

### DIFF
--- a/cadasta/config/settings/production.py
+++ b/cadasta/config/settings/production.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import raven
 import requests
 from .default import *  # NOQA
@@ -52,9 +53,17 @@ ES_HOST = os.environ['ES_HOST']
 
 RAVEN_CONFIG = {
     'dsn': os.environ['SENTRY_DSN'],
-    # If you are using git, you can also automatically configure the
-    # release based on the git info.
-    'release': raven.fetch_git_sha(os.path.abspath(os.pardir)),
+    'release':
+        subprocess.check_output(
+            'git symbolic-ref -q --short HEAD'
+            ' || '
+            'git describe --tags --exact-match',
+            shell=True
+        ).decode().strip(),
+    'tags': {
+        'git_sha': raven.fetch_git_sha(os.path.abspath(os.pardir))
+    },
+    'environment': os.environ['SENTRY_ENVIRONMENT'],
 }
 
 DJOSER.update({  # NOQA

--- a/provision/roles/cadasta/install/tasks/main.yml
+++ b/provision/roles/cadasta/install/tasks/main.yml
@@ -38,6 +38,7 @@
       TWILIO_PHONE={{ twilio_phone }}
       QUEUE_PREFIX="{{ identifier }}"
       SENTRY_DSN="{{ sentry_dsn }}"
+      SENTRY_ENVIRONMENT="{{ identifier }}"
 
 
 - name: Enable environment variables for SSH
@@ -71,6 +72,7 @@
       Defaults  env_keep += TWILIO_PHONE
       Defaults  env_keep += QUEUE_PREFIX
       Defaults  env_keep += SENTRY_DSN
+      Defaults  env_keep += SENTRY_ENVIRONMENT
 
 # This is VERY ugly.  The problem is that Ansible keeps SSH
 # connections open across tasks, so the environment variable changes

--- a/provision/roles/webserver/production/templates/uwsgi.ini
+++ b/provision/roles/webserver/production/templates/uwsgi.ini
@@ -43,3 +43,4 @@ env = TWILIO_PHONE={{ twilio_phone }}
 env = QUEUE_PREFIX={{ identifier }}
 env = RESULT_DB_HOST={{ db_host }}
 env = SENTRY_DSN={{ sentry_dsn }}
+env = SENTRY_ENVIRONMENT="{{ identifier }}"


### PR DESCRIPTION
### Proposed changes in this pull request


#### Why I made this change

Ensure `environment` is available on the Sentry logs and that `release` is better than just the git sha.

#### Description of the change

Set the `environment` detail for Sentry from the `SENTRY_ENVIRONMENT` environment variable. This will match the `identifier` provided by Ansible (same thing used to populate the template identifying staging/demo/platform systems).

Set the `release` environment to the output of `git symbolic-ref -q --short HEAD || git describe --tags --exact-match`, which will report the branch name if a branch is checked out or the tag name if the codebase is checked out from a tag.

Finally, I'm putting the git sha as a tag onto the sentry logs which seems good to keep.

#### How someone else can test the change

Comment out all other details from the `production` settings (outside of the `RAVEN_CONFIG`), spin up the django shell and examine the `RAVEN_CONFIG` object.

### When should this PR be merged

Before #2010 is released.

### Risks

It's possible that I'm misunderstanding how the `RAVEN_CONFIG` should be configured (although I don't think so).  See [the docs](https://docs.sentry.io/clients/python/advanced/) for details.

### Follow-up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]


### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
