### PR TITLE
 Add empty option to select fields

### DIFF
--- a/cadasta/core/form_mixins.py
+++ b/cadasta/core/form_mixins.py
@@ -98,7 +98,7 @@ class AttributeFormMixin(SchemaSelectorMixin):
                     else:
                         chs = [(c, c) for c in attr.choices]
 
-                    field_kwargs['choices'] = chs
+                    field_kwargs['choices'] = [('', '')] + chs
                 if atype.form_field == 'BooleanField':
                     field_kwargs['required'] = attr.required
                     if len(attr.default) > 0:

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -43,6 +43,6 @@ django-otp==0.4.3
 twilio==6.12.1
 phonenumbers==8.9.4
 cadasta-workertoolbox==0.6.0
-git+https://github.com/celery/kombu@0f4da  # TODO: update to 4.1.1+ when released
+kombu==4.2.1
 pybreaker==0.4.2
 libsass==0.14.4


### PR DESCRIPTION
### Proposed changes in this pull request

#### Why I made this change

If you have a non-required select field in a questionnaire, it is possible to leave that field blank in ODK.

If you edit the dataset on the website and save the record, a value is assigned to previously blank select fields.

The issue is that we don't support the concept of "no selection" on the website and thus the first value in the select field is automatically selected.

#### Description of the change

I added an empty option to all select fields. I chose to added it to all fields instead of only the non-required ones to enforce that users actually select a value for required fields instead of just using the option selected by default. 

I also updated to the latest kombu version because the build on Travis would fail otherwise. 

#### How someone else can test the change

Create a new project using [this form](https://github.com/Cadasta/cadasta-platform/files/2058201/e2i5dpffikimw5eggv9dftyq.xlsx). You'll see in the form that parties have different select fields:

- `ethnicity` is required and has a default value
- `physical_status` is _not_ required and has a default value
- `age_range` is _not_ required and _does not_ a default value
- `profession` is required and _does not_ a default value

Create a project using the form, then create a party. When submitting the form check for the following conditions:

- All fields that have a default value should have the default value selected. 
- All fields that do not have a default value should default to the empty selection.
- The form should not submit if a required field is left empty. 

After you successfully created the party, go and edit the party.

- All fields where you selected a value before should have that value selected. 
- All empty fields that have a default value should have the default value selected. 
- All empty fields that do not have a default value should default to the empty selection.
- The form should not submit if a required field is left empty. 

### When should this PR be merged

This is somewhat urgent to one partner so we need to get it through quickly. 

### Risks

None

### Follow-up actions

None

### Checklist (for reviewing)

#### General

**Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 

- [ ] Review 1
- [ ] Review 2

**Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 

- [ ] Review 1
- [ ] Review 2

**Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

- [ ] Review 1
- [ ] Review 2

#### Functionality

**Are all requirements met?** Compare implemented functionality with the requirements specification.

- [ ] Review 1
- [ ] Review 2

**Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

- [ ] Review 1
- [ ] Review 2

#### Code

**Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

- [ ] Review 1
- [ ] Review 2

**Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 

- [ ] Review 1
- [ ] Review 2

**Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

- [ ] Review 1
- [ ] Review 2

**Is the code documented sufficiently?** Large and complex classes, functions or methods must be annotated with comments following our [code-style guidelines](https://devwiki.corp.cadasta.org/Contributing%20Style%20Guide#documentation-and-comments).

- [ ] Review 1
- [ ] Review 2

**Has the scalability of this change been evaluated?**

- [ ] Review 1
- [ ] Review 2

**Is there a maintenance plan in place?**

- [ ] Review 1
- [ ] Review 2

#### Tests

**Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 

- [ ] Review 1
- [ ] Review 2

**If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.

- [ ] Review 1
- [ ] Review 2

**If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

- [ ] Review 1
- [ ] Review 2

#### Security

**Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**

- [ ] Review 1
- [ ] Review 2

**Are all UI and API inputs run through forms or serializers?** 

- [ ] Review 1
- [ ] Review 2

**Are all external inputs validated and sanitized appropriately?**

- [ ] Review 1
- [ ] Review 2

**Does all branching logic have a default case?**

- [ ] Review 1
- [ ] Review 2

**Does this solution handle outliers and edge cases gracefully?**

- [ ] Review 1
- [ ] Review 2

**Are all external communications secured and restricted to SSL?**

- [ ] Review 1
- [ ] Review 2

#### Documentation

**Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).

- [ ] Review 1
- [ ] Review 2

**Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).

- [ ] Review 1
- [ ] Review 2

**Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

- [ ] Review 1
- [ ] Review 2
