### PR TITLE
Remove recursive template code

### DIFF
--- a/cadasta/templates/organization/project_attrs_import.html
+++ b/cadasta/templates/organization/project_attrs_import.html
@@ -11,13 +11,6 @@
 {% block step_content %}
 
 {{ wizard.management_form }}
-{% if wizard.form.forms %}
-    {{ wizard.form.management_form }}
-    {% for form in wizard.form.forms %}
-        {{ form }}
-    {% endfor %}
-{% else %}
-
   <div class="panel panel-default">
 
     <div class="panel-body">
@@ -122,7 +115,5 @@
     </div>
 
   </div>
-
-{% endif %}
 
 {% endblock %}

--- a/cadasta/templates/organization/project_defaults_import.html
+++ b/cadasta/templates/organization/project_defaults_import.html
@@ -1,5 +1,13 @@
-{% extends "organization/project_import_wrapper.html" %} {% load i18n %} {% load widget_tweaks %} {% block extra_script %} {{ block.super }} {{ form.media }} {% endblock %} {% block step_content %} {{ wizard.management_form }} {% if wizard.form.forms %} {{ wizard.form.management_form
-}} {% for form in wizard.form.forms %} {{ form }} {% endfor %} {% else %}
+{% extends "organization/project_import_wrapper.html" %}
+{% load i18n %}
+{% load widget_tweaks %}
+{% block extra_script %}
+  {{ block.super }}
+  {{ form.media }}
+{% endblock %}
+
+{% block step_content %}
+{{ wizard.management_form }}
 
 <div class="panel panel-default">
     <div class="panel-body">
@@ -102,4 +110,4 @@
     </div>
 </div>
 
-{% endif %} {% endblock %}
+{% endblock %}

--- a/cadasta/templates/organization/project_select_import.html
+++ b/cadasta/templates/organization/project_select_import.html
@@ -5,20 +5,16 @@
 {{ block.super }}
 {{ form.media }}
 {% endblock %}
+
 {% block step_content %}
 {{ wizard.management_form }}
-{% if wizard.form.forms %}
-{{ wizard.form.management_form }}
-{% for form in wizard.form.forms %}
-{{ form }}
-{% endfor %}
-{% else %}
 
 <div class="panel panel-default">
     <div class="panel-body">
         <h3>{% trans "Import details" %}</h3>
         <div class="row">
             <div class="col-md-9">
+
                 {{ wizard.form.non_field_errors }}
                 <div class="form-group{% if form.name.errors %} has-error{% endif %}">
                     <label class="control-label" for="{{ form.name.id_for_label }}">{% trans "Import name" %}</label>
@@ -59,7 +55,6 @@
                             {{ form.entity_types.errors }}
                         </div>
                         <li class="checkbox">
-                            {{ wizard.form.entity_types.values_list }}
                             <label class="control-label" for="id_select_file-entity_types_parties">
                                 <input type="checkbox" id="id_select_file-entity_types_parties" name="select_file-entity_types" type="checkbox" value="PT" data-parsley-multiple="select_file-entity_types" {% if 'PT' in wizard.form.entity_types.value %}checked{% endif %}> {% trans "Party" %}
                                 <small>{% trans "Includes party information for individuals, groups, corporations." %}</small>
@@ -101,5 +96,4 @@
         <a class="btn btn-link pull-left cancel" href="{% url 'organization:project-dashboard' object.organization.slug object.slug %}">{% trans "Cancel" %}</a>
     </div>
 </div>
-
-{% endif %} {% endblock %}
+{% endblock %}


### PR DESCRIPTION
### Proposed changes in this pull request

#### Why I made this change

After we deployed `v1.17.0`, the import pages in all projects throw a `502 Bad Gateway`. Our debug logs show stack overflow for these events, which causes the server to crash and restart. 

The issue is caused by an `if`  statement in the template; if removed the page renders as expected. 

I don't fully understand the purpose of the code in question, why it's there and what it does. Looking at the template itself and testing out different scenarios it seems like the condition is never met and the template in the `else` branch is always rendered. I'm assuming the code is not needed. 

The reason we haven't seen the error before is likely because of some changes to our logging setup, when we switched from Opbeat to Sentry. 

#### Description of the change

Removed the faulty code. 

#### How someone else can test the change

Add the following logger to the `LOGGING['loggers']` in the dev settings:

```python
       'django.template': {
           'handlers': ['console'],
           'level': 'DEBUG',
       }
```

This will create the same logs that we see on production in `debug.log`.

Navigate to any project dashboard and click the big _Import_ button. 

On `master`, the dev server should crash.

These changes applied, the page should render successfully.

### When should this PR be merged

ASAP, so we can get the latest release back on prod.

### Risks

As I don't fully understand the purpose of the code I removed, there's a slight chance some import scenarios will fail. I've tested different scenarios but I might have missed some. 

All functional tests should pass, so I'm assuming the commin scenaros will work with these changes applied. 

### Follow-up actions

—

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
