### PR TITLE
Upgrade dev env to Postgres 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ language: python
 python:
   - '3.5'
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'
   apt:
     packages:
-      - postgresql-9.4-postgis-2.3
+      - postgresql-9.5-postgis-2.3
   browserstack:
     username: eugenealvinvilla1
     access_key:

--- a/provision/roles/db/development/files/postgresql.conf
+++ b/provision/roles/db/development/files/postgresql.conf
@@ -38,15 +38,15 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/9.4/main'		# use data in another directory
+data_directory = '/var/lib/postgresql/9.5/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/9.4/main/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/9.5/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/9.4/main/pg_ident.conf'	# ident configuration file
+ident_file = '/etc/postgresql/9.5/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/9.4-main.pid'			# write an extra PID file
+external_pid_file = '/var/run/postgresql/9.5-main.pid'			# write an extra PID file
 					# (change requires restart)
 
 
@@ -447,7 +447,7 @@ log_timezone = 'UTC'
 #track_functions = none			# none, pl, all
 #track_activity_query_size = 1024	# (change requires restart)
 #update_process_title = on
-stats_temp_directory = '/var/run/postgresql/9.4-main.pg_stat_tmp'
+stats_temp_directory = '/var/run/postgresql/9.5-main.pg_stat_tmp'
 
 
 # - Statistics Monitoring -

--- a/provision/roles/db/development/tasks/main.yml
+++ b/provision/roles/db/development/tasks/main.yml
@@ -13,13 +13,13 @@
   become: yes
   become_user: root
   register: pg_hba
-  copy: src=pg_hba.conf dest=/etc/postgresql/9.4/main/pg_hba.conf force=yes
+  copy: src=pg_hba.conf dest=/etc/postgresql/9.5/main/pg_hba.conf force=yes
 
 - name: Listen for external connections
   become: yes
   become_user: root
   register: postgresql_conf
-  copy: src=postgresql.conf dest=/etc/postgresql/9.4/main/postgresql.conf force=yes
+  copy: src=postgresql.conf dest=/etc/postgresql/9.5/main/postgresql.conf force=yes
 
 - name: Restart Postgres
   become: yes

--- a/provision/shared_vars.yml
+++ b/provision/shared_vars.yml
@@ -1,7 +1,7 @@
-postgresql_version: "9.4"
+postgresql_version: "9.5"
 aws_postgresql_version: "9.4.5"
-postgis_version: "2.1"
-postgis_package_version: "2.1.*.pgdg14.04+1"
+postgis_version: "2.2"
+postgis_package_version: "2.2.*.pgdg14.04+1"
 base_path: /opt/cadasta/
 application_path: "{{ base_path }}cadasta-platform/"
 virtualenv_path: "{{ base_path }}env/"


### PR DESCRIPTION
### Proposed changes in this pull request

Upgrades the dev and test environment to Postgres 9.5. 

#### Why I made this change

Postgres 9.4 is no longer supported and cannot be installed. 

#### Description of the change

Updates all references from Postgres 9.4 to 9.5

#### How someone else can test the change

Spin up a fresh development environment; run the tests or the test server. 